### PR TITLE
feat(sources): add RSS feed for McKinsey

### DIFF
--- a/supabase/migrations/20251203122300_add_mckinsey_rss.sql
+++ b/supabase/migrations/20251203122300_add_mckinsey_rss.sql
@@ -1,0 +1,6 @@
+-- Add RSS feed for McKinsey (they have a working general insights RSS)
+-- The discovery agent's keyword scoring will filter for BFSI-relevant content
+
+UPDATE kb_source 
+SET rss_feed = 'https://www.mckinsey.com/insights/rss'
+WHERE slug = 'mckinsey';


### PR DESCRIPTION
Uses McKinsey's general insights RSS feed (`https://www.mckinsey.com/insights/rss`).

The discovery agent's keyword scoring filters for BFSI-relevant content.

Tested: Found 3 relevant articles on first run.