### PR TITLE
feat: improve publication card, modal, and filter interactions

### DIFF
--- a/src/features/publications/PublicationCard.astro
+++ b/src/features/publications/PublicationCard.astro
@@ -86,6 +86,7 @@ const candidates = [...itemThumbs];
   data-slug={item.slug}
   data-url={item.url}
   data-source_name={item.source_name || ''}
+  data-title={item.title}
   data-thumbnail={item.thumbnail || ''}
   data-summary-medium={item.summary_medium || ''}
   data-date_published={item.date_published || ''}
@@ -95,12 +96,15 @@ const candidates = [...itemThumbs];
     class="absolute inset-0 rounded-2xl focus:outline-none focus:ring-2 focus:ring-sky-500 z-10"
     aria-label={`View details for ${item.title}`}
     tabindex="0"
-    data-card-link
-    data-open-modal="true"></a>
+    data-card-link></a>
 
-  <div class="relative z-20 pointer-events-none">
+  <div class="relative z-20 pointer-events-none flex flex-col h-full">
     <div class="flex items-center gap-2">
-      <h3 id={`t-${item.slug}`} class="text-xl font-semibold text-sky-200">
+      <h3
+        id={`t-${item.slug}`}
+        class="text-xl font-semibold text-sky-200 line-clamp-2"
+        title={item.title}
+      >
         {item.title}
       </h3>
       {
@@ -131,13 +135,14 @@ const candidates = [...itemThumbs];
       {item.authors?.length && <span> · {item.authors[0]}</span>}
     </div>
 
-    <div class="relative mt-2">
+    <!-- Thumbnail area (fixed height) -->
+    <div
+      class="relative mt-2 w-full rounded-md border border-neutral-800 bg-neutral-800/40"
+      style="aspect-ratio: 16 / 9; overflow: hidden;"
+    >
       {
         hasImage ? (
-          <div
-            class="relative w-full rounded-md border border-neutral-800 bg-neutral-800/40"
-            style="aspect-ratio: 16 / 9; overflow: hidden;"
-          >
+          <>
             <div class="absolute inset-0 rounded-md bg-neutral-800/40" />
             <img
               src={candidates[0]}
@@ -152,49 +157,36 @@ const candidates = [...itemThumbs];
               sizes="(min-width: 1024px) 560px, (min-width: 640px) 480px, 100vw"
               class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-300"
             />
-          </div>
+          </>
         ) : (
-          <div class="relative w-full rounded-md border border-neutral-800 bg-neutral-900/80 px-4 py-10 flex items-center justify-center">
-            <p class="text-xs text-neutral-500 text-center">
-              Thumbnail not available yet. Full publication preview below.
-            </p>
+          <div class="absolute inset-0 flex items-center justify-center">
+            <svg
+              class="h-10 w-10 text-neutral-700"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
           </div>
         )
       }
+    </div>
 
-      {
-        item.summary_short && (
-          <div class="relative mt-3">
-            <p class="text-sm text-neutral-300 line-clamp-3">{item.summary_short}</p>
-            <div class="mt-2 flex justify-end">
-              <button
-                class="relative z-30 inline-flex items-center gap-1 text-sm text-sky-300 hover:text-sky-200 transition-colors px-2 py-1 rounded hover:bg-neutral-800/50 pointer-events-auto"
-                type="button"
-                data-open-modal="true"
-                aria-label="Preview summary"
-              >
-                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                  />
-                </svg>
-                Preview
-              </button>
-            </div>
-          </div>
-        )
-      }
+    {
+      item.summary_short && (
+        <p class="mt-2 text-sm text-neutral-300 line-clamp-2">{item.summary_short}</p>
+      )
+    }
 
-      <div class="mt-3 flex flex-wrap gap-1.5">
+    <!-- Tags row with Preview button aligned - pushed to bottom -->
+    <div class="mt-auto pt-3 flex items-start justify-between gap-2">
+      <div class="flex flex-wrap items-center gap-1.5 flex-1 min-w-0">
         {/* Core metadata */}
         {
           role && (
@@ -274,15 +266,42 @@ const candidates = [...itemThumbs];
               </span>
             ))
         }
-        {/* Overflow indicator */}
+        {/* Overflow indicator - opens modal */}
         {
           (regulators.length > 2 || regulations.length > 2) && (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-700/50 text-neutral-400 ring-1 ring-inset ring-neutral-600/30">
+            <button
+              type="button"
+              data-open-modal="true"
+              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-700/50 text-neutral-400 ring-1 ring-inset ring-neutral-600/30 hover:bg-neutral-600/50 hover:text-neutral-300 transition-colors pointer-events-auto"
+            >
               +{Math.max(0, regulators.length - 2) + Math.max(0, regulations.length - 2)} more
-            </span>
+            </button>
           )
         }
       </div>
+
+      <!-- Preview button -->
+      <button
+        class="relative z-30 flex-shrink-0 inline-flex items-center gap-1 text-xs text-sky-300 hover:text-sky-200 transition-colors px-2 py-0.5 rounded hover:bg-neutral-800/50 pointer-events-auto"
+        type="button"
+        data-open-modal="true"
+        aria-label="Preview summary"
+      >
+        <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+          ></path>
+        </svg>
+        Preview
+      </button>
     </div>
   </div>
 </li>

--- a/src/features/publications/PublicationModal.astro
+++ b/src/features/publications/PublicationModal.astro
@@ -5,63 +5,64 @@
     role="dialog"
     aria-modal="true"
     aria-labelledby="modal-title"
-    class="absolute inset-0 flex items-start justify-center overflow-auto p-4"
+    class="absolute inset-0 flex items-center justify-center overflow-auto p-4"
   >
+    <!-- Modal panel - matches card styling and approximate width -->
     <div
-      class="relative mt-10 w-full max-w-3xl rounded-2xl border border-neutral-800 bg-neutral-950 shadow-xl"
+      class="relative w-full max-w-[calc(min(100%,38rem))] rounded-2xl border border-neutral-800 bg-neutral-900/60 p-5 shadow-xl ring-1 ring-neutral-800/40"
     >
-      <!-- Close -->
-      <div class="absolute right-3 top-3 flex items-center gap-3">
-        <span class="text-xs text-neutral-500">
-          Press
-          <kbd
-            class="rounded border border-neutral-700 bg-neutral-800 px-1.5 py-0.5 text-neutral-400"
-            >ESC</kbd
-          >
-          to close
-        </span>
+      <!-- Close button -->
+      <button
+        id="modal-close"
+        aria-label="Close"
+        class="absolute right-3 top-3 rounded p-1.5 text-neutral-400 hover:text-white hover:bg-neutral-800 transition-colors"
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+      </button>
 
-        <button
-          id="modal-close"
-          aria-label="Close"
-          class="rounded p-2 text-neutral-300 hover:text-white"
-        >
-          ✕
-        </button>
+      <!-- Title -->
+      <h3 id="modal-title" class="text-xl font-semibold pr-10">
+        <span id="modal-title-text" class="text-sky-200"></span>
+      </h3>
+
+      <!-- Meta -->
+      <div id="modal-meta" class="mt-1 text-sm text-neutral-200"></div>
+
+      <!-- Summary (medium) -->
+      <div
+        id="modal-summary"
+        class="mt-3 text-sm text-neutral-300 prose prose-invert prose-sm max-w-none"
+      >
       </div>
 
-      <!-- Content -->
-      <div class="p-6">
-        <h3 id="modal-title" class="text-2xl font-semibold pr-32">
-          <span id="modal-title-text" class="text-sky-200"></span>
-        </h3>
+      <!-- Tags container -->
+      <div id="modal-tags" class="mt-3 flex flex-wrap gap-1.5"></div>
 
-        <div id="modal-meta" class="mt-2 text-sm text-neutral-400"></div>
-
-        <!-- Tags container -->
-        <div id="modal-tags" class="mt-4 flex flex-wrap gap-2 text-xs"></div>
-
-        <!-- Summary (from summary_medium or summary_long) -->
-        <div
-          id="modal-summary"
-          class="mt-4 text-base text-neutral-200 prose prose-invert prose-sm max-w-none"
+      <!-- Footer with action -->
+      <div class="mt-4 flex items-center justify-between">
+        <span class="text-xs text-neutral-500">
+          Press <kbd
+            class="rounded border border-neutral-700 bg-neutral-800 px-1 py-0.5 text-neutral-400"
+            >ESC</kbd
+          > to close
+        </span>
+        <a
+          id="modal-view-details"
+          class="inline-flex items-center gap-1.5 rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 transition-colors"
+          href="#"
         >
-        </div>
-
-        <!-- Button -->
-        <div class="mt-6">
-          <a
-            id="modal-view-details"
-            class="inline-flex items-center gap-2 rounded-lg bg-sky-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-sky-500 transition-colors"
-            href="#"
-          >
-            View full publication
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"
-              ></path>
-            </svg>
-          </a>
-        </div>
+          More details
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"
+            ></path>
+          </svg>
+        </a>
       </div>
     </div>
   </div>

--- a/src/features/publications/publication-modal.ts
+++ b/src/features/publications/publication-modal.ts
@@ -1,12 +1,3 @@
-function nextSrc(el: HTMLImageElement): string | null {
-  const n = el.dataset.next || '';
-  if (!n) return null;
-  const parts = n.split('|');
-  const nx = parts.shift();
-  el.dataset.next = parts.join('|');
-  return nx || null;
-}
-
 import { linkify } from '../../lib/text';
 
 let lastFocus: Element | null = null;
@@ -14,7 +5,7 @@ let focusTrapHandler: ((e: FocusEvent) => void) | null = null;
 
 function extractCardData(li: HTMLElement) {
   return {
-    title: li.querySelector('a')?.textContent?.trim() || '',
+    title: li.dataset.title || li.querySelector('a')?.textContent?.trim() || '',
     meta: (li.querySelector('.mt-1') as HTMLElement)?.textContent?.trim() || '',
     summary:
       (li.querySelector('p.text-sm') as HTMLElement)?.textContent ||
@@ -22,8 +13,6 @@ function extractCardData(li: HTMLElement) {
       '',
     link: (li.querySelector('a') as HTMLAnchorElement)?.href || '#',
     slug: li.dataset.slug || '',
-    thumb: li.dataset.thumbnail || '',
-    img: li.querySelector<HTMLImageElement>('img'),
     tags: [
       li.dataset.role || '',
       li.dataset.industry || '',
@@ -43,33 +32,6 @@ function renderTags(tagsEl: HTMLElement, tags: string[]) {
     b.textContent = t;
     tagsEl.appendChild(b);
   }
-}
-
-function getImageCandidates(thumb: string): string[] {
-  if (!thumb) return [];
-  if (/\.(webp|png|jpe?g)$/i.test(thumb)) return [thumb];
-  return [`${thumb}.webp`, `${thumb}.png`, `${thumb}.jpg`];
-}
-
-function setupModalImage(
-  modalImg: HTMLImageElement,
-  candidates: string[],
-  fallbackImg: HTMLImageElement | null,
-) {
-  const dedup = Array.from(new Set(candidates));
-
-  if (dedup.length) {
-    modalImg.src = dedup[0];
-    modalImg.dataset.next = dedup.slice(1).join('|');
-  } else if (fallbackImg) {
-    modalImg.src = fallbackImg.currentSrc || fallbackImg.src;
-    modalImg.dataset.next = fallbackImg.dataset.next || '';
-  }
-
-  modalImg.onerror = () => {
-    const nx = nextSrc(modalImg);
-    if (nx) modalImg.src = nx;
-  };
 }
 
 function openModalFrom(li: HTMLElement) {
@@ -98,11 +60,6 @@ function openModalFrom(li: HTMLElement) {
 
   const viewA = document.getElementById('modal-view-details') as HTMLAnchorElement | null;
   if (viewA) viewA.href = data.slug ? `/${data.slug}` : data.link;
-
-  const modalImg = document.getElementById('modal-img') as HTMLImageElement | null;
-  if (!modalImg) return;
-
-  setupModalImage(modalImg, getImageCandidates(data.thumb), data.img);
 
   const closeBtn = document.getElementById('modal-close') as HTMLButtonElement | null;
   closeBtn?.focus();
@@ -138,21 +95,6 @@ export default function initPublicationModal() {
     if (e.key === 'Escape') closeModal();
   });
 
-  function bindCard(li: HTMLElement) {
-    li.addEventListener('click', (e) => {
-      if ((e.target as HTMLElement).closest('[data-open-modal]')) return;
-      if ((e.target as HTMLElement).closest("a[id^='t-']")) return;
-      openModalFrom(li);
-    });
-
-    li.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        openModalFrom(li);
-      }
-    });
-  }
-
   function bindButton(btn: HTMLElement) {
     btn.addEventListener('click', (e) => {
       e.preventDefault();
@@ -162,14 +104,10 @@ export default function initPublicationModal() {
     });
   }
 
-  document.querySelectorAll('li.group').forEach((el) => bindCard(el as HTMLElement));
   document.querySelectorAll('[data-open-modal]').forEach((el) => bindButton(el as HTMLElement));
 
   function handleAddedNode(n: Node) {
     if (!(n instanceof Element)) return;
-
-    if (n.matches('li.group')) bindCard(n as HTMLElement);
-    n.querySelectorAll?.('li.group').forEach((el) => bindCard(el as HTMLElement));
 
     if (n.matches('[data-open-modal]')) bindButton(n as HTMLElement);
     n.querySelectorAll?.('[data-open-modal]').forEach((el) => bindButton(el as HTMLElement));

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -292,7 +292,8 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
               modal.classList.remove('hidden');
               document.body.style.overflow = 'hidden';
 
-              const title = el.querySelector('a')?.textContent || '';
+              const title =
+                el.getAttribute('data-title') || el.querySelector('a')?.textContent || '';
               const href = el.querySelector('a')?.href || '#';
 
               const titleEl = document.getElementById('modal-title-text');

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -69,6 +69,19 @@ const ogImage = thumbCandidates[0];
   }
 
   <article class="mx-auto max-w-3xl">
+    <!-- Back button for returning to scroll position -->
+    <button
+      id="back-btn"
+      type="button"
+      class="mb-4 inline-flex items-center gap-1.5 text-sm text-sky-400 hover:text-sky-300 transition-colors"
+    >
+      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"
+        ></path>
+      </svg>
+      Back
+    </button>
+
     <Breadcrumbs
       segments={[
         { label: 'Home', href: '/' },
@@ -182,4 +195,19 @@ const ogImage = thumbCandidates[0];
       </a>
     </div>
   </article>
+
+  <script>
+    const backBtn = document.getElementById('back-btn');
+    if (backBtn) {
+      backBtn.addEventListener('click', () => {
+        // If there's history, go back (preserves scroll position)
+        if (window.history.length > 1) {
+          window.history.back();
+        } else {
+          // Fallback: navigate to publications
+          window.location.href = '/publications';
+        }
+      });
+    }
+  </script>
 </Base>

--- a/src/pages/admin/review.astro
+++ b/src/pages/admin/review.astro
@@ -231,8 +231,26 @@ import Base from '../../layouts/Base.astro';
                 : `/thumbs/${item.thumbnail}`;
             }
 
+            // Prepare role from persona scores (highest scoring persona)
+            const topPersona = Object.entries(personaScores).sort(
+              ([, a], [, b]) => Number(b) - Number(a),
+            )[0];
+            const role = topPersona ? topPersona[0] : '';
+
             return `
-            <article class="rounded-xl border border-neutral-800 bg-neutral-900/60 transition hover:border-neutral-700" data-item-id="${item.id}">
+            <li class="group rounded-xl border border-neutral-800 bg-neutral-900/60 transition hover:border-neutral-700" 
+              data-item-id="${item.id}"
+              data-role="${role}"
+              data-industry="${industryCodes.length > 0 ? industryMap.get(industryCodes[0]) || industryCodes[0] : ''}"
+              data-topic="${topicCodes.length > 0 ? topicMap.get(topicCodes[0]) || topicCodes[0] : ''}"
+              data-content_type=""
+              data-geography=""
+              data-slug=""
+              data-url="${item.url}"
+              data-summary-medium="${(summary.medium || '').replace(/"/g, '&quot;')}"
+              data-authors=""
+              data-source_name="">
+              <a href="${item.url}" target="_blank" rel="noopener noreferrer" class="sr-only">${payload.title}</a>
               <div class="flex gap-6 p-6">
                 <!-- Thumbnail -->
                 ${
@@ -252,7 +270,7 @@ import Base from '../../layouts/Base.astro';
                     <div class="flex-1">
                       <h2 class="text-2xl font-semibold text-sky-200 break-words">${payload.title}</h2>
                       <div class="mt-2 flex flex-wrap gap-2 text-sm text-neutral-400">
-                        <span>� ${new Date(payload.published_at).toLocaleDateString()}</span>
+                        <span>📅 ${new Date(payload.published_at).toLocaleDateString()}</span>
                         <span>•</span>
                         <a href="${item.url}" target="_blank" rel="noopener noreferrer" class="text-sky-400 hover:text-sky-300 hover:underline">View original →</a>
                       </div>
@@ -260,6 +278,10 @@ import Base from '../../layouts/Base.astro';
                     
                     <!-- Action Buttons -->
                     <div class="flex flex-col gap-2 flex-shrink-0">
+                      <button class="preview-btn inline-flex items-center justify-center gap-1 rounded-lg border border-neutral-600 bg-neutral-800 px-6 py-2 font-medium text-neutral-300 hover:bg-neutral-700 transition whitespace-nowrap" type="button" data-open-modal="true">
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
+                        Preview
+                      </button>
                       <button class="approve-btn rounded-lg bg-emerald-600 px-6 py-2 font-semibold text-white hover:bg-emerald-500 transition whitespace-nowrap" data-id="${item.id}">✓ Approve</button>
                       <button class="reject-btn rounded-lg bg-red-600 px-6 py-2 font-semibold text-white hover:bg-red-500 transition whitespace-nowrap" data-id="${item.id}">✗ Reject</button>
                     </div>
@@ -468,7 +490,7 @@ import Base from '../../layouts/Base.astro';
                   </div>
                 </div>
               </div>
-            </article>
+            </li>
           `;
           })
           .join('');

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -341,11 +341,25 @@ const expandItemThumb = (t: string | undefined) => {
             <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800 space-y-2">
               {
                 industryWithCounts.map((l1) => (
-                  <details class="border border-neutral-800/50 rounded-md overflow-hidden">
+                  <details
+                    class="industry-l1 border border-neutral-800/50 rounded-md overflow-hidden"
+                    data-code={l1.code}
+                  >
                     <summary class="flex items-center justify-between px-3 py-2 cursor-pointer bg-neutral-900/30 hover:bg-neutral-800/30 transition-colors text-xs">
-                      <span class="font-medium text-neutral-400 uppercase tracking-wider">
-                        {l1.name}
-                      </span>
+                      <div class="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          name="filter-industry"
+                          value={l1.code}
+                          class="industry-checkbox h-3.5 w-3.5 rounded border-neutral-600 bg-neutral-800 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 cursor-pointer"
+                          data-level="1"
+                          data-code={l1.code}
+                          onclick="event.stopPropagation()"
+                        />
+                        <span class="font-medium text-neutral-400 uppercase tracking-wider">
+                          {l1.name}
+                        </span>
+                      </div>
                       <svg
                         class="w-3.5 h-3.5 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
                         fill="none"
@@ -360,34 +374,76 @@ const expandItemThumb = (t: string | undefined) => {
                         />
                       </svg>
                     </summary>
-                    <div class="px-3 py-2 bg-neutral-950/30">
-                      <div class="flex flex-wrap gap-1.5">
-                        <label class="filter-checkbox cursor-pointer">
-                          <input
-                            type="checkbox"
-                            name="filter-industry"
-                            value={l1.code}
-                            class="sr-only peer"
-                          />
-                          <span class="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs border border-dashed border-neutral-600 bg-neutral-900/50 text-neutral-400 transition-all peer-checked:border-solid peer-checked:border-cyan-500 peer-checked:bg-cyan-500/10 peer-checked:text-cyan-300 hover:border-neutral-500 hover:bg-neutral-800/50">
-                            All
-                          </span>
-                        </label>
-                        {l1.children?.map((l2) => (
-                          <label class="filter-checkbox cursor-pointer">
-                            <input
-                              type="checkbox"
-                              name="filter-industry"
-                              value={l2.code}
-                              class="sr-only peer"
-                            />
-                            <span class="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs border border-neutral-700 bg-neutral-900 text-neutral-300 transition-all peer-checked:border-cyan-500 peer-checked:bg-cyan-500/10 peer-checked:text-cyan-300 hover:border-neutral-600 hover:bg-neutral-800">
-                              {l2.name}
-                              {l2.count ? <span class="text-neutral-500">{l2.count}</span> : null}
-                            </span>
-                          </label>
-                        ))}
-                      </div>
+                    <div class="px-3 py-2 bg-neutral-950/30 space-y-1.5">
+                      {/* L2 items - collapsible sections */}
+                      {l1.children?.map((l2) => (
+                        <details
+                          class="industry-l2 ml-2 border border-neutral-800/40 rounded overflow-hidden"
+                          data-code={l2.code}
+                          data-parent={l1.code}
+                        >
+                          <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-neutral-900/20 hover:bg-neutral-800/30 transition-colors">
+                            <div class="flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                name="filter-industry"
+                                value={l2.code}
+                                class="industry-checkbox h-3 w-3 rounded border-neutral-600 bg-neutral-800 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 cursor-pointer"
+                                data-level="2"
+                                data-code={l2.code}
+                                data-parent={l1.code}
+                                onclick="event.stopPropagation()"
+                              />
+                              <span class="text-[11px] font-medium text-neutral-400 uppercase tracking-wide">
+                                {l2.name}
+                                {l2.count ? (
+                                  <span class="text-neutral-500 font-normal normal-case ml-1">
+                                    {l2.count}
+                                  </span>
+                                ) : null}
+                              </span>
+                            </div>
+                            {l2.children && l2.children.length > 0 && (
+                              <svg
+                                class="w-3 h-3 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  stroke-width="2"
+                                  d="M19 9l-7 7-7-7"
+                                />
+                              </svg>
+                            )}
+                          </summary>
+                          {l2.children && l2.children.length > 0 && (
+                            <div class="px-2.5 py-2 bg-neutral-950/20 flex flex-wrap gap-1.5">
+                              {l2.children?.map((l3) => (
+                                <label class="filter-checkbox cursor-pointer">
+                                  <input
+                                    type="checkbox"
+                                    name="filter-industry"
+                                    value={l3.code}
+                                    class="industry-checkbox sr-only peer"
+                                    data-level="3"
+                                    data-code={l3.code}
+                                    data-parent={l2.code}
+                                  />
+                                  <span class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs border border-neutral-700/70 bg-neutral-900/70 text-neutral-400 transition-all peer-checked:border-cyan-500 peer-checked:bg-cyan-500/10 peer-checked:text-cyan-300 hover:border-neutral-600 hover:bg-neutral-800">
+                                    {l3.name}
+                                    {l3.count ? (
+                                      <span class="text-neutral-500">{l3.count}</span>
+                                    ) : null}
+                                  </span>
+                                </label>
+                              ))}
+                            </div>
+                          )}
+                        </details>
+                      ))}
                     </div>
                   </details>
                 ))
@@ -638,36 +694,40 @@ const expandItemThumb = (t: string | undefined) => {
     </div>
   </section>
 
-  <!-- Floating Filter Button (FAB) -->
-  <button
-    id="open-filter-panel"
-    aria-label="Open filters"
-    class="fixed bottom-6 left-6 z-40 flex h-14 items-center gap-2 px-5 rounded-full bg-sky-600 text-white shadow-lg hover:bg-sky-500 transition-all focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-neutral-950"
-  >
-    <!-- Filter icon (default) -->
-    <svg id="fab-icon" class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
-      ></path>
-    </svg>
-    <!-- Loading spinner (shown during filtering) -->
-    <svg id="fab-spinner" class="h-5 w-5 animate-spin hidden" fill="none" viewBox="0 0 24 24">
-      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
-      ></circle>
-      <path
-        class="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      ></path>
-    </svg>
-    <span class="font-medium">Filters</span>
-    <span
-      id="fab-filter-count"
-      class="hidden px-2 py-0.5 text-xs font-bold bg-white text-sky-600 rounded-full"></span>
-  </button>
+  <!-- Floating Filter Button (FAB) - aligned with content -->
+  <div class="fixed bottom-6 left-0 right-0 z-40 pointer-events-none">
+    <div class="mx-auto max-w-5xl px-4">
+      <button
+        id="open-filter-panel"
+        aria-label="Open filters"
+        class="pointer-events-auto flex h-14 items-center gap-2 px-5 rounded-full bg-sky-600 text-white shadow-lg hover:bg-sky-500 transition-all focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-neutral-950"
+      >
+        <!-- Filter icon (default) -->
+        <svg id="fab-icon" class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
+          ></path>
+        </svg>
+        <!-- Loading spinner (shown during filtering) -->
+        <svg id="fab-spinner" class="h-5 w-5 animate-spin hidden" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+          ></circle>
+          <path
+            class="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          ></path>
+        </svg>
+        <span class="font-medium">Filters</span>
+        <span
+          id="fab-filter-count"
+          class="hidden px-2 py-0.5 text-xs font-bold bg-white text-sky-600 rounded-full"></span>
+      </button>
+    </div>
+  </div>
 
   <!-- Back to Top -->
   <button
@@ -741,6 +801,99 @@ const expandItemThumb = (t: string | undefined) => {
   <script>
     import initMultiSelectFilters from '../features/publications/multi-select-filters.ts';
     initMultiSelectFilters();
+  </script>
+
+  <!-- Industry cascading selection -->
+  <script>
+    function initIndustryCascade() {
+      const checkboxes = document.querySelectorAll('.industry-checkbox');
+
+      checkboxes.forEach((checkbox) => {
+        checkbox.addEventListener('change', (e) => {
+          const target = e.target as HTMLInputElement;
+          const level = target.dataset.level;
+          const code = target.dataset.code;
+          const isChecked = target.checked;
+
+          if (level === '1') {
+            // L1 checked/unchecked: cascade to all L2s and L3s
+            const l2Checkboxes = document.querySelectorAll(
+              `.industry-checkbox[data-parent="${code}"]`,
+            );
+            l2Checkboxes.forEach((l2) => {
+              (l2 as HTMLInputElement).checked = isChecked;
+              // Also cascade to L3s under this L2
+              const l2Code = (l2 as HTMLInputElement).dataset.code;
+              const l3Checkboxes = document.querySelectorAll(
+                `.industry-checkbox[data-parent="${l2Code}"]`,
+              );
+              l3Checkboxes.forEach((l3) => {
+                (l3 as HTMLInputElement).checked = isChecked;
+              });
+            });
+          } else if (level === '2') {
+            // L2 checked/unchecked: cascade to all L3s
+            const l3Checkboxes = document.querySelectorAll(
+              `.industry-checkbox[data-parent="${code}"]`,
+            );
+            l3Checkboxes.forEach((l3) => {
+              (l3 as HTMLInputElement).checked = isChecked;
+            });
+            // Update parent L1 state
+            updateParentState(target.dataset.parent!, '1');
+          } else if (level === '3') {
+            // L3 changed: update parent L2 and L1 states
+            updateParentState(target.dataset.parent!, '2');
+          }
+
+          // Trigger change event for filter system
+          target.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+      });
+
+      function updateParentState(parentCode: string, parentLevel: string) {
+        const parentCheckbox = document.querySelector(
+          `.industry-checkbox[data-code="${parentCode}"][data-level="${parentLevel}"]`,
+        ) as HTMLInputElement;
+        if (!parentCheckbox) return;
+
+        const childCheckboxes = document.querySelectorAll(
+          `.industry-checkbox[data-parent="${parentCode}"]`,
+        );
+        const children = Array.from(childCheckboxes) as HTMLInputElement[];
+
+        const checkedCount = children.filter((c) => c.checked).length;
+        const indeterminateCount = children.filter((c) => c.indeterminate).length;
+        const totalChildren = children.length;
+
+        if (checkedCount === 0 && indeterminateCount === 0) {
+          // No children checked or indeterminate
+          parentCheckbox.checked = false;
+          parentCheckbox.indeterminate = false;
+        } else if (checkedCount === totalChildren && indeterminateCount === 0) {
+          // All children fully checked
+          parentCheckbox.checked = true;
+          parentCheckbox.indeterminate = false;
+        } else {
+          // Some children checked or some indeterminate
+          parentCheckbox.checked = false;
+          parentCheckbox.indeterminate = true;
+        }
+
+        // If this was L2, also update L1
+        if (parentLevel === '2') {
+          const l1Code = parentCheckbox.dataset.parent;
+          if (l1Code) updateParentState(l1Code, '1');
+        }
+      }
+    }
+
+    // Initialize on load and after any dynamic content changes
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', initIndustryCascade);
+    } else {
+      initIndustryCascade();
+    }
   </script>
 
   <!-- Back to Top interaction -->


### PR DESCRIPTION
Fixes KB-150

Card improvements:
- Card clicks navigate to detail page (not modal)
- Preview button opens modal
- Titles limited to 2 lines with ellipsis
- Tags and Preview button top-aligned at bottom
- Thumbnail placeholder for cards without images
- Consistent card heights

Modal improvements:
- Matches card dimensions and styling
- Shows full title, medium summary, all tags
- 'More details' button (replaces ambiguous 'View full publication')
- Close button and ESC key support

Navigation improvements:
- Back button on detail page uses history.back() for scroll position
- Blue styling for back button

Filter UX overhaul:
- Unified checkbox pattern for L1/L2/L3 industry hierarchy
- Cascading selection (select Banking → all children selected)
- Indeterminate state propagates up (partial selection shows dash)
- Fine-grained control (select parent, then uncheck specific children)
- Floating Filters button aligned with content area

Admin review page:
- Same card/modal behavior as public pages
- Preview button with modal support