### PR TITLE
improvement(admin): add hover tooltips to Feed column icons KB-166

### DIFF
--- a/src/pages/admin/sources.astro
+++ b/src/pages/admin/sources.astro
@@ -221,7 +221,15 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
             </span>
           </td>
           <td class="py-3 pr-4">
-            ${source.rss_feed ? '📡' : source.sitemap_url ? '🗺️' : source.scraper_config ? '🤖' : '❌'}
+            ${
+              source.rss_feed
+                ? '<span title="RSS Feed configured" class="cursor-help">📡</span>'
+                : source.sitemap_url
+                  ? '<span title="Sitemap configured" class="cursor-help">🗺️</span>'
+                  : source.scraper_config
+                    ? '<span title="Web scraper configured" class="cursor-help">🤖</span>'
+                    : '<span title="No feed configured" class="cursor-help">❌</span>'
+            }
           </td>
           <td class="py-3 pr-4">
             <button


### PR DESCRIPTION
## Summary
Adds hover tooltips to the Feed column icons in Source Management for better UX.

## Changes
Icons now display tooltips on hover:
- 📡 → "RSS Feed configured"
- 🗺️ → "Sitemap configured"
- 🤖 → "Web scraper configured"
- ❌ → "No feed configured"

Also adds `cursor-help` class for visual hint that hover is available.

Closes KB-166