### PR TITLE
fix: add publication_id column to agent_run table

### DIFF
--- a/supabase/migrations/20251201220000_add_publication_id_to_agent_run.sql
+++ b/supabase/migrations/20251201220000_add_publication_id_to_agent_run.sql
@@ -1,0 +1,11 @@
+-- Add publication_id column to agent_run table
+-- This allows tracking which publication an agent run relates to (for future post-approval agents)
+-- KB-132
+
+ALTER TABLE agent_run
+ADD COLUMN IF NOT EXISTS publication_id uuid REFERENCES kb_publication(id) ON DELETE SET NULL;
+
+-- Add index for lookups by publication
+CREATE INDEX IF NOT EXISTS idx_agent_run_publication_id ON agent_run(publication_id);
+
+COMMENT ON COLUMN agent_run.publication_id IS 'Optional reference to publication (for post-approval agents)';


### PR DESCRIPTION
Agent runs were failing with 'Could not find the publication_id column' because runner.js inserts publication_id but the column didn't exist.

- Add publication_id column (nullable, FK to kb_publication)
- Add index for lookups
- Supports future post-approval agents

Closes KB-132