### PR TITLE
fix: use correct env var name PUBLIC_SUPABASE_URL in nightly workflow

### DIFF
--- a/.github/workflows/nightly-discovery.yml
+++ b/.github/workflows/nightly-discovery.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run discovery (agent-api)
         env:
-          SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
         run: node services/agent-api/src/cli.js discovery
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run enrichment pipeline (limit 20 per night)
         env:
-          SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: node services/agent-api/src/cli.js process-queue --limit=20


### PR DESCRIPTION
Fixes KB-152

The workflow was setting SUPABASE_URL but the agent code expects PUBLIC_SUPABASE_URL, causing 'supabaseUrl is required' error.