### PR TITLE
feat: improve typography and add theme toggle (KB-112)

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -18,13 +18,23 @@ const navItems = [
 const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.startsWith(href));
 ---
 
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>{title}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
     <link rel="canonical" href={canonical} />
+
+    <!-- Theme initialization (prevents flash) -->
+    <script is:inline>
+      (function () {
+        const stored = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const theme = stored || (prefersDark ? 'dark' : 'light');
+        document.documentElement.classList.toggle('dark', theme === 'dark');
+      })();
+    </script>
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
@@ -57,257 +67,360 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
     <slot name="head" />
   </head>
 
-  <body class="min-h-screen bg-neutral-950 text-neutral-200 antialiased">
+  <body
+    class="min-h-screen bg-neutral-50 dark:bg-neutral-950 text-neutral-800 dark:text-neutral-200 antialiased transition-colors duration-200"
+  >
     <!-- HEADER -->
-    <header class="border-b border-neutral-800">
+    <header
+      class="border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950"
+    >
       <div class="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
         <a href="/" aria-label="BFSI Insights home" class="group inline-flex flex-col items-center">
-          <span class="text-xl font-normal tracking-tight dark:text-white">BFSI</span>
-          <span class="-mt-0.5 text-sm font-bold uppercase text-sky-400">insights</span>
+          <span class="text-xl font-normal tracking-tight text-neutral-900 dark:text-white"
+            >BFSI</span
+          >
+          <span class="-mt-0.5 text-sm font-bold uppercase text-sky-500 dark:text-sky-400"
+            >insights</span
+          >
         </a>
 
-        <!-- Desktop Navigation -->
-        <nav class="hidden sm:flex items-center gap-1 text-sm" aria-label="Main navigation">
-          {
-            navItems.map((item, idx) => (
-              <>
-                {idx > 0 && <span class="mx-2 text-neutral-700">|</span>}
+        <!-- Desktop Navigation + Theme Toggle -->
+        <div class="hidden sm:flex items-center gap-4">
+          <nav class="flex items-center gap-1 text-sm" aria-label="Main navigation">
+            {
+              navItems.map((item, idx) => (
+                <>
+                  {idx > 0 && <span class="mx-2 text-neutral-700">|</span>}
+                  <a
+                    href={item.href}
+                    class:list={[
+                      'px-3 py-1.5 rounded-md transition-colors',
+                      isActive(item.href)
+                        ? 'text-sky-400 font-medium border-b-2 border-sky-400'
+                        : 'text-neutral-300 hover:text-white hover:bg-neutral-800',
+                    ]}
+                    aria-current={isActive(item.href) ? 'page' : undefined}
+                  >
+                    {item.label}
+                  </a>
+                </>
+              ))
+            }
+          </nav>
+
+          <!-- Theme Toggle Button -->
+          <button
+            id="theme-toggle"
+            type="button"
+            class="w-9 h-9 flex items-center justify-center rounded-lg text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            aria-label="Toggle theme"
+          >
+            <!-- Sun icon (shown in dark mode) -->
+            <svg
+              class="w-5 h-5 hidden dark:block"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+              ></path>
+            </svg>
+            <!-- Moon icon (shown in light mode) -->
+            <svg
+              class="w-5 h-5 block dark:hidden"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+              ></path>
+            </svg>
+          </button>
+        </div>
+
+        <!-- Mobile: Theme Toggle + Menu Button -->
+        <div class="sm:hidden flex items-center gap-2">
+          <button
+            id="theme-toggle-mobile"
+            type="button"
+            class="w-10 h-10 flex items-center justify-center rounded-md text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            aria-label="Toggle theme"
+          >
+            <svg
+              class="w-5 h-5 hidden dark:block"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+              ></path>
+            </svg>
+            <svg
+              class="w-5 h-5 block dark:hidden"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+              ></path>
+            </svg>
+          </button>
+          <button
+            id="mobile-menu-btn"
+            type="button"
+            class="w-10 h-10 flex items-center justify-center rounded-md text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            aria-expanded="false"
+            aria-controls="mobile-menu"
+            aria-label="Open menu"
+          >
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 6h16M4 12h16M4 18h16"></path>
+            </svg>
+          </button>
+        </div>
+
+        <!-- Mobile Menu Backdrop -->
+        <div id="mobile-menu-overlay" class="fixed inset-0 bg-black/60 z-40 hidden sm:hidden"></div>
+
+        <!-- Mobile Menu Panel -->
+        <nav
+          id="mobile-menu"
+          class="fixed top-0 right-0 bottom-0 w-64 bg-neutral-900 border-l border-neutral-800 z-50 translate-x-full transition-transform duration-300 ease-in-out sm:hidden"
+          aria-label="Mobile navigation"
+        >
+          <div class="flex items-center justify-between p-4 border-b border-neutral-800">
+            <span class="text-sm font-medium text-neutral-200">Menu</span>
+            <button
+              id="mobile-menu-close"
+              class="w-8 h-8 flex items-center justify-center rounded-md text-neutral-400 hover:text-white hover:bg-neutral-800 transition-colors"
+              aria-label="Close menu"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"></path>
+              </svg>
+            </button>
+          </div>
+
+          <div class="flex flex-col p-4 space-y-1">
+            {
+              navItems.map((item) => (
                 <a
                   href={item.href}
                   class:list={[
-                    'px-3 py-1.5 rounded-md transition-colors',
+                    'px-4 py-3 rounded-md text-sm transition-colors',
                     isActive(item.href)
-                      ? 'text-sky-400 font-medium border-b-2 border-sky-400'
-                      : 'text-neutral-300 hover:text-white hover:bg-neutral-800',
+                      ? 'bg-sky-400/10 text-sky-400 font-medium'
+                      : 'text-neutral-300 hover:bg-neutral-800 hover:text-white',
                   ]}
                   aria-current={isActive(item.href) ? 'page' : undefined}
                 >
                   {item.label}
                 </a>
-              </>
-            ))
-          }
+              ))
+            }
+          </div>
         </nav>
-
-        <!-- Mobile Menu Open Button -->
-        <button
-          id="mobile-menu-btn"
-          type="button"
-          class="sm:hidden w-10 h-10 flex items-center justify-center rounded-md text-neutral-300 hover:text-white hover:bg-neutral-800 transition-colors"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
-          aria-label="Open menu"
-        >
-          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M4 6h16M4 12h16M4 18h16"></path>
-          </svg>
-        </button>
       </div>
 
-      <!-- Mobile Menu Backdrop -->
-      <div id="mobile-menu-overlay" class="fixed inset-0 bg-black/60 z-40 hidden sm:hidden"></div>
+      <!-- MAIN -->
+      <main class="mx-auto max-w-5xl px-4 py-8">
+        <slot />
+      </main>
 
-      <!-- Mobile Menu Panel -->
-      <nav
-        id="mobile-menu"
-        class="fixed top-0 right-0 bottom-0 w-64 bg-neutral-900 border-l border-neutral-800 z-50 translate-x-full transition-transform duration-300 ease-in-out sm:hidden"
-        aria-label="Mobile navigation"
-      >
-        <div class="flex items-center justify-between p-4 border-b border-neutral-800">
-          <span class="text-sm font-medium text-neutral-200">Menu</span>
-          <button
-            id="mobile-menu-close"
-            class="w-8 h-8 flex items-center justify-center rounded-md text-neutral-400 hover:text-white hover:bg-neutral-800 transition-colors"
-            aria-label="Close menu"
+      <!-- FOOTER -->
+      <footer class="border-t border-neutral-800">
+        <div
+          class="mx-auto max-w-5xl px-4 py-6 text-xs text-neutral-400 flex items-center justify-between"
+        >
+          <a
+            href="https://www.rtminnovations.com/"
+            target="_blank"
+            rel="noopener"
+            class="hover:underline"
           >
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"></path>
-            </svg>
-          </button>
+            &copy; {2025} RTM INNOVATIONS
+          </a>
+          <nav class="space-x-4">
+            <a href="/feed.xml" class="hover:underline">RSS feed</a>
+            <a href="/updates.json" class="hover:underline">Updates JSON</a>
+          </nav>
         </div>
+      </footer>
 
-        <div class="flex flex-col p-4 space-y-1">
-          {
-            navItems.map((item) => (
-              <a
-                href={item.href}
-                class:list={[
-                  'px-4 py-3 rounded-md text-sm transition-colors',
-                  isActive(item.href)
-                    ? 'bg-sky-400/10 text-sky-400 font-medium'
-                    : 'text-neutral-300 hover:bg-neutral-800 hover:text-white',
-                ]}
-                aria-current={isActive(item.href) ? 'page' : undefined}
-              >
-                {item.label}
-              </a>
-            ))
+      <PublicationModal />
+
+      <!-- Scripts -->
+      <script type="module">
+        import { marked } from 'https://cdn.jsdelivr.net/npm/marked@11/+esm';
+
+        marked.setOptions({ breaks: true, gfm: true });
+
+        (function () {
+          // ---------- MODAL HANDLING ----------
+          const modal = document.getElementById('modal');
+          if (modal) {
+            let lastFocus = null;
+
+            const parseSummary = (t) => (t ? marked.parse(t.replace(/\(more\)\s*$/, '')) : '');
+
+            const openModal = (el) => {
+              lastFocus = document.activeElement;
+              modal.classList.remove('hidden');
+              document.body.style.overflow = 'hidden';
+
+              const title = el.querySelector('a')?.textContent || '';
+              const href = el.querySelector('a')?.href || '#';
+
+              const titleEl = document.getElementById('modal-title-text');
+              if (titleEl) titleEl.textContent = title;
+
+              const metaParts = [];
+              const authors = el.getAttribute('data-authors');
+              const source = el.getAttribute('data-source_name');
+              if (authors) metaParts.push(authors);
+              if (source) metaParts.push(source);
+              const metaEl = document.getElementById('modal-meta');
+              if (metaEl) metaEl.textContent = metaParts.join(' • ');
+
+              const tagsEl = document.getElementById('modal-tags');
+              if (tagsEl) {
+                tagsEl.innerHTML = '';
+                ['role', 'industry', 'topic', 'content_type', 'geography'].forEach((attr) => {
+                  const value = el.getAttribute(`data-${attr}`);
+                  if (value) {
+                    const span = document.createElement('span');
+                    span.className =
+                      'rounded-md border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-xs text-neutral-300';
+                    span.textContent = value;
+                    tagsEl.appendChild(span);
+                  }
+                });
+              }
+
+              const summaryEl = document.getElementById('modal-summary');
+              if (summaryEl) {
+                const summary = el.getAttribute('data-summary-medium') || '';
+                summaryEl.innerHTML = parseSummary(summary);
+              }
+
+              const viewDetails = document.getElementById('modal-view-details');
+              if (viewDetails) viewDetails.setAttribute('href', href);
+            };
+
+            const closeModal = () => {
+              modal.classList.add('hidden');
+              document.body.style.overflow = '';
+              if (lastFocus && typeof lastFocus.focus === 'function') {
+                lastFocus.focus();
+              }
+            };
+
+            document.getElementById('modal-close')?.addEventListener('click', closeModal);
+            document.getElementById('modal-backdrop')?.addEventListener('click', closeModal);
+            window.addEventListener('keydown', (e) => {
+              if (e.key === 'Escape') closeModal();
+            });
+
+            document.addEventListener('click', (e) => {
+              const target = e.target;
+              if (!target) return;
+              const btn = target.closest('[data-open-modal]');
+              if (!btn) return;
+              e.preventDefault();
+              e.stopPropagation();
+              const card = btn.closest('li');
+              if (card) openModal(card);
+            });
           }
-        </div>
-      </nav>
-    </header>
 
-    <!-- MAIN -->
-    <main class="mx-auto max-w-5xl px-4 py-8">
-      <slot />
-    </main>
+          // ---------- MOBILE MENU ----------
+          const menuBtn = document.getElementById('mobile-menu-btn');
+          const menu = document.getElementById('mobile-menu');
+          const closeBtn = document.getElementById('mobile-menu-close');
+          const overlay = document.getElementById('mobile-menu-overlay');
 
-    <!-- FOOTER -->
-    <footer class="border-t border-neutral-800">
-      <div
-        class="mx-auto max-w-5xl px-4 py-6 text-xs text-neutral-400 flex items-center justify-between"
-      >
-        <a
-          href="https://www.rtminnovations.com/"
-          target="_blank"
-          rel="noopener"
-          class="hover:underline"
-        >
-          &copy; {2025} RTM INNOVATIONS
-        </a>
-        <nav class="space-x-4">
-          <a href="/feed.xml" class="hover:underline">RSS feed</a>
-          <a href="/updates.json" class="hover:underline">Updates JSON</a>
-        </nav>
-      </div>
-    </footer>
-
-    <PublicationModal />
-
-    <!-- Scripts -->
-    <script type="module">
-      import { marked } from 'https://cdn.jsdelivr.net/npm/marked@11/+esm';
-
-      marked.setOptions({ breaks: true, gfm: true });
-
-      (function () {
-        // ---------- MODAL HANDLING ----------
-        const modal = document.getElementById('modal');
-        if (modal) {
-          let lastFocus = null;
-
-          const parseSummary = (t) => (t ? marked.parse(t.replace(/\(more\)\s*$/, '')) : '');
-
-          const openModal = (el) => {
-            lastFocus = document.activeElement;
-            modal.classList.remove('hidden');
+          const openMenu = () => {
+            if (!menu || !overlay || !menuBtn) return;
+            menu.classList.remove('translate-x-full');
+            overlay.classList.remove('hidden');
+            menuBtn.setAttribute('aria-expanded', 'true');
             document.body.style.overflow = 'hidden';
-
-            const title = el.querySelector('a')?.textContent || '';
-            const href = el.querySelector('a')?.href || '#';
-
-            const titleEl = document.getElementById('modal-title-text');
-            if (titleEl) titleEl.textContent = title;
-
-            const metaParts = [];
-            const authors = el.getAttribute('data-authors');
-            const source = el.getAttribute('data-source_name');
-            if (authors) metaParts.push(authors);
-            if (source) metaParts.push(source);
-            const metaEl = document.getElementById('modal-meta');
-            if (metaEl) metaEl.textContent = metaParts.join(' • ');
-
-            const tagsEl = document.getElementById('modal-tags');
-            if (tagsEl) {
-              tagsEl.innerHTML = '';
-              ['role', 'industry', 'topic', 'content_type', 'geography'].forEach((attr) => {
-                const value = el.getAttribute(`data-${attr}`);
-                if (value) {
-                  const span = document.createElement('span');
-                  span.className =
-                    'rounded-md border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-xs text-neutral-300';
-                  span.textContent = value;
-                  tagsEl.appendChild(span);
-                }
-              });
-            }
-
-            const summaryEl = document.getElementById('modal-summary');
-            if (summaryEl) {
-              const summary = el.getAttribute('data-summary-medium') || '';
-              summaryEl.innerHTML = parseSummary(summary);
-            }
-
-            const viewDetails = document.getElementById('modal-view-details');
-            if (viewDetails) viewDetails.setAttribute('href', href);
+            const first = menu.querySelector('a');
+            if (first) setTimeout(() => first.focus(), 100);
           };
 
-          const closeModal = () => {
-            modal.classList.add('hidden');
+          const closeMenu = () => {
+            if (!menu || !overlay || !menuBtn) return;
+            menu.classList.add('translate-x-full');
+            overlay.classList.add('hidden');
+            menuBtn.setAttribute('aria-expanded', 'false');
             document.body.style.overflow = '';
-            if (lastFocus && typeof lastFocus.focus === 'function') {
-              lastFocus.focus();
-            }
+            menuBtn.focus();
           };
 
-          document.getElementById('modal-close')?.addEventListener('click', closeModal);
-          document.getElementById('modal-backdrop')?.addEventListener('click', closeModal);
+          menuBtn?.addEventListener('click', () => {
+            const open = menuBtn.getAttribute('aria-expanded') === 'true';
+            open ? closeMenu() : openMenu();
+          });
+
+          closeBtn?.addEventListener('click', closeMenu);
+          overlay?.addEventListener('click', closeMenu);
+
           window.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape') closeModal();
+            if (e.key === 'Escape') closeMenu();
           });
 
-          document.addEventListener('click', (e) => {
+          menu?.addEventListener('click', (e) => {
             const target = e.target;
-            if (!target) return;
-            const btn = target.closest('[data-open-modal]');
-            if (!btn) return;
-            e.preventDefault();
-            e.stopPropagation();
-            const card = btn.closest('li');
-            if (card) openModal(card);
+            if (target && target.tagName === 'A') closeMenu();
           });
-        }
 
-        // ---------- MOBILE MENU ----------
-        const menuBtn = document.getElementById('mobile-menu-btn');
-        const menu = document.getElementById('mobile-menu');
-        const closeBtn = document.getElementById('mobile-menu-close');
-        const overlay = document.getElementById('mobile-menu-overlay');
+          // ---------- THEME TOGGLE ----------
+          const themeToggle = document.getElementById('theme-toggle');
+          const themeToggleMobile = document.getElementById('theme-toggle-mobile');
 
-        const openMenu = () => {
-          if (!menu || !overlay || !menuBtn) return;
-          menu.classList.remove('translate-x-full');
-          overlay.classList.remove('hidden');
-          menuBtn.setAttribute('aria-expanded', 'true');
-          document.body.style.overflow = 'hidden';
-          const first = menu.querySelector('a');
-          if (first) setTimeout(() => first.focus(), 100);
-        };
+          const toggleTheme = () => {
+            const isDark = document.documentElement.classList.contains('dark');
+            const newTheme = isDark ? 'light' : 'dark';
+            document.documentElement.classList.toggle('dark', newTheme === 'dark');
+            localStorage.setItem('theme', newTheme);
+          };
 
-        const closeMenu = () => {
-          if (!menu || !overlay || !menuBtn) return;
-          menu.classList.add('translate-x-full');
-          overlay.classList.add('hidden');
-          menuBtn.setAttribute('aria-expanded', 'false');
-          document.body.style.overflow = '';
-          menuBtn.focus();
-        };
+          themeToggle?.addEventListener('click', toggleTheme);
+          themeToggleMobile?.addEventListener('click', toggleTheme);
 
-        menuBtn?.addEventListener('click', () => {
-          const open = menuBtn.getAttribute('aria-expanded') === 'true';
-          open ? closeMenu() : openMenu();
-        });
-
-        closeBtn?.addEventListener('click', closeMenu);
-        overlay?.addEventListener('click', closeMenu);
-
-        window.addEventListener('keydown', (e) => {
-          if (e.key === 'Escape') closeMenu();
-        });
-
-        menu?.addEventListener('click', (e) => {
-          const target = e.target;
-          if (target && target.tagName === 'A') closeMenu();
-        });
-      })();
-    </script>
+          // Listen for system preference changes
+          window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+            if (!localStorage.getItem('theme')) {
+              document.documentElement.classList.toggle('dark', e.matches);
+            }
+          });
+        })();
+      </script>
+    </header>
   </body>
 </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,36 @@ import typography from '@tailwindcss/typography';
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   darkMode: 'class',
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      // Slightly bump up small font sizes for better readability
+      fontSize: {
+        xs: ['0.8125rem', { lineHeight: '1.25rem' }], // 13px (was 12px)
+        sm: ['0.9375rem', { lineHeight: '1.375rem' }], // 15px (was 14px)
+      },
+      // Typography plugin customization for dark mode
+      typography: {
+        DEFAULT: {
+          css: {
+            '--tw-prose-body': 'rgb(229 229 229)', // neutral-200
+            '--tw-prose-headings': 'rgb(250 250 250)', // neutral-50
+            '--tw-prose-links': 'rgb(125 211 252)', // sky-300
+            '--tw-prose-bold': 'rgb(250 250 250)',
+            '--tw-prose-counters': 'rgb(163 163 163)', // neutral-400
+            '--tw-prose-bullets': 'rgb(115 115 115)', // neutral-500
+            '--tw-prose-hr': 'rgb(64 64 64)', // neutral-700
+            '--tw-prose-quotes': 'rgb(212 212 212)', // neutral-300
+            '--tw-prose-quote-borders': 'rgb(64 64 64)',
+            '--tw-prose-captions': 'rgb(163 163 163)',
+            '--tw-prose-code': 'rgb(250 250 250)',
+            '--tw-prose-pre-code': 'rgb(229 229 229)',
+            '--tw-prose-pre-bg': 'rgb(23 23 23)', // neutral-900
+            '--tw-prose-th-borders': 'rgb(64 64 64)',
+            '--tw-prose-td-borders': 'rgb(38 38 38)', // neutral-800
+          },
+        },
+      },
+    },
+  },
   plugins: [typography],
 };


### PR DESCRIPTION
- Add light/dark theme toggle with system preference auto-detection
- Theme persists in localStorage across sessions
- Bump up text-xs (12→13px) and text-sm (14→15px) for better readability
- Configure @tailwindcss/typography for dark mode colors
- Add transition animations for smooth theme switching
- Theme toggle button in header (desktop and mobile)