### PR TITLE
fix: pass URL to thumbnail agent via payload

### DIFF
--- a/services/agent-api/src/agents/enrich-item.js
+++ b/services/agent-api/src/agents/enrich-item.js
@@ -37,6 +37,7 @@ async function stepFetch(queueItem) {
 
   const payload = {
     ...queueItem.payload,
+    url: queueItem.url, // Ensure URL is in payload for thumbnail agent
     title: content.title,
     description: content.description,
     textContent: content.textContent,

--- a/services/agent-api/src/agents/thumbnail.js
+++ b/services/agent-api/src/agents/thumbnail.js
@@ -28,7 +28,9 @@ export async function runThumbnailer(queueItem) {
       console.log(`📸 Generating thumbnail for: ${payload.title}`);
 
       const targetUrl = payload.url || payload.source_url;
-      if (!targetUrl) throw new Error('No URL provided');
+      if (!targetUrl) {
+        throw new Error('No URL provided in payload (expected payload.url or payload.source_url)');
+      }
 
       // Step 1: Launch browser
       const browserStepId = await startStep('browser_launch', { url: targetUrl });


### PR DESCRIPTION
Root cause: stepFetch built payload from queueItem.payload but URL was at queueItem.url (top level), never copied to payload. Thumbnail agent expected payload.url which was undefined.

Changes:
- stepFetch now copies queueItem.url to payload.url
- Improved error message in thumbnail.js for missing URL
- Added 7 tests for URL handling in payload and thumbnail extraction

Closes KB-130