### PR TITLE
fix(publications): reorder DOM elements when sorting KB-167

### DIFF
--- a/src/features/publications/multi-select-filters.ts
+++ b/src/features/publications/multi-select-filters.ts
@@ -189,13 +189,17 @@ export default function initMultiSelectFilters() {
 
     const totalMatching = matchingIndices.length;
     const visibleCount = Math.min(currentPage * PAGE_SIZE, totalMatching);
-    const visibleIndices = new Set(matchingIndices.slice(0, visibleCount));
+    const visibleIndices = matchingIndices.slice(0, visibleCount);
 
+    // Reorder DOM elements based on sorted indices
     let visible = 0;
-    data.forEach((item, index) => {
-      const isVisible = visibleIndices.has(index);
-      item.el.classList.toggle('hidden', !isVisible);
-      if (isVisible) visible++;
+    data.forEach((item) => item.el.classList.add('hidden'));
+
+    visibleIndices.forEach((index) => {
+      const item = data[index];
+      item.el.classList.remove('hidden');
+      list.appendChild(item.el); // Move to end = sorted order
+      visible++;
     });
 
     // Update UI


### PR DESCRIPTION
## Bug
Sorting dropdown appeared to work but didn't change the visual order - items stayed in their original HTML order.

## Root Cause
Previous implementation only toggled visibility on sorted indices but never actually reordered the DOM elements.

## Fix
Use `appendChild` to move elements in sorted order - appending an existing element moves it to the end, effectively reordering.

Closes KB-167