### PR TITLE
fix(admin): fetch fresh payload before title update, show all tags on…

### DIFF
--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -153,18 +153,18 @@ const ogImage = thumbCandidates[0];
         )
       }
       {
-        item.industry && (
+        (item.industries || []).map((code: string) => (
           <span class="rounded-md border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-neutral-300">
-            {item.industry}
+            {code}
           </span>
-        )
+        ))
       }
       {
-        item.topic && (
+        (item.topics || []).map((code: string) => (
           <span class="rounded-md border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-neutral-300">
-            {item.topic}
+            {code}
           </span>
-        )
+        ))
       }
       {
         item.geography && (

--- a/src/pages/admin/review.astro
+++ b/src/pages/admin/review.astro
@@ -632,11 +632,19 @@ import PublicationModal from '../../features/publications/PublicationModal.astro
 
       try {
         // Update title in queue item if changed
+        // IMPORTANT: Fetch fresh payload to avoid overwriting re-enriched data
         if (editedTitle !== item.payload?.title) {
+          const { data: freshItem, error: fetchError } = await supabase
+            .from('ingestion_queue')
+            .select('payload')
+            .eq('id', item.id)
+            .single();
+          if (fetchError) throw fetchError;
+
           const { error: updateError } = await supabase
             .from('ingestion_queue')
             .update({
-              payload: { ...item.payload, title: editedTitle },
+              payload: { ...freshItem.payload, title: editedTitle },
             })
             .eq('id', item.id);
           if (updateError) throw updateError;


### PR DESCRIPTION
… detail page

- Title edit was overwriting re-enriched payload with stale client data
- Detail page now shows all industries/topics from arrays

Fixes KB-157