### PR TITLE
feat: taxonomy curation UI during article review (KB-134)

### DIFF
--- a/src/pages/admin/review.astro
+++ b/src/pages/admin/review.astro
@@ -125,22 +125,33 @@ import Base from '../../layouts/Base.astro';
           return;
         }
 
-        // Load taxonomy for code-to-label mapping
-        const [queueResult, industriesResult, topicsResult] = await Promise.all([
-          supabase
-            .from('ingestion_queue')
-            .select('*')
-            .eq('status', 'enriched')
-            .order('fetched_at', { ascending: false }),
-          supabase.from('bfsi_industry').select('code, name').order('sort_order'),
-          supabase.from('bfsi_topic').select('code, name').order('sort_order'),
-        ]);
+        // Load taxonomy for code-to-label mapping and existing entities for duplicate detection
+        const [queueResult, industriesResult, topicsResult, vendorsResult, orgsResult] =
+          await Promise.all([
+            supabase
+              .from('ingestion_queue')
+              .select('*')
+              .eq('status', 'enriched')
+              .order('fetched_at', { ascending: false }),
+            supabase.from('bfsi_industry').select('code, name').order('sort_order'),
+            supabase.from('bfsi_topic').select('code, name').order('sort_order'),
+            supabase.from('ag_vendor').select('id, name'),
+            supabase.from('bfsi_organization').select('id, organization_name'),
+          ]);
 
         if (queueResult.error) throw queueResult.error;
 
         // Create lookup maps
         const industryMap = new Map((industriesResult.data || []).map((i) => [i.code, i.name]));
         const topicMap = new Map((topicsResult.data || []).map((t) => [t.code, t.name]));
+
+        // Existing entities for duplicate detection (lowercase for case-insensitive matching)
+        const existingVendors = new Set(
+          (vendorsResult.data || []).map((v) => v.name.toLowerCase()),
+        );
+        const existingOrgs = new Set(
+          (orgsResult.data || []).map((o) => o.organization_name.toLowerCase()),
+        );
 
         loading.classList.add('hidden');
         const pending = queueResult.data || [];
@@ -183,6 +194,18 @@ import Base from '../../layouts/Base.astro';
             const personaScores = payload.persona_scores || {};
             const industryCodes = payload.industry_codes || [];
             const topicCodes = payload.topic_codes || [];
+            const vendorNames = payload.vendor_names || [];
+            const organizationNames = payload.organization_names || [];
+
+            // Check which entities are new vs existing
+            const vendorStatus = vendorNames.map((name) => ({
+              name,
+              isNew: !existingVendors.has(name.toLowerCase()),
+            }));
+            const orgStatus = organizationNames.map((name) => ({
+              name,
+              isNew: !existingOrgs.has(name.toLowerCase()),
+            }));
 
             // Validate summary lengths
             const shortLen = summary.short?.length || 0;
@@ -322,6 +345,80 @@ import Base from '../../layouts/Base.astro';
                     }
                   </div>
 
+                  <!-- Entity Curation (Vendors & Organizations) -->
+                  ${
+                    vendorStatus.length > 0 || orgStatus.length > 0
+                      ? `
+                  <div class="mt-4 p-4 rounded-lg border border-amber-500/20 bg-amber-500/5">
+                    <div class="flex items-center gap-2 mb-3">
+                      <span class="text-xs font-semibold text-amber-300 uppercase">🏷️ Taxonomy Curation</span>
+                      <span class="text-xs text-neutral-400">(Select entities to add to database)</span>
+                    </div>
+                    
+                    ${
+                      vendorStatus.length > 0
+                        ? `
+                    <div class="mb-3">
+                      <span class="text-xs font-medium text-neutral-400">AI/Tech Vendors</span>
+                      <div class="flex flex-wrap gap-2 mt-1">
+                        ${vendorStatus
+                          .map(
+                            (v) => `
+                          <label class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md cursor-pointer transition
+                            ${v.isNew ? 'bg-emerald-500/10 border border-emerald-500/30 hover:bg-emerald-500/20' : 'bg-neutral-800 border border-neutral-700'}">
+                            <input type="checkbox" 
+                              class="vendor-checkbox rounded border-neutral-600 bg-neutral-800 text-emerald-500 focus:ring-emerald-500/30"
+                              data-item-id="${item.id}"
+                              data-entity-type="vendor"
+                              data-entity-name="${v.name}"
+                              ${v.isNew ? 'checked' : ''}
+                            />
+                            <span class="text-sm ${v.isNew ? 'text-emerald-300' : 'text-neutral-400'}">${v.name}</span>
+                            ${v.isNew ? '<span class="text-xs px-1.5 py-0.5 rounded bg-emerald-500/20 text-emerald-400">NEW</span>' : '<span class="text-xs text-neutral-500">exists</span>'}
+                          </label>
+                        `,
+                          )
+                          .join('')}
+                      </div>
+                    </div>
+                    `
+                        : ''
+                    }
+                    
+                    ${
+                      orgStatus.length > 0
+                        ? `
+                    <div>
+                      <span class="text-xs font-medium text-neutral-400">BFSI Organizations</span>
+                      <div class="flex flex-wrap gap-2 mt-1">
+                        ${orgStatus
+                          .map(
+                            (o) => `
+                          <label class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md cursor-pointer transition
+                            ${o.isNew ? 'bg-sky-500/10 border border-sky-500/30 hover:bg-sky-500/20' : 'bg-neutral-800 border border-neutral-700'}">
+                            <input type="checkbox"
+                              class="org-checkbox rounded border-neutral-600 bg-neutral-800 text-sky-500 focus:ring-sky-500/30"
+                              data-item-id="${item.id}"
+                              data-entity-type="organization"
+                              data-entity-name="${o.name}"
+                              ${o.isNew ? 'checked' : ''}
+                            />
+                            <span class="text-sm ${o.isNew ? 'text-sky-300' : 'text-neutral-400'}">${o.name}</span>
+                            ${o.isNew ? '<span class="text-xs px-1.5 py-0.5 rounded bg-sky-500/20 text-sky-400">NEW</span>' : '<span class="text-xs text-neutral-500">exists</span>'}
+                          </label>
+                        `,
+                          )
+                          .join('')}
+                      </div>
+                    </div>
+                    `
+                        : ''
+                    }
+                  </div>
+                  `
+                      : ''
+                  }
+
                   <!-- Persona Scores -->
                   ${
                     Object.keys(personaScores).length > 0
@@ -392,12 +489,31 @@ import Base from '../../layouts/Base.astro';
             article.classList.add('opacity-60');
             target.textContent = '⏳ Publishing...';
 
+            // Collect selected entities for taxonomy curation
+            const selectedVendors = [];
+            const selectedOrgs = [];
+
+            article.querySelectorAll('.vendor-checkbox:checked').forEach((cb) => {
+              if (cb instanceof HTMLInputElement && cb.dataset.entityName) {
+                selectedVendors.push(cb.dataset.entityName);
+              }
+            });
+
+            article.querySelectorAll('.org-checkbox:checked').forEach((cb) => {
+              if (cb instanceof HTMLInputElement && cb.dataset.entityName) {
+                selectedOrgs.push(cb.dataset.entityName);
+              }
+            });
+
             // Call SQL function which:
             // 1. Inserts into kb_publication
             // 2. Creates taxonomy relationships
-            // 3. Marks as approved
+            // 3. Upserts approved vendors and organizations
+            // 4. Marks as approved
             const { error } = await supabase.rpc('approve_from_queue', {
               p_queue_id: id,
+              p_approved_vendors: selectedVendors,
+              p_approved_organizations: selectedOrgs,
             });
 
             if (error) {
@@ -407,8 +523,14 @@ import Base from '../../layouts/Base.astro';
               return;
             }
 
+            // Show count of entities added
+            const entityMsg = [];
+            if (selectedVendors.length > 0) entityMsg.push(`${selectedVendors.length} vendors`);
+            if (selectedOrgs.length > 0) entityMsg.push(`${selectedOrgs.length} orgs`);
+            const entityNote = entityMsg.length > 0 ? ` (+${entityMsg.join(', ')})` : '';
+
             article.classList.add('opacity-50');
-            target.textContent = '✓ Published! Live on site.';
+            target.textContent = `✓ Published!${entityNote}`;
             target.setAttribute('disabled', 'true');
             setTimeout(() => article.remove(), 2000);
           }

--- a/supabase/migrations/20251202030000_approve_with_entity_curation.sql
+++ b/supabase/migrations/20251202030000_approve_with_entity_curation.sql
@@ -1,0 +1,207 @@
+-- ============================================================================
+-- KB-134: Add entity curation to approve_from_queue
+-- ============================================================================
+-- Adds optional parameters for upserting approved vendors and organizations
+-- during article approval process.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION approve_from_queue(
+  p_queue_id uuid,
+  p_approved_vendors text[] DEFAULT '{}',
+  p_approved_organizations text[] DEFAULT '{}'
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_queue ingestion_queue%ROWTYPE;
+  v_id uuid;
+  v_slug text;
+  v_payload jsonb;
+  v_source_domain text;
+  v_industry_code text;
+  v_topic_code text;
+  v_regulator_code text;
+  v_regulation_code text;
+  v_process_code text;
+  v_vendor_name text;
+  v_org_name text;
+  v_thumb_bucket text;
+  v_thumb_path text;
+BEGIN
+  -- Get enriched item
+  SELECT * INTO v_queue 
+  FROM ingestion_queue 
+  WHERE id = p_queue_id AND status = 'enriched' 
+  FOR UPDATE;
+  
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Queue item % not found or not enriched', p_queue_id;
+  END IF;
+  
+  v_payload := v_queue.payload;
+  v_source_domain := (regexp_match(v_queue.url, 'https?://([^/]+)'))[1];
+
+  -- Extract thumbnail info from payload
+  v_thumb_bucket := COALESCE(v_payload->>'thumbnail_bucket', 'asset');
+  v_thumb_path := v_payload->>'thumbnail_path';
+  
+  -- Generate slug
+  v_slug := lower(regexp_replace(
+    regexp_replace(v_payload->>'title', '[^a-zA-Z0-9\s-]', '', 'g'),
+    '\s+', '-', 'g'
+  ));
+  v_slug := substring(v_slug from 1 for 100);
+  
+  -- Ensure unique slug
+  WHILE EXISTS (SELECT 1 FROM kb_publication WHERE slug = v_slug) LOOP
+    v_slug := v_slug || '-' || substring(md5(random()::text) from 1 for 6);
+  END LOOP;
+  
+  -- Check for existing by source_url
+  SELECT id INTO v_id FROM kb_publication WHERE source_url = v_queue.url_norm;
+  
+  IF v_id IS NOT NULL THEN
+    -- Update existing
+    UPDATE kb_publication SET
+      title = v_payload->>'title',
+      date_published = (v_payload->>'published_at')::timestamptz,
+      summary_short = v_payload->'summary'->>'short',
+      summary_medium = v_payload->'summary'->>'medium',
+      summary_long = v_payload->'summary'->>'long',
+      thumbnail_bucket = v_thumb_bucket,
+      thumbnail_path = v_thumb_path,
+      last_edited = now()
+    WHERE id = v_id;
+    
+    -- Clear existing relationships for re-tagging
+    DELETE FROM kb_publication_bfsi_industry WHERE publication_id = v_id;
+    DELETE FROM kb_publication_bfsi_topic WHERE publication_id = v_id;
+    DELETE FROM kb_publication_regulator WHERE publication_id = v_id;
+    DELETE FROM kb_publication_regulation WHERE publication_id = v_id;
+    DELETE FROM kb_publication_bfsi_process WHERE publication_id = v_id;
+  ELSE
+    -- Insert new publication
+    INSERT INTO kb_publication (
+      slug, title, author, date_published, 
+      source_url, source_name, source_domain,
+      thumbnail_bucket, thumbnail_path,
+      summary_short, summary_medium, summary_long,
+      role, content_type,
+      status, origin_queue_id
+    )
+    VALUES (
+      v_slug,
+      v_payload->>'title',
+      NULL,
+      (v_payload->>'published_at')::timestamptz,
+      v_queue.url,
+      v_source_domain,
+      v_source_domain,
+      v_thumb_bucket,
+      v_thumb_path,
+      v_payload->'summary'->>'short',
+      v_payload->'summary'->>'medium',
+      v_payload->'summary'->>'long',
+      CASE 
+        WHEN (v_payload->'persona_scores'->>'executive')::float > 0.7 THEN 'executive'
+        WHEN (v_payload->'persona_scores'->>'professional')::float > 0.7 THEN 'professional'
+        ELSE 'researcher'
+      END,
+      'article',
+      'published',
+      p_queue_id
+    )
+    RETURNING id INTO v_id;
+  END IF;
+  
+  -- Insert industry relationships
+  FOR v_industry_code IN 
+    SELECT jsonb_array_elements_text(COALESCE(v_payload->'industry_codes', '[]'::jsonb))
+  LOOP
+    INSERT INTO kb_publication_bfsi_industry (publication_id, industry_code)
+    VALUES (v_id, v_industry_code)
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+  
+  -- Insert topic relationships  
+  FOR v_topic_code IN 
+    SELECT jsonb_array_elements_text(COALESCE(v_payload->'topic_codes', '[]'::jsonb))
+  LOOP
+    INSERT INTO kb_publication_bfsi_topic (publication_id, topic_code)
+    VALUES (v_id, v_topic_code)
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+  
+  -- Insert regulator relationships
+  FOR v_regulator_code IN 
+    SELECT jsonb_array_elements_text(COALESCE(v_payload->'regulator_codes', '[]'::jsonb))
+  LOOP
+    INSERT INTO kb_publication_regulator (publication_id, regulator_code)
+    VALUES (v_id, v_regulator_code)
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+  
+  -- Insert regulation relationships
+  FOR v_regulation_code IN 
+    SELECT jsonb_array_elements_text(COALESCE(v_payload->'regulation_codes', '[]'::jsonb))
+  LOOP
+    INSERT INTO kb_publication_regulation (publication_id, regulation_code)
+    VALUES (v_id, v_regulation_code)
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+  
+  -- Insert process relationships
+  FOR v_process_code IN 
+    SELECT jsonb_array_elements_text(COALESCE(v_payload->'process_codes', '[]'::jsonb))
+  LOOP
+    INSERT INTO kb_publication_bfsi_process (publication_id, process_code)
+    VALUES (v_id, v_process_code)
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+  
+  -- ============================================================================
+  -- NEW: Upsert approved vendors to ag_vendor
+  -- ============================================================================
+  FOREACH v_vendor_name IN ARRAY p_approved_vendors
+  LOOP
+    INSERT INTO ag_vendor (name)
+    VALUES (v_vendor_name)
+    ON CONFLICT (name_lc) DO NOTHING;
+  END LOOP;
+  
+  -- ============================================================================
+  -- NEW: Upsert approved organizations to bfsi_organization
+  -- ============================================================================
+  FOREACH v_org_name IN ARRAY p_approved_organizations
+  LOOP
+    INSERT INTO bfsi_organization (organization_name)
+    VALUES (v_org_name)
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+  
+  -- Mark as approved
+  UPDATE ingestion_queue 
+  SET status = 'approved'
+  WHERE id = p_queue_id;
+  
+  RETURN v_id;
+END;
+$$;
+
+-- Add unique constraint on organization_name if not exists
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint 
+    WHERE conname = 'bfsi_organization_name_unique'
+  ) THEN
+    ALTER TABLE bfsi_organization 
+    ADD CONSTRAINT bfsi_organization_name_unique 
+    UNIQUE (organization_name);
+  END IF;
+END $$;
+
+COMMENT ON FUNCTION approve_from_queue IS 'Approves a queue item, creates publication, sets up taxonomy relationships, and optionally upserts new vendors/organizations';


### PR DESCRIPTION
Admin review UI improvements:
- Display extracted vendor_names and organization_names from payload
- Checkbox toggles to select which entities to add to taxonomy
- Visual distinction between NEW and existing entities
- New entities pre-checked, existing unchecked by default
- Shows count of entities added after approval

Database changes:
- approve_from_queue now accepts p_approved_vendors and p_approved_organizations
- Upserts selected vendors to ag_vendor table
- Upserts selected organizations to bfsi_organization table
- Added unique constraint on bfsi_organization.organization_name
- Duplicate detection prevents recreating existing entries