### PR TITLE
fix(admin): require auth for publication edits KB-167

### DIFF
--- a/src/pages/admin/publications.astro
+++ b/src/pages/admin/publications.astro
@@ -96,6 +96,16 @@ import Base from '../../layouts/Base.astro';
     import.meta.env.PUBLIC_SUPABASE_ANON_KEY,
   );
 
+  // Check authentication
+  async function checkAuth() {
+    const { data } = await supabase.auth.getSession();
+    if (!data.session) {
+      window.location.href = '/login';
+      return false;
+    }
+    return true;
+  }
+
   const loading = document.getElementById('loading');
   const publicationsEl = document.getElementById('publications');
   const searchInput = document.getElementById('search') as HTMLInputElement;
@@ -173,6 +183,8 @@ import Base from '../../layouts/Base.astro';
   }
 
   async function saveChanges() {
+    if (!(await checkAuth())) return;
+
     const id = editId.value;
     const newTitle = editTitle.value.trim();
 
@@ -236,6 +248,10 @@ import Base from '../../layouts/Base.astro';
     setTimeout(() => (triggerBuild.textContent = '🚀 Trigger Build'), 3000);
   });
 
-  // Initial load
-  loadPublications();
+  // Initial load with auth check
+  (async () => {
+    if (await checkAuth()) {
+      loadPublications();
+    }
+  })();
 </script>

--- a/supabase/migrations/20251203151000_allow_authenticated_publication_updates.sql
+++ b/supabase/migrations/20251203151000_allow_authenticated_publication_updates.sql
@@ -1,0 +1,12 @@
+-- Allow authenticated users to update kb_publication
+-- Required for admin publications edit page
+
+-- Add update policy for authenticated users
+CREATE POLICY "kb_publication_update_authenticated" 
+  ON kb_publication 
+  FOR UPDATE 
+  USING (auth.role() = 'authenticated')
+  WITH CHECK (auth.role() = 'authenticated');
+
+-- Grant UPDATE permission to authenticated role
+GRANT UPDATE ON kb_publication TO authenticated;


### PR DESCRIPTION
## Issue
Publication edits weren't saving due to RLS policy - anon users can't update `kb_publication`.

## Fix
1. Added RLS policy allowing authenticated users to UPDATE `kb_publication`
2. Added auth check to publications edit page - redirects to `/login` if not logged in

## Migration
Already applied to remote database.

Closes KB-167