### PR TITLE
fix(security): fix view and RLS policy issues

### DIFF
--- a/supabase/migrations/20251205002200_fix_security_definer_views.sql
+++ b/supabase/migrations/20251205002200_fix_security_definer_views.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- Fix SECURITY DEFINER views
+-- ============================================================================
+-- Recreate views with explicit SECURITY INVOKER to ensure RLS policies
+-- of the querying user are enforced, not the view creator.
+-- ============================================================================
+
+-- Drop and recreate v_queue_health with SECURITY INVOKER
+DROP VIEW IF EXISTS v_queue_health;
+CREATE VIEW v_queue_health 
+WITH (security_invoker = true) AS
+SELECT 
+  status,
+  CASE 
+    WHEN discovered_at > NOW() - INTERVAL '1 day' THEN '0_last_24h'
+    WHEN discovered_at > NOW() - INTERVAL '7 days' THEN '1_last_week'
+    WHEN discovered_at > NOW() - INTERVAL '30 days' THEN '2_last_month'
+    ELSE '3_older'
+  END as age_bucket,
+  COUNT(*) as count,
+  MIN(discovered_at) as oldest,
+  MAX(discovered_at) as newest
+FROM ingestion_queue
+GROUP BY status, age_bucket
+ORDER BY status, age_bucket;
+
+COMMENT ON VIEW v_queue_health IS 'Queue health summary: items by status and age bucket';
+
+-- Drop and recreate v_queue_pending_by_source with SECURITY INVOKER
+DROP VIEW IF EXISTS v_queue_pending_by_source;
+CREATE VIEW v_queue_pending_by_source
+WITH (security_invoker = true) AS
+SELECT 
+  payload->>'source' as source,
+  COUNT(*) as pending_count,
+  MIN(discovered_at) as oldest_pending,
+  AVG(EXTRACT(EPOCH FROM (NOW() - discovered_at))/86400)::numeric(10,1) as avg_age_days
+FROM ingestion_queue
+WHERE status = 'pending'
+GROUP BY payload->>'source'
+ORDER BY pending_count DESC;
+
+COMMENT ON VIEW v_queue_pending_by_source IS 'Pending items grouped by source to identify backlog';
+
+-- Drop and recreate v_queue_daily_stats with SECURITY INVOKER
+DROP VIEW IF EXISTS v_queue_daily_stats;
+CREATE VIEW v_queue_daily_stats
+WITH (security_invoker = true) AS
+SELECT 
+  DATE(reviewed_at) as review_date,
+  status,
+  COUNT(*) as count
+FROM ingestion_queue
+WHERE reviewed_at > NOW() - INTERVAL '7 days'
+GROUP BY DATE(reviewed_at), status
+ORDER BY review_date DESC, status;
+
+COMMENT ON VIEW v_queue_daily_stats IS 'Daily processing statistics for last 7 days';

--- a/supabase/migrations/20251205002300_fix_rls_performance.sql
+++ b/supabase/migrations/20251205002300_fix_rls_performance.sql
@@ -1,0 +1,31 @@
+-- ============================================================================
+-- Fix RLS performance issues
+-- ============================================================================
+-- 1. Wrap auth.<function>() calls in (select ...) for initplan optimization
+-- 2. Consolidate overlapping permissive policies on kb_channel
+-- ============================================================================
+
+-- Fix kb_publication policy: wrap auth.role() in select
+DROP POLICY IF EXISTS "kb_publication_update_authenticated" ON kb_publication;
+CREATE POLICY "kb_publication_update_authenticated" 
+  ON kb_publication 
+  FOR UPDATE 
+  USING ((select auth.role()) = 'authenticated')
+  WITH CHECK ((select auth.role()) = 'authenticated');
+
+-- Fix kb_channel policies: remove overlapping SELECT permissions
+-- The "Channels are publicly readable" policy already handles SELECT for everyone
+-- So we only need authenticated policy for INSERT, UPDATE, DELETE (not ALL)
+
+DROP POLICY IF EXISTS "Authenticated users can modify channels" ON kb_channel;
+
+-- Separate policies for each action to avoid overlap with public SELECT
+CREATE POLICY "Authenticated users can insert channels" ON kb_channel
+  FOR INSERT WITH CHECK ((select auth.role()) = 'authenticated');
+
+CREATE POLICY "Authenticated users can update channels" ON kb_channel
+  FOR UPDATE USING ((select auth.role()) = 'authenticated')
+  WITH CHECK ((select auth.role()) = 'authenticated');
+
+CREATE POLICY "Authenticated users can delete channels" ON kb_channel
+  FOR DELETE USING ((select auth.role()) = 'authenticated');


### PR DESCRIPTION
Fixes Supabase linter warnings:

**SECURITY DEFINER views** (ERROR):
- Recreate views with `security_invoker=true`

**Auth RLS initplan** (WARN):
- Wrap `auth.role()` in `(select ...)` for performance

**Multiple permissive policies** (WARN):
- Split kb_channel ALL policy into INSERT/UPDATE/DELETE to avoid overlapping SELECT