### PR TITLE
feat(kb-171): add channels and refine source categories

### DIFF
--- a/docs/data-model/schema.md
+++ b/docs/data-model/schema.md
@@ -74,12 +74,51 @@ erDiagram
 
 ### Core Tables
 
-| Table                   | Purpose                     |
-| ----------------------- | --------------------------- |
-| `kb_publication`        | Published content           |
-| `kb_publication_pretty` | Flattened view for frontend |
-| `ingestion_queue`       | Processing pipeline         |
-| `kb_source`             | RSS feed configurations     |
+| Table                   | Purpose                           |
+| ----------------------- | --------------------------------- |
+| `kb_publication`        | Published content                 |
+| `kb_publication_pretty` | Flattened view for frontend       |
+| `ingestion_queue`       | Processing pipeline               |
+| `kb_source`             | Content sources (feeds, scrapers) |
+| `kb_channel`            | Strategic information streams     |
+
+## Content Metadata Concepts (KB-171)
+
+Four distinct concepts structure content metadata:
+
+| Concept                       | Meaning                        | Examples                                   |
+| ----------------------------- | ------------------------------ | ------------------------------------------ |
+| `kb_source.category`          | Type of producing organization | regulator, central_bank, vendor, academic  |
+| `kb_publication.content_type` | Form of the document           | article, report, peer-reviewed-paper       |
+| `bfsi_topic`                  | High-level subject theme       | credit_risk, payments, digital_identity    |
+| `kb_channel`                  | Strategic information stream   | regulatory_intelligence, academic_research |
+
+### Channels (kb_channel)
+
+Strategic groupings that define why content exists in the platform:
+
+| Slug                      | Name                          | Purpose                                       |
+| ------------------------- | ----------------------------- | --------------------------------------------- |
+| `regulatory_intelligence` | Regulatory Intelligence       | Official regulatory publications, guidelines  |
+| `prudential_statistics`   | Prudential & Risk Statistics  | Statistical data from central banks, BIS, IMF |
+| `market_disclosures`      | Market Disclosures            | Annual reports, 10-K filings, IR content      |
+| `vendor_innovation`       | Vendor & Innovation Insights  | Product updates, case studies from vendors    |
+| `academic_research`       | Academic & Technical Research | Papers from arXiv, SSRN, universities         |
+| `open_datasets`           | Open Datasets & Indicators    | Structured data from Open Banking, CBS, etc.  |
+
+### Source Categories (kb_source.category)
+
+| Value             | Description                                   |
+| ----------------- | --------------------------------------------- |
+| `regulator`       | Supervisory authorities (EBA, ESMA, AFM, FCA) |
+| `central_bank`    | Central banks (ECB, Fed, DNB)                 |
+| `vendor`          | Technology vendors (BFSI and AI/agentic)      |
+| `research`        | Research organizations, think tanks           |
+| `consulting`      | Big 4, strategy consulting firms              |
+| `media_outlet`    | News, trade publications                      |
+| `standards_body`  | NIST, ISO, BCBS, FATF, W3C                    |
+| `academic`        | Universities, academic publishers             |
+| `government_body` | Government agencies (non-regulatory)          |
 
 ### Guardrail Taxonomies (curated, fixed)
 

--- a/src/components/admin/SourceFormModal.astro
+++ b/src/components/admin/SourceFormModal.astro
@@ -67,6 +67,23 @@
         </div>
       </div>
 
+      <!-- Channel (strategic information stream) -->
+      <div>
+        <label class="block text-sm font-medium text-neutral-300 mb-1">Channel *</label>
+        <select
+          id="source-channel"
+          required
+          class="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white focus:border-sky-500 focus:outline-none"
+        >
+          <option value="regulatory_intelligence">⚖️ Regulatory Intelligence</option>
+          <option value="prudential_statistics">📊 Prudential & Risk Statistics</option>
+          <option value="market_disclosures">📈 Market Disclosures</option>
+          <option value="vendor_innovation">🚀 Vendor & Innovation Insights</option>
+          <option value="academic_research">🎓 Academic & Technical Research</option>
+          <option value="open_datasets">📦 Open Datasets & Indicators</option>
+        </select>
+      </div>
+
       <div class="grid grid-cols-2 gap-4">
         <div>
           <label class="block text-sm font-medium text-neutral-300 mb-1">Category *</label>
@@ -75,15 +92,15 @@
             required
             class="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white focus:border-sky-500 focus:outline-none"
           >
-            <option value="financial-media">Financial Media</option>
-            <option value="ai-thought-leader">AI Thought Leader</option>
-            <option value="strategy-consulting">Strategy Consulting</option>
-            <option value="big4">Big 4</option>
-            <option value="consulting">Consulting</option>
+            <option value="regulator">Regulator</option>
+            <option value="central_bank">Central Bank</option>
             <option value="vendor">Vendor</option>
             <option value="research">Research</option>
-            <option value="regulator">Regulator</option>
-            <option value="publication">Publication</option>
+            <option value="consulting">Consulting</option>
+            <option value="media_outlet">Media Outlet</option>
+            <option value="standards_body">Standards Body</option>
+            <option value="academic">Academic</option>
+            <option value="government_body">Government Body</option>
           </select>
         </div>
         <div>

--- a/src/pages/admin/sources.astro
+++ b/src/pages/admin/sources.astro
@@ -43,7 +43,7 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
       <span class="text-sm font-medium text-neutral-700 dark:text-neutral-300">Display</span>
     </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
       <!-- Grouping -->
       <div>
         <label class="block text-xs text-neutral-500 dark:text-neutral-400 mb-1.5">Grouping</label>
@@ -52,6 +52,7 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
           class="w-full rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-3 py-1.5 text-sm text-neutral-900 dark:text-neutral-200"
         >
           <option value="">No grouping</option>
+          <option value="channel_slug">Channel</option>
           <option value="category">Category</option>
           <option value="tier">Tier</option>
         </select>
@@ -67,6 +68,7 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
           >
             <option value="sort_order">Priority</option>
             <option value="name">Name</option>
+            <option value="channel_slug">Channel</option>
             <option value="category">Category</option>
             <option value="tier">Tier</option>
             <option value="enabled">Enabled</option>
@@ -91,6 +93,23 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
         </div>
       </div>
 
+      <!-- Filter: Channel -->
+      <div>
+        <label class="block text-xs text-neutral-500 dark:text-neutral-400 mb-1.5">Channel</label>
+        <select
+          id="filter-channel"
+          class="w-full rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-3 py-1.5 text-sm text-neutral-900 dark:text-neutral-200"
+        >
+          <option value="">All Channels</option>
+          <option value="regulatory_intelligence">⚖️ Regulatory</option>
+          <option value="prudential_statistics">📊 Statistics</option>
+          <option value="market_disclosures">📈 Disclosures</option>
+          <option value="vendor_innovation">🚀 Vendor</option>
+          <option value="academic_research">🎓 Academic</option>
+          <option value="open_datasets">📦 Datasets</option>
+        </select>
+      </div>
+
       <!-- Filter: Category -->
       <div>
         <label class="block text-xs text-neutral-500 dark:text-neutral-400 mb-1.5">Category</label>
@@ -99,12 +118,15 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
           class="w-full rounded-md border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-3 py-1.5 text-sm text-neutral-900 dark:text-neutral-200"
         >
           <option value="">All Categories</option>
-          <option value="strategy-consulting">Strategy Consulting</option>
-          <option value="big4">Big 4</option>
-          <option value="vendor">Vendors</option>
+          <option value="regulator">Regulator</option>
+          <option value="central_bank">Central Bank</option>
+          <option value="vendor">Vendor</option>
           <option value="research">Research</option>
-          <option value="regulator">Regulators</option>
-          <option value="publication">Publication</option>
+          <option value="consulting">Consulting</option>
+          <option value="media_outlet">Media Outlet</option>
+          <option value="standards_body">Standards Body</option>
+          <option value="academic">Academic</option>
+          <option value="government_body">Government Body</option>
         </select>
       </div>
 
@@ -183,6 +205,7 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
     const modal = document.getElementById('source-modal');
     const modalTitle = document.getElementById('modal-title');
     const form = document.getElementById('source-form') as HTMLFormElement;
+    const filterChannel = document.getElementById('filter-channel') as HTMLSelectElement;
     const filterCategory = document.getElementById('filter-category') as HTMLSelectElement;
     const filterTier = document.getElementById('filter-tier') as HTMLSelectElement;
     const filterEnabled = document.getElementById('filter-enabled') as HTMLSelectElement;
@@ -245,6 +268,9 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
       let filtered = [...sources];
 
       // Apply filters
+      if (filterChannel.value) {
+        filtered = filtered.filter((s) => s.channel_slug === filterChannel.value);
+      }
       if (filterCategory.value) {
         filtered = filtered.filter((s) => s.category === filterCategory.value);
       }
@@ -379,15 +405,15 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
 
     function getCategoryColor(category: string): string {
       const colors: Record<string, string> = {
-        'financial-media': 'bg-blue-500/20 text-blue-300',
-        'ai-thought-leader': 'bg-purple-500/20 text-purple-300',
-        'strategy-consulting': 'bg-emerald-500/20 text-emerald-300',
-        big4: 'bg-emerald-500/20 text-emerald-300',
-        consulting: 'bg-teal-500/20 text-teal-300',
+        regulator: 'bg-red-500/20 text-red-300',
+        central_bank: 'bg-amber-500/20 text-amber-300',
         vendor: 'bg-orange-500/20 text-orange-300',
         research: 'bg-pink-500/20 text-pink-300',
-        regulator: 'bg-red-500/20 text-red-300',
-        publication: 'bg-sky-500/20 text-sky-300',
+        consulting: 'bg-teal-500/20 text-teal-300',
+        media_outlet: 'bg-sky-500/20 text-sky-300',
+        standards_body: 'bg-purple-500/20 text-purple-300',
+        academic: 'bg-indigo-500/20 text-indigo-300',
+        government_body: 'bg-slate-500/20 text-slate-300',
       };
       return colors[category] || 'bg-neutral-700 text-neutral-300';
     }
@@ -426,8 +452,10 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
       (document.getElementById('source-priority') as HTMLSelectElement).value = String(
         Math.ceil((source.sort_order || 100) / 100),
       );
+      (document.getElementById('source-channel') as HTMLSelectElement).value =
+        source.channel_slug || 'vendor_innovation';
       (document.getElementById('source-category') as HTMLSelectElement).value =
-        source.category || 'publication';
+        source.category || 'vendor';
       (document.getElementById('source-tier') as HTMLSelectElement).value =
         source.tier || 'standard';
       (document.getElementById('source-description') as HTMLTextAreaElement).value =
@@ -496,6 +524,7 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
         slug: (document.getElementById('source-slug') as HTMLInputElement).value,
         domain: (document.getElementById('source-domain') as HTMLInputElement).value,
         sort_order: priority * 100,
+        channel_slug: (document.getElementById('source-channel') as HTMLSelectElement).value,
         category: (document.getElementById('source-category') as HTMLSelectElement).value,
         tier: (document.getElementById('source-tier') as HTMLSelectElement).value,
         description:
@@ -530,6 +559,7 @@ import SourceFormModal from '../../components/admin/SourceFormModal.astro';
     });
 
     // Filter handlers
+    filterChannel?.addEventListener('change', renderSources);
     filterCategory?.addEventListener('change', renderSources);
     filterTier?.addEventListener('change', renderSources);
     filterEnabled?.addEventListener('change', renderSources);

--- a/supabase/migrations/20251204220000_add_channels_and_refine_categories.sql
+++ b/supabase/migrations/20251204220000_add_channels_and_refine_categories.sql
@@ -1,0 +1,170 @@
+-- KB-171: Add channels and refine source categories
+-- 
+-- This migration implements the strategic content structure from KB-169:
+-- 1. Creates kb_channel table for 6 strategic information streams
+-- 2. Adds channel_slug FK to kb_source
+-- 3. Refines category values for source types
+-- 4. Maps existing sources to channels
+
+-- ============================================================
+-- 1. CREATE kb_channel TABLE
+-- ============================================================
+-- Channels represent strategic information streams that group sources
+-- by their role in the knowledge platform
+
+CREATE TABLE IF NOT EXISTS kb_channel (
+  slug TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  icon TEXT,  -- emoji or icon identifier
+  sort_order INTEGER DEFAULT 100,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Add comment for documentation
+COMMENT ON TABLE kb_channel IS 'Strategic information streams for content categorization (KB-169)';
+COMMENT ON COLUMN kb_channel.slug IS 'URL-safe identifier';
+COMMENT ON COLUMN kb_channel.name IS 'Display name';
+COMMENT ON COLUMN kb_channel.description IS 'Purpose and scope of this channel';
+
+-- Seed the 6 strategic channels
+INSERT INTO kb_channel (slug, name, description, icon, sort_order) VALUES
+  ('regulatory_intelligence', 'Regulatory Intelligence', 
+   'Official regulatory publications, guidelines, consultations, and enforcement from supervisory authorities (EBA, ESMA, EIOPA, ECB, DNB, AFM, FCA, MAS, etc.)', 
+   '⚖️', 10),
+  ('prudential_statistics', 'Prudential & Risk Statistics', 
+   'Statistical data, risk metrics, and quantitative reports from central banks, BIS, IMF, FATF, and statistical agencies', 
+   '📊', 20),
+  ('market_disclosures', 'Market Disclosures', 
+   'Annual reports, 10-K/10-Q filings, investor relations, and corporate disclosures from banks, insurers, fintechs, and servicers', 
+   '📈', 30),
+  ('vendor_innovation', 'Vendor & Innovation Insights', 
+   'Product updates, case studies, whitepapers, and technical content from BFSI vendors and AI/agentic technology providers', 
+   '🚀', 40),
+  ('academic_research', 'Academic & Technical Research', 
+   'Peer-reviewed papers, working papers, and research from arXiv, SSRN, BIS, universities, and research institutes', 
+   '🎓', 50),
+  ('open_datasets', 'Open Datasets & Indicators', 
+   'Structured datasets, APIs, and indicators from Open Banking, CBS, KNMI, World Bank, and other open data sources', 
+   '📦', 60)
+ON CONFLICT (slug) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  icon = EXCLUDED.icon,
+  sort_order = EXCLUDED.sort_order;
+
+-- ============================================================
+-- 2. ADD channel_slug TO kb_source
+-- ============================================================
+
+ALTER TABLE kb_source 
+  ADD COLUMN IF NOT EXISTS channel_slug TEXT REFERENCES kb_channel(slug);
+
+-- Add index for filtering by channel
+CREATE INDEX IF NOT EXISTS idx_kb_source_channel ON kb_source(channel_slug);
+
+COMMENT ON COLUMN kb_source.channel_slug IS 'Strategic channel this source belongs to';
+
+-- ============================================================
+-- 3. REFINE CATEGORY VALUES
+-- ============================================================
+-- Categories describe what kind of organization produced the content
+-- 
+-- Old values: big4, strategy-consulting, vendor, research, regulator, publication
+-- New values: regulator, central_bank, vendor, research, media_outlet, consulting, 
+--             standards_body, academic, government_body
+
+-- First, migrate existing values to new taxonomy
+UPDATE kb_source SET category = 'consulting' WHERE category = 'big4';
+UPDATE kb_source SET category = 'consulting' WHERE category = 'strategy-consulting';
+UPDATE kb_source SET category = 'media_outlet' WHERE category = 'publication';
+
+-- Drop old constraint if exists and add new one
+ALTER TABLE kb_source DROP CONSTRAINT IF EXISTS ref_source_category_check;
+ALTER TABLE kb_source ADD CONSTRAINT kb_source_category_check 
+  CHECK (category IN (
+    'regulator',        -- Supervisory authorities (EBA, ESMA, AFM, FCA, etc.)
+    'central_bank',     -- Central banks (ECB, Fed, DNB monetary policy)
+    'vendor',           -- Technology vendors (BFSI and AI/agentic)
+    'research',         -- Research organizations, think tanks
+    'media_outlet',     -- News, trade publications
+    'consulting',       -- Big 4, strategy consulting firms
+    'standards_body',   -- NIST, ISO, BCBS, FATF, W3C
+    'academic',         -- Universities, academic publishers
+    'government_body'   -- Government agencies (non-regulatory)
+  ));
+
+-- ============================================================
+-- 4. MAP EXISTING SOURCES TO CHANNELS
+-- ============================================================
+-- Based on current category and known source purposes
+
+-- Regulators → regulatory_intelligence
+UPDATE kb_source SET channel_slug = 'regulatory_intelligence' 
+WHERE category = 'regulator';
+
+-- Central banks with statistical focus → prudential_statistics (override later if needed)
+-- Central banks with regulatory focus → regulatory_intelligence
+UPDATE kb_source SET channel_slug = 'regulatory_intelligence' 
+WHERE category = 'central_bank';
+
+-- Vendors → vendor_innovation
+UPDATE kb_source SET channel_slug = 'vendor_innovation' 
+WHERE category = 'vendor';
+
+-- Research (BIS working papers, think tanks) → academic_research
+UPDATE kb_source SET channel_slug = 'academic_research' 
+WHERE category = 'research';
+
+-- Academic → academic_research
+UPDATE kb_source SET channel_slug = 'academic_research' 
+WHERE category = 'academic';
+
+-- Consulting → vendor_innovation (they publish insights similar to vendors)
+UPDATE kb_source SET channel_slug = 'vendor_innovation' 
+WHERE category = 'consulting';
+
+-- Media → varies, default to vendor_innovation for now
+UPDATE kb_source SET channel_slug = 'vendor_innovation' 
+WHERE category = 'media_outlet';
+
+-- Standards bodies → regulatory_intelligence (standards inform regulation)
+UPDATE kb_source SET channel_slug = 'regulatory_intelligence' 
+WHERE category = 'standards_body';
+
+-- ============================================================
+-- 5. SPECIFIC SOURCE CHANNEL OVERRIDES
+-- ============================================================
+-- Some sources need specific channel assignments based on their content focus
+
+-- arXiv and SSRN are clearly academic
+UPDATE kb_source SET channel_slug = 'academic_research' 
+WHERE slug IN ('arxiv', 'arxiv-q-fin', 'ssrn');
+
+-- BIS has both research and statistics - put in academic for papers
+UPDATE kb_source SET channel_slug = 'academic_research' 
+WHERE slug = 'bis' AND category = 'research';
+
+-- ECB, Fed, DNB statistics → prudential_statistics
+-- (We may need to split these sources later, but for now keep in regulatory)
+
+-- ============================================================
+-- 6. ADD RLS POLICY FOR kb_channel
+-- ============================================================
+
+ALTER TABLE kb_channel ENABLE ROW LEVEL SECURITY;
+
+-- Everyone can read channels
+CREATE POLICY "Channels are publicly readable" ON kb_channel
+  FOR SELECT USING (true);
+
+-- Only authenticated users can modify (admin)
+CREATE POLICY "Authenticated users can modify channels" ON kb_channel
+  FOR ALL USING (auth.role() = 'authenticated');
+
+-- ============================================================
+-- 7. UPDATE kb_publication_pretty VIEW (if channel should be visible)
+-- ============================================================
+-- This is optional - add channel to the view if needed for filtering
+-- We'll do this in a separate migration if required
+

--- a/supabase/migrations/20251204220100_seed_kb169_sources.sql
+++ b/supabase/migrations/20251204220100_seed_kb169_sources.sql
@@ -1,0 +1,253 @@
+-- KB-171: Seed additional sources from KB-169 comprehensive list
+-- 
+-- Categories covered:
+-- 1. EU Regulators
+-- 2. NL Regulators  
+-- 3. International Regulators
+-- 4. Statistical sources
+-- 5. BFSI Tech Vendors
+-- 6. AI/Agentic Vendors
+-- 7. Academic sources
+-- 8. Standards bodies
+
+-- ============================================================
+-- EU REGULATORS
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('eba', 'European Banking Authority', 'eba.europa.eu', 'regulator', 'regulatory_intelligence', 'premium', true,
+   'Technical Standards, Guidelines, Q&A for EU banking regulation', 100),
+  ('esma', 'European Securities and Markets Authority', 'esma.europa.eu', 'regulator', 'regulatory_intelligence', 'premium', true,
+   'MiFID II updates, guidance, reporting requirements', 100),
+  ('eiopa', 'European Insurance and Occupational Pensions Authority', 'eiopa.europa.eu', 'regulator', 'regulatory_intelligence', 'premium', true,
+   'Solvency II, stress test reports, insurance supervision', 100),
+  ('ec-fisma', 'European Commission FISMA', 'finance.ec.europa.eu', 'regulator', 'regulatory_intelligence', 'premium', true,
+   'EU financial legislation, impact assessments, DORA, AI Act', 100),
+  ('srb', 'Single Resolution Board', 'srb.europa.eu', 'regulator', 'regulatory_intelligence', 'standard', true,
+   'Resolution plans, MREL requirements', 150)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- NL REGULATORS
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('afm', 'Autoriteit Financiële Markten', 'afm.nl', 'regulator', 'regulatory_intelligence', 'premium', true,
+   'Dutch financial conduct authority - leidraden, toezichtsignalen, onderzoeken', 100),
+  ('ap', 'Autoriteit Persoonsgegevens', 'autoriteitpersoonsgegevens.nl', 'regulator', 'regulatory_intelligence', 'standard', true,
+   'Dutch data protection authority - richtsnoeren, handhaving, GDPR', 150),
+  ('acm', 'Autoriteit Consument & Markt', 'acm.nl', 'regulator', 'regulatory_intelligence', 'standard', true,
+   'Competition and consumer authority - payment market rules', 150),
+  ('kifid', 'Kifid', 'kifid.nl', 'regulator', 'regulatory_intelligence', 'standard', true,
+   'Financial services complaints institute - uitspraken, trends', 200)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- INTERNATIONAL REGULATORS
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('fca', 'Financial Conduct Authority', 'fca.org.uk', 'regulator', 'regulatory_intelligence', 'premium', true,
+   'UK financial regulator - policy statements, Dear CEO letters, innovation guidance', 100),
+  ('pra', 'Prudential Regulation Authority', 'bankofengland.co.uk', 'regulator', 'regulatory_intelligence', 'premium', true,
+   'UK prudential regulator - supervisory statements, capital requirements', 100),
+  ('fincen', 'FinCEN', 'fincen.gov', 'regulator', 'regulatory_intelligence', 'standard', true,
+   'US Financial Crimes Enforcement - AML advisories, red flags', 150),
+  ('occ', 'Office of the Comptroller of the Currency', 'occ.gov', 'regulator', 'regulatory_intelligence', 'standard', true,
+   'US national bank regulator - bulletins, enforcement', 150),
+  ('fdic', 'Federal Deposit Insurance Corporation', 'fdic.gov', 'regulator', 'regulatory_intelligence', 'standard', true,
+   'US deposit insurance - financial institution letters, guidance', 150),
+  ('mas', 'Monetary Authority of Singapore', 'mas.gov.sg', 'regulator', 'regulatory_intelligence', 'premium', true,
+   'Singapore central bank & regulator - leading fintech/AI regulation globally', 100)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- STATISTICAL SOURCES
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('ecb-sdw', 'ECB Statistical Data Warehouse', 'sdw.ecb.europa.eu', 'central_bank', 'prudential_statistics', 'premium', true,
+   'Euro area financial and economic statistics', 100),
+  ('dnb-stats', 'DNB Statistiek', 'statistiek.dnb.nl', 'central_bank', 'prudential_statistics', 'premium', true,
+   'Dutch central bank statistics - monetary, payments, financial', 100),
+  ('eurostat', 'Eurostat', 'ec.europa.eu/eurostat', 'government_body', 'prudential_statistics', 'standard', true,
+   'EU statistical office - economic indicators', 150),
+  ('oecd-data', 'OECD Data', 'data.oecd.org', 'research', 'prudential_statistics', 'standard', true,
+   'Economic data and indicators from OECD countries', 150),
+  ('imf-data', 'IMF Data Portal', 'data.imf.org', 'research', 'prudential_statistics', 'standard', true,
+   'International financial and economic data', 150),
+  ('worldbank-data', 'World Bank Open Data', 'data.worldbank.org', 'research', 'open_datasets', 'standard', true,
+   'Development and economic indicators globally', 150),
+  ('epc', 'European Payments Council', 'europeanpaymentscouncil.eu', 'standards_body', 'prudential_statistics', 'standard', true,
+   'SEPA payment statistics and standards', 150)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- FRAUD/AML/CYBER SOURCES
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('fatf', 'Financial Action Task Force', 'fatf-gafi.org', 'standards_body', 'regulatory_intelligence', 'premium', true,
+   'Global AML/CFT standards, mutual evaluations, guidance', 100),
+  ('enisa', 'ENISA', 'enisa.europa.eu', 'regulator', 'regulatory_intelligence', 'standard', true,
+   'EU cybersecurity agency - threat reports, guidance', 150),
+  ('europol-iocta', 'Europol IOCTA', 'europol.europa.eu', 'government_body', 'regulatory_intelligence', 'standard', true,
+   'Internet Organised Crime Threat Assessment', 150)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- BFSI TECH VENDORS
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('ohpen', 'Ohpen', 'ohpen.com', 'vendor', 'vendor_innovation', 'standard', true,
+   'Cloud banking platform - case studies, whitepapers', 200),
+  ('mambu', 'Mambu', 'mambu.com', 'vendor', 'vendor_innovation', 'standard', true,
+   'SaaS banking engine - product docs, case briefs', 200),
+  ('thought-machine', 'Thought Machine', 'thoughtmachine.net', 'vendor', 'vendor_innovation', 'standard', true,
+   'Core banking - architecture papers', 200),
+  ('temenos', 'Temenos', 'temenos.com', 'vendor', 'vendor_innovation', 'standard', true,
+   'Banking software - regulatory notes, compliance updates', 200),
+  ('finastra', 'Finastra', 'finastra.com', 'vendor', 'vendor_innovation', 'standard', true,
+   'Financial software - open banking, payments', 200),
+  ('feedzai', 'Feedzai', 'feedzai.com', 'vendor', 'vendor_innovation', 'standard', true,
+   'AI fraud prevention - risk intelligence', 200),
+  ('taktile', 'Taktile', 'taktile.com', 'vendor', 'vendor_innovation', 'standard', true,
+   'Credit decisioning automation', 200)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- AI/AGENTIC VENDORS
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('openai-blog', 'OpenAI Blog', 'openai.com', 'vendor', 'vendor_innovation', 'premium', true,
+   'OpenAI developer blog, research, product updates', 100),
+  ('anthropic', 'Anthropic Research', 'anthropic.com', 'vendor', 'vendor_innovation', 'premium', true,
+   'Claude, constitutional AI, safety research', 100),
+  ('deepmind', 'Google DeepMind', 'deepmind.google', 'vendor', 'vendor_innovation', 'premium', true,
+   'AI research papers, Gemini updates', 100),
+  ('meta-ai', 'Meta AI Research', 'ai.meta.com', 'vendor', 'vendor_innovation', 'standard', true,
+   'LLaMA, open models, research', 150),
+  ('microsoft-research', 'Microsoft Research', 'microsoft.com/research', 'vendor', 'vendor_innovation', 'standard', true,
+   'AI research, Azure AI updates', 150),
+  ('nvidia-tech', 'Nvidia Technical Blog', 'developer.nvidia.com', 'vendor', 'vendor_innovation', 'standard', true,
+   'GPU computing, AI infrastructure', 150),
+  ('huggingface', 'Hugging Face', 'huggingface.co', 'vendor', 'academic_research', 'standard', true,
+   'Model cards, papers, open source ML', 150),
+  ('langchain-blog', 'LangChain Blog', 'blog.langchain.dev', 'vendor', 'vendor_innovation', 'standard', true,
+   'LangChain, LangGraph, agentic patterns', 150)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- ACADEMIC SOURCES
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('nber', 'NBER', 'nber.org', 'academic', 'academic_research', 'standard', true,
+   'National Bureau of Economic Research - working papers', 150),
+  ('repec', 'RePEc', 'repec.org', 'academic', 'academic_research', 'standard', true,
+   'Research Papers in Economics - open repository', 200),
+  ('cpb', 'CPB Netherlands', 'cpb.nl', 'research', 'academic_research', 'standard', true,
+   'Centraal Planbureau - Dutch economic policy analysis', 150),
+  ('wrr', 'WRR', 'wrr.nl', 'research', 'academic_research', 'standard', true,
+   'Wetenschappelijke Raad voor het Regeringsbeleid - policy research', 200),
+  ('cepr', 'CEPR', 'cepr.org', 'academic', 'academic_research', 'standard', true,
+   'Centre for Economic Policy Research - policy insights', 150)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- STANDARDS BODIES
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('nist', 'NIST', 'nist.gov', 'standards_body', 'regulatory_intelligence', 'standard', true,
+   'US standards - SP 800 series, AI RMF, cybersecurity', 150),
+  ('bcbs', 'Basel Committee (BCBS)', 'bis.org/bcbs', 'standards_body', 'regulatory_intelligence', 'premium', true,
+   'Basel capital standards, consultative papers', 100)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- OPEN DATASETS
+-- ============================================================
+
+INSERT INTO kb_source (slug, name, domain, category, channel_slug, tier, enabled, description, sort_order) VALUES
+  ('uk-openbanking', 'UK Open Banking', 'openbanking.org.uk', 'standards_body', 'open_datasets', 'standard', true,
+   'UK Open Banking API specs, adoption metrics', 150),
+  ('cbs', 'CBS Netherlands', 'cbs.nl', 'government_body', 'open_datasets', 'standard', true,
+   'Dutch statistics bureau - economic data', 150),
+  ('knmi', 'KNMI', 'knmi.nl', 'government_body', 'open_datasets', 'standard', true,
+   'Dutch climate data - relevant for insurance risk', 200),
+  ('bis-innovation', 'BIS Innovation Hub', 'bisih.org', 'research', 'open_datasets', 'standard', true,
+   'Central bank innovation projects, datasets', 150)
+ON CONFLICT (slug) DO UPDATE SET
+  channel_slug = EXCLUDED.channel_slug,
+  description = EXCLUDED.description;
+
+-- ============================================================
+-- UPDATE EXISTING SOURCES WITH CHANNELS
+-- ============================================================
+-- Ensure all existing sources have a channel assigned
+
+-- ECB main → regulatory_intelligence (supervisory)
+UPDATE kb_source SET channel_slug = 'regulatory_intelligence', category = 'central_bank'
+WHERE slug = 'ecb' AND channel_slug IS NULL;
+
+-- Fed → regulatory_intelligence
+UPDATE kb_source SET channel_slug = 'regulatory_intelligence', category = 'central_bank'
+WHERE slug = 'fed' AND channel_slug IS NULL;
+
+-- DNB → regulatory_intelligence
+UPDATE kb_source SET channel_slug = 'regulatory_intelligence', category = 'central_bank'
+WHERE slug = 'dnb' AND channel_slug IS NULL;
+
+-- FSB → regulatory_intelligence
+UPDATE kb_source SET channel_slug = 'regulatory_intelligence'
+WHERE slug = 'fsb' AND channel_slug IS NULL;
+
+-- BIS → academic_research (working papers focus)
+UPDATE kb_source SET channel_slug = 'academic_research'
+WHERE slug = 'bis' AND channel_slug IS NULL;
+
+-- IMF → regulatory_intelligence (policy focus)
+UPDATE kb_source SET channel_slug = 'regulatory_intelligence'
+WHERE slug = 'imf' AND channel_slug IS NULL;
+
+-- arXiv sources → academic_research
+UPDATE kb_source SET channel_slug = 'academic_research'
+WHERE slug LIKE 'arxiv%' AND channel_slug IS NULL;
+
+-- SSRN → academic_research
+UPDATE kb_source SET channel_slug = 'academic_research'
+WHERE slug = 'ssrn' AND channel_slug IS NULL;
+
+-- McKinsey, BCG, Deloitte etc → vendor_innovation
+UPDATE kb_source SET channel_slug = 'vendor_innovation'
+WHERE category = 'consulting' AND channel_slug IS NULL;
+
+-- OpenAI existing → vendor_innovation
+UPDATE kb_source SET channel_slug = 'vendor_innovation'
+WHERE slug = 'openai' AND channel_slug IS NULL;
+
+-- Catch-all: any remaining sources without channel
+UPDATE kb_source SET channel_slug = 'vendor_innovation'
+WHERE channel_slug IS NULL;
+


### PR DESCRIPTION
- Create kb_channel table with 6 strategic information streams
- Add channel_slug FK to kb_source
- Refine categories: merge big4+strategy-consulting→consulting, rename publication→media_outlet
- Add new categories: central_bank, standards_body, academic, government_body
- Seed 45+ sources from KB-169 (EU/NL/intl regulators, vendors, academic, etc.)
- Update SourceFormModal with channel dropdown
- Add channel filter and grouping to sources.astro
- Document metadata concepts in schema.md

Closes KB-171