### PR TITLE
feat(discovery): add premium source RSS feeds and extend scraper

### DIFF
--- a/services/agent-api/src/lib/scrapers.js
+++ b/services/agent-api/src/lib/scrapers.js
@@ -1,7 +1,25 @@
 import { chromium } from 'playwright';
 
+/**
+ * Scrape articles from a website using Playwright
+ *
+ * Extended scraper_config options:
+ * - url: URL to scrape (required)
+ * - selectors.article: CSS selector for article containers (required)
+ * - selectors.title: CSS selector for title within article (required)
+ * - selectors.link: CSS selector for link within article (required)
+ * - selectors.date: CSS selector for date within article (optional)
+ * - selectors.description: CSS selector for description (optional)
+ * - waitFor: CSS selector to wait for before scraping (optional)
+ * - waitMs: Additional wait time in ms after page load (default: 2000)
+ * - limit: Max number of articles to return (optional)
+ * - pagination: { type: 'loadMore'|'scroll', selector: '.load-more', maxPages: 3 }
+ * - extractors: { title: 'text'|'attr:data-title', url: 'href'|'attr:data-url' }
+ */
 export async function scrapeWebsite(source) {
   if (!source.scraper_config) return [];
+
+  const config = source.scraper_config;
 
   // Use stealth settings to bypass bot detection
   const browser = await chromium.launch({
@@ -29,26 +47,73 @@ export async function scrapeWebsite(source) {
   });
 
   try {
-    await page.goto(source.scraper_config.url, {
+    await page.goto(config.url, {
       waitUntil: 'domcontentloaded',
       timeout: 30000,
     });
 
-    // Wait for content to load
-    await new Promise((r) => setTimeout(r, 2000));
+    // Wait for specific selector if configured
+    if (config.waitFor) {
+      await page.waitForSelector(config.waitFor, { timeout: 10000 }).catch(() => {
+        // Continue even if selector not found
+      });
+    }
 
+    // Wait for content to load
+    const waitMs = config.waitMs ?? 2000;
+    await new Promise((r) => setTimeout(r, waitMs));
+
+    // Handle pagination if configured
+    if (config.pagination) {
+      await handlePagination(page, config.pagination);
+    }
+
+    // Extract articles with extended options
     const articles = await page.$$eval(
-      source.scraper_config.selectors.article,
-      (elements, selectors) => {
-        return elements
-          .map((el) => ({
-            title: el.querySelector(selectors.title)?.textContent?.trim(),
-            url: el.querySelector(selectors.link)?.href,
-            date: el.querySelector(selectors.date)?.textContent?.trim(),
-          }))
-          .filter((a) => a.title && a.url);
+      config.selectors.article,
+      (elements, opts) => {
+        const { selectors, extractors = {}, limit } = opts;
+
+        // Helper to extract value based on extractor config
+        const extract = (el, selector, extractor = 'text') => {
+          const target = el.querySelector(selector);
+          if (!target) return null;
+
+          if (extractor === 'text') {
+            return target.textContent?.trim();
+          } else if (extractor === 'href') {
+            return target.href;
+          } else if (extractor.startsWith('attr:')) {
+            const attr = extractor.replace('attr:', '');
+            return target.getAttribute(attr);
+          }
+          return target.textContent?.trim();
+        };
+
+        let results = elements.map((el) => ({
+          title: extract(el, selectors.title, extractors.title || 'text'),
+          url: extract(el, selectors.link, extractors.url || 'href'),
+          date: selectors.date ? extract(el, selectors.date, extractors.date || 'text') : null,
+          description: selectors.description
+            ? extract(el, selectors.description, extractors.description || 'text')
+            : null,
+        }));
+
+        // Filter valid articles
+        results = results.filter((a) => a.title && a.url);
+
+        // Apply limit if configured
+        if (limit && limit > 0) {
+          results = results.slice(0, limit);
+        }
+
+        return results;
       },
-      source.scraper_config.selectors,
+      {
+        selectors: config.selectors,
+        extractors: config.extractors || {},
+        limit: config.limit,
+      },
     );
 
     return articles;
@@ -56,5 +121,25 @@ export async function scrapeWebsite(source) {
     throw new Error(`Scraping failed: ${error.message}`);
   } finally {
     await browser.close();
+  }
+}
+
+/**
+ * Handle pagination (load more button or infinite scroll)
+ */
+async function handlePagination(page, pagination) {
+  const { type, selector, maxPages = 2 } = pagination;
+
+  for (let i = 0; i < maxPages - 1; i++) {
+    if (type === 'loadMore' && selector) {
+      const loadMoreBtn = await page.$(selector);
+      if (!loadMoreBtn) break;
+
+      await loadMoreBtn.click();
+      await new Promise((r) => setTimeout(r, 1500));
+    } else if (type === 'scroll') {
+      await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+      await new Promise((r) => setTimeout(r, 1500));
+    }
   }
 }

--- a/supabase/migrations/20251203130000_add_premium_rss_feeds.sql
+++ b/supabase/migrations/20251203130000_add_premium_rss_feeds.sql
@@ -1,0 +1,17 @@
+-- Add RSS feeds for premium sources (regulators)
+-- These are official RSS feeds from the source websites
+
+-- ECB: Publications RSS
+UPDATE kb_source 
+SET rss_feed = 'https://www.ecb.europa.eu/rss/pub.html'
+WHERE slug = 'ecb';
+
+-- Federal Reserve: FEDS Notes (financial research)
+UPDATE kb_source 
+SET rss_feed = 'https://www.federalreserve.gov/feeds/feds_notes.xml'
+WHERE slug = 'fed';
+
+-- BIS: BIS and FSI publications
+UPDATE kb_source 
+SET rss_feed = 'https://www.bis.org/doclist/bis_fsi_publs.rss'
+WHERE slug = 'bis';

--- a/supabase/migrations/20251203131000_add_consultancy_scrapers.sql
+++ b/supabase/migrations/20251203131000_add_consultancy_scrapers.sql
@@ -1,0 +1,34 @@
+-- Add scraper configs for consultancies without RSS feeds
+-- Uses extended scraper config with waitFor, limit, etc.
+
+-- BCG: Financial Institutions insights page
+UPDATE kb_source SET
+  scraper_config = '{
+    "url": "https://www.bcg.com/industries/financial-institutions/insights",
+    "waitFor": "[class*=''card'']",
+    "waitMs": 3000,
+    "limit": 20,
+    "selectors": {
+      "article": "[class*=''card''], [class*=''Card'']",
+      "title": "h3, h4, h5, [class*=''title'']",
+      "link": "a",
+      "description": "p, [class*=''description'']"
+    }
+  }'::jsonb
+WHERE slug = 'bcg';
+
+-- Bain: Financial Services insights page  
+UPDATE kb_source SET
+  scraper_config = '{
+    "url": "https://www.bain.com/insights/industry-insights/financial-services-insights/",
+    "waitFor": "[class*=''card'']",
+    "waitMs": 3000,
+    "limit": 20,
+    "selectors": {
+      "article": "[class*=''card''], [class*=''Card''], article",
+      "title": "h3, h4, [class*=''title'']",
+      "link": "a",
+      "description": "p, [class*=''description''], [class*=''excerpt'']"
+    }
+  }'::jsonb
+WHERE slug = 'bain';


### PR DESCRIPTION
## Changes

### RSS feeds added
- **ECB**: `ecb.europa.eu/rss/pub.html`
- **Fed**: `federalreserve.gov/feeds/feds_notes.xml`
- **BIS**: `bis.org/doclist/bis_fsi_publs.rss`

### Scraper improvements
- Extended config with `waitFor`, `waitMs`, `pagination`, `extractors`, `limit`
- Added scraper configs for BCG and Bain (no RSS available)

### Parser fixes
- Handle CDATA-wrapped links in RSS (Fed uses this)
- Skip keyword filter for premium regulator sources (content always BFSI-relevant)

## Test results
- ECB: 7 publications ✅
- Fed: 14 publications ✅
- BIS: 9 publications ✅
- McKinsey: 3 publications ✅ (separate PR #67)