### PR TITLE
fix(kb-172): use kb_geography table in tagger

### DIFF
--- a/services/agent-api/src/agents/tag.js
+++ b/services/agent-api/src/agents/tag.js
@@ -100,7 +100,7 @@ async function loadTaxonomies() {
       .select('code, name, level, parent_code')
       .order('level')
       .order('name'),
-    supabase.from('bfsi_geography').select('code, name').order('name'),
+    supabase.from('kb_geography').select('code, name').order('sort_order'),
     supabase.from('ag_use_case').select('code, name').order('name'),
     supabase.from('ag_capability').select('code, name').order('name'),
     supabase.from('regulator').select('code, name').order('name'),


### PR DESCRIPTION
The tagger was referencing `bfsi_geography` which doesn't exist.

Fixed to use `kb_geography` table (where the geography taxonomy lives).

Now the enrichment agent will see all 27 geography codes including:
- Macro-regions: emea, apac, amer, africa
- Blocs: eu, mena, gcc  
- Countries: qa, sa, ae, in, etc.