### PR TITLE
fix: add created_at to bfsi_organization

### DIFF
--- a/supabase/migrations/20251205014600_add_created_at_to_bfsi_organization.sql
+++ b/supabase/migrations/20251205014600_add_created_at_to_bfsi_organization.sql
@@ -1,0 +1,12 @@
+-- Add created_at column to bfsi_organization for tracking when entities were added
+ALTER TABLE bfsi_organization 
+ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();
+
+-- Backfill existing rows with current timestamp (better than null)
+UPDATE bfsi_organization 
+SET created_at = NOW() 
+WHERE created_at IS NULL;
+
+-- Make it not null for future inserts
+ALTER TABLE bfsi_organization 
+ALTER COLUMN created_at SET NOT NULL;


### PR DESCRIPTION
Adds timestamp tracking for when organizations are added.

- Adds `created_at` column with default NOW()
- Backfills existing rows with current timestamp
- Makes column NOT NULL for future inserts