### PR TITLE
feat(discovery): include premium sources in nightly run

### DIFF
--- a/.github/workflows/nightly-discovery.yml
+++ b/.github/workflows/nightly-discovery.yml
@@ -35,7 +35,7 @@ jobs:
           PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: node services/agent-api/src/cli.js discovery --agentic
+        run: node services/agent-api/src/cli.js discovery --agentic --premium
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
Adds `--premium` flag to nightly discovery workflow to include 13 premium sources (ECB, Fed, FT, Big 4, consultancies).

These sources already have proper handling via `premium-handler.js` (headline_only/landing_page modes).