### PR TITLE
feat(kb-172): expand geography taxonomy and add filter

### DIFF
--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -38,6 +38,14 @@ const { data: processTaxonomy } = await supabase
   .select('code, name, level, parent_code, sort_order')
   .order('sort_order');
 
+// Load geography lookup
+const { data: geographyData } = await supabase
+  .from('kb_geography')
+  .select('code, name, sort_order')
+  .order('sort_order');
+
+// geographyLookup used when displaying geography names in filter chips
+
 // Build hierarchical structure for industry
 type TaxonomyItem = {
   code: string;
@@ -92,6 +100,25 @@ publications.forEach((p) => {
   });
 });
 
+// Count geography usage
+const countByGeography = new Map<string, number>();
+publications.forEach((p) => {
+  if (p.geography) {
+    countByGeography.set(p.geography, (countByGeography.get(p.geography) || 0) + 1);
+  }
+});
+
+// Build geography filter options with counts, sorted by sort_order
+const geographyFilterOptions = (geographyData || [])
+  .filter((g) => countByGeography.has(g.code))
+  .map((g) => ({
+    code: g.code,
+    name: g.name,
+    count: countByGeography.get(g.code) || 0,
+    sort_order: g.sort_order,
+  }))
+  .sort((a, b) => a.sort_order - b.sort_order);
+
 // Add counts to hierarchy
 const addCounts = (items: TaxonomyItem[], countMap: Map<string, number>): TaxonomyItem[] => {
   return items.map((item) => ({
@@ -105,8 +132,10 @@ const industryWithCounts = addCounts(industryHierarchy, countByIndustry);
 const processWithCounts = addCounts(processHierarchy, countByProcess);
 
 const filters = filterConfig || [];
-// Exclude industry from flat filters (we'll render it hierarchically)
-const flatFilters = filters.filter((filter) => !['industry'].includes(filter.column_name));
+// Exclude industry and geography from flat filters (we render them separately)
+const flatFilters = filters.filter(
+  (filter) => !['industry', 'geography'].includes(filter.column_name),
+);
 
 // Build filter value lists + counts (handles both single values and arrays)
 const createValuesWithCounts = (field: keyof Publication) => {
@@ -534,6 +563,54 @@ const expandItemThumb = (t: string | undefined) => {
                   ))
                 ) : (
                   <p class="text-xs text-neutral-500 italic">No process tags yet</p>
+                )
+              }
+            </div>
+          </details>
+
+          <!-- Geography Filter -->
+          <details
+            class="filter-group border border-neutral-800 rounded-lg overflow-hidden"
+            data-filter-key="geography"
+          >
+            <summary
+              class="flex items-center justify-between px-4 py-3 cursor-pointer bg-neutral-900/50 hover:bg-neutral-800/50 transition-colors"
+            >
+              <span class="text-sm font-medium text-neutral-200">Geography</span>
+              <svg
+                class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M19 9l-7 7-7-7"></path>
+              </svg>
+            </summary>
+            <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800">
+              {
+                geographyFilterOptions.length > 0 ? (
+                  <div class="flex flex-wrap gap-2">
+                    {geographyFilterOptions.map((g) => (
+                      <label class="filter-checkbox cursor-pointer">
+                        <input
+                          type="checkbox"
+                          name="filter-geography"
+                          value={g.code}
+                          class="sr-only peer"
+                        />
+                        <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm border border-neutral-700 bg-neutral-900 text-neutral-300 transition-all peer-checked:border-sky-500 peer-checked:bg-sky-500/10 peer-checked:text-sky-300 hover:border-neutral-600 hover:bg-neutral-800">
+                          {g.name}
+                          <span class="text-xs text-neutral-500">{g.count}</span>
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                ) : (
+                  <p class="text-xs text-neutral-500 italic">No geography tags yet</p>
                 )
               }
             </div>

--- a/supabase/migrations/20251205004200_improve_geography_taxonomy.sql
+++ b/supabase/migrations/20251205004200_improve_geography_taxonomy.sql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- KB-172: Improve kb_geography taxonomy
+-- ============================================================================
+-- Comprehensive geography taxonomy with 4 conceptual levels:
+--   1. Global (worldwide scope)
+--   2. Macro-regions (EMEA, APAC, Americas, Africa)
+--   3. Regional blocs (EU, GCC, MENA)
+--   4. Countries (ISO-3166 2-letter codes)
+--   5. Fallback (other)
+-- 
+-- Publications can be tagged with multiple geographies, e.g.:
+--   - Qatar neobank case → gcc, mena, qa
+--   - EU AI Act → eu, emea
+--   - Global vendor landscape → global
+-- ============================================================================
+
+-- Create table if not exists (in case it was created directly in Supabase)
+CREATE TABLE IF NOT EXISTS kb_geography (
+  code TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  sort_order INTEGER DEFAULT 100,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Enable RLS if not already
+ALTER TABLE kb_geography ENABLE ROW LEVEL SECURITY;
+
+-- Ensure public read policy exists
+DROP POLICY IF EXISTS "Public read geography" ON kb_geography;
+DROP POLICY IF EXISTS "Geography is publicly readable" ON kb_geography;
+CREATE POLICY "Geography is publicly readable" ON kb_geography FOR SELECT USING (true);
+
+-- ============================================================================
+-- Seed/update geography values using UPSERT
+-- ============================================================================
+-- Preserves existing rows (id, created_at) while updating sort_order/description
+
+-- Global scope
+INSERT INTO kb_geography (code, name, sort_order, description) VALUES
+  ('global', 'Global', 10, 'Worldwide or multi-region relevance')
+ON CONFLICT (code) DO UPDATE SET 
+  name = EXCLUDED.name, sort_order = EXCLUDED.sort_order, description = EXCLUDED.description, updated_at = NOW();
+
+-- Macro-regions (business view)
+INSERT INTO kb_geography (code, name, sort_order, description) VALUES
+  ('emea', 'Europe, Middle East & Africa', 20, 'Macro-region combining Europe, Middle East and Africa'),
+  ('apac', 'Asia-Pacific', 30, 'Asia-Pacific region (East Asia, South Asia, Southeast Asia, Oceania)'),
+  ('amer', 'Americas', 40, 'North and South America combined'),
+  ('africa', 'Africa', 50, 'African continent (can overlap with EMEA)')
+ON CONFLICT (code) DO UPDATE SET 
+  name = EXCLUDED.name, sort_order = EXCLUDED.sort_order, description = EXCLUDED.description, updated_at = NOW();
+
+-- Regional blocs / overlays
+INSERT INTO kb_geography (code, name, sort_order, description) VALUES
+  ('eu', 'European Union', 100, 'EU-wide focus (regulation, policy, or markets under EU law)'),
+  ('mena', 'Middle East & North Africa', 110, 'MENA region (when focus is specifically MENA, not full EMEA)'),
+  ('gcc', 'Gulf Cooperation Council', 120, 'GCC bloc: Bahrain, Kuwait, Oman, Qatar, Saudi Arabia, UAE')
+ON CONFLICT (code) DO UPDATE SET 
+  name = EXCLUDED.name, sort_order = EXCLUDED.sort_order, description = EXCLUDED.description, updated_at = NOW();
+
+-- Key countries - Europe
+INSERT INTO kb_geography (code, name, sort_order, description) VALUES
+  ('uk', 'United Kingdom', 200, 'UK-specific focus'),
+  ('nl', 'Netherlands', 210, 'Netherlands-specific focus'),
+  ('de', 'Germany', 220, 'Germany-specific focus'),
+  ('fr', 'France', 230, 'France-specific focus'),
+  ('ch', 'Switzerland', 240, 'Switzerland-specific focus'),
+  ('ie', 'Ireland', 250, 'Ireland-specific focus')
+ON CONFLICT (code) DO UPDATE SET 
+  name = EXCLUDED.name, sort_order = EXCLUDED.sort_order, description = EXCLUDED.description, updated_at = NOW();
+
+-- Key countries - Americas
+INSERT INTO kb_geography (code, name, sort_order, description) VALUES
+  ('us', 'United States', 300, 'US-specific focus'),
+  ('ca', 'Canada', 310, 'Canada-specific focus'),
+  ('br', 'Brazil', 320, 'Brazil-specific focus')
+ON CONFLICT (code) DO UPDATE SET 
+  name = EXCLUDED.name, sort_order = EXCLUDED.sort_order, description = EXCLUDED.description, updated_at = NOW();
+
+-- Key countries - GCC / MENA
+INSERT INTO kb_geography (code, name, sort_order, description) VALUES
+  ('qa', 'Qatar', 400, 'Qatar-specific focus'),
+  ('sa', 'Saudi Arabia', 410, 'Saudi Arabia-specific focus'),
+  ('ae', 'United Arab Emirates', 420, 'UAE-specific focus'),
+  ('kw', 'Kuwait', 430, 'Kuwait-specific focus'),
+  ('om', 'Oman', 440, 'Oman-specific focus'),
+  ('bh', 'Bahrain', 450, 'Bahrain-specific focus')
+ON CONFLICT (code) DO UPDATE SET 
+  name = EXCLUDED.name, sort_order = EXCLUDED.sort_order, description = EXCLUDED.description, updated_at = NOW();
+
+-- Key countries - Asia-Pacific
+INSERT INTO kb_geography (code, name, sort_order, description) VALUES
+  ('in', 'India', 500, 'India-specific focus'),
+  ('sg', 'Singapore', 510, 'Singapore-specific focus'),
+  ('hk', 'Hong Kong', 520, 'Hong Kong-specific focus'),
+  ('cn', 'China', 530, 'China-specific focus'),
+  ('jp', 'Japan', 540, 'Japan-specific focus'),
+  ('au', 'Australia', 550, 'Australia-specific focus')
+ON CONFLICT (code) DO UPDATE SET 
+  name = EXCLUDED.name, sort_order = EXCLUDED.sort_order, description = EXCLUDED.description, updated_at = NOW();
+
+-- Fallback
+INSERT INTO kb_geography (code, name, sort_order, description) VALUES
+  ('other', 'Other / Unspecified', 900, 'Any other geography or unclear focus')
+ON CONFLICT (code) DO UPDATE SET 
+  name = EXCLUDED.name, sort_order = EXCLUDED.sort_order, description = EXCLUDED.description, updated_at = NOW();
+
+-- Add comment
+COMMENT ON TABLE kb_geography IS 'Geography taxonomy: Global → Macro-regions → Regional blocs → Countries. Publications can have multiple geography tags.';
+
+-- Grant permissions
+GRANT SELECT ON kb_geography TO anon, authenticated;


### PR DESCRIPTION
## Database
- Add comprehensive 4-level hierarchy (Global → Macro-regions → Blocs → Countries)
- 27 geography codes including Qatar, India, GCC members, key BFSI markets

## Structure
| Level | Codes |
|-------|-------|
| Global | global |
| Macro | emea, apac, amer, africa |
| Blocs | eu, mena, gcc |
| Europe | uk, nl, de, fr, ch, ie |
| Americas | us, ca, br |
| GCC/MENA | qa, sa, ae, kw, om, bh |
| APAC | in, sg, hk, cn, jp, au |
| Fallback | other |

## UI
- Add Geography filter section to publications page
- Shows only geographies with tagged publications
- Displays human-readable names from kb_geography lookup

Closes KB-172