### PR TITLE
feat(KB-175): Add delete functionality for published articles

### DIFF
--- a/admin-next/src/app/(dashboard)/published/page.tsx
+++ b/admin-next/src/app/(dashboard)/published/page.tsx
@@ -1,0 +1,98 @@
+import { createServiceRoleClient } from '@/lib/supabase/server';
+import { formatDateTime } from '@/lib/utils';
+import { PublicationActions } from './publication-actions';
+
+interface Publication {
+  id: string;
+  slug: string;
+  title: string;
+  source_url: string;
+  source_slug: string;
+  published_at: string;
+  created_at: string;
+}
+
+async function getPublications(search?: string) {
+  const supabase = createServiceRoleClient();
+
+  let query = supabase
+    .from('kb_publication')
+    .select('id, slug, title, source_url, source_slug, published_at, created_at')
+    .order('created_at', { ascending: false })
+    .limit(100);
+
+  if (search) {
+    query = query.ilike('title', `%${search}%`);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error('Error fetching publications:', error);
+    return [];
+  }
+
+  return data as Publication[];
+}
+
+export default async function PublishedPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ search?: string }>;
+}) {
+  const params = await searchParams;
+  const publications = await getPublications(params.search);
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold">Published Articles</h1>
+        <p className="mt-1 text-sm text-neutral-400">{publications.length} published articles</p>
+      </header>
+
+      {/* Search */}
+      <form className="max-w-md">
+        <input
+          type="text"
+          name="search"
+          placeholder="Search publications..."
+          defaultValue={params.search}
+          className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-4 py-2 text-white placeholder-neutral-500 focus:border-sky-500 focus:outline-none"
+        />
+      </form>
+
+      {/* Publications List */}
+      <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 divide-y divide-neutral-800">
+        {publications.length === 0 ? (
+          <div className="p-12 text-center">
+            <p className="text-neutral-400">No publications found</p>
+          </div>
+        ) : (
+          publications.map((pub) => (
+            <div key={pub.id} className="p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium text-white">{pub.title}</p>
+                  <a
+                    href={pub.source_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-sky-400 hover:text-sky-300 truncate block mt-1"
+                  >
+                    {pub.source_url}
+                  </a>
+                  <div className="flex items-center gap-4 mt-2 text-xs text-neutral-500">
+                    <span>Source: {pub.source_slug}</span>
+                    <span>Published: {formatDateTime(pub.published_at)}</span>
+                    <span>Added: {formatDateTime(pub.created_at)}</span>
+                  </div>
+                </div>
+                <PublicationActions publicationId={pub.id} title={pub.title} />
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin-next/src/app/(dashboard)/published/publication-actions.tsx
+++ b/admin-next/src/app/(dashboard)/published/publication-actions.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface PublicationActionsProps {
+  publicationId: string;
+  title: string;
+}
+
+export function PublicationActions({ publicationId, title }: PublicationActionsProps) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleDelete = async () => {
+    if (!confirm(`Are you sure you want to delete "${title}"?\n\nThis action cannot be undone.`)) {
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const res = await fetch(`/api/publications/${publicationId}`, {
+        method: 'DELETE',
+      });
+
+      if (res.ok) {
+        router.refresh();
+      } else {
+        const data = await res.json();
+        alert(`Failed to delete: ${data.error}`);
+      }
+    } catch (err) {
+      alert(`Error: ${err instanceof Error ? err.message : 'Unknown'}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <a
+        href={`/review?search=${encodeURIComponent(title)}`}
+        className="px-3 py-1.5 rounded-lg border border-neutral-700 text-neutral-300 text-sm hover:bg-neutral-800"
+      >
+        View Source
+      </a>
+      <button
+        onClick={handleDelete}
+        disabled={loading}
+        className="px-3 py-1.5 rounded-lg border border-red-500/30 text-red-400 text-sm font-medium hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {loading ? '...' : '🗑️ Delete'}
+      </button>
+    </div>
+  );
+}

--- a/admin-next/src/app/api/publications/[id]/route.ts
+++ b/admin-next/src/app/api/publications/[id]/route.ts
@@ -1,0 +1,18 @@
+import { createServiceRoleClient } from '@/lib/supabase/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = createServiceRoleClient();
+
+  const { error } = await supabase.from('kb_publication').delete().eq('id', id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/admin-next/src/components/ui/sidebar.tsx
+++ b/admin-next/src/components/ui/sidebar.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils';
 const navItems = [
   { href: '/', label: 'Dashboard', icon: '📊' },
   { href: '/review', label: 'Review Queue', icon: '📋' },
+  { href: '/published', label: 'Published', icon: '✅' },
   { href: '/proposals', label: 'Proposals', icon: '📥' },
   { href: '/evaluate', label: 'Evaluate', icon: '🔬' },
   { href: '/compare', label: 'Compare', icon: '⚖️' },

--- a/src/pages/admin/publications.astro
+++ b/src/pages/admin/publications.astro
@@ -129,13 +129,22 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
             Added ${new Date(pub.date_added).toLocaleDateString()}
           </p>
         </div>
-        <button
-          class="edit-btn ml-4 rounded-lg border border-neutral-700 px-3 py-1.5 text-sm font-medium text-neutral-300 hover:bg-neutral-800"
-          data-id="${pub.id}"
-          data-title="${pub.title.replace(/"/g, '&quot;')}"
-        >
-          Edit
-        </button>
+        <div class="flex gap-2 ml-4">
+          <button
+            class="edit-btn rounded-lg border border-neutral-700 px-3 py-1.5 text-sm font-medium text-neutral-300 hover:bg-neutral-800"
+            data-id="${pub.id}"
+            data-title="${pub.title.replace(/"/g, '&quot;')}"
+          >
+            Edit
+          </button>
+          <button
+            class="delete-btn rounded-lg border border-red-500/30 px-3 py-1.5 text-sm font-medium text-red-400 hover:bg-red-500/10"
+            data-id="${pub.id}"
+            data-title="${pub.title.replace(/"/g, '&quot;')}"
+          >
+            🗑️
+          </button>
+        </div>
       </div>
     `,
       )
@@ -148,6 +157,31 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
         openEditModal(target.dataset.id!, target.dataset.title!);
       });
     });
+
+    document.querySelectorAll('.delete-btn').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        const target = e.currentTarget as HTMLElement;
+        deletePublication(target.dataset.id!, target.dataset.title!);
+      });
+    });
+  }
+
+  async function deletePublication(id: string, title: string) {
+    if (!confirm(`Are you sure you want to delete "${title}"?\n\nThis action cannot be undone.`)) {
+      return;
+    }
+
+    if (!(await checkAuth())) return;
+
+    const { error } = await supabase.from('kb_publication').delete().eq('id', id);
+
+    if (error) {
+      alert('Error deleting: ' + error.message);
+      return;
+    }
+
+    // Refresh list
+    await loadPublications();
   }
 
   function openEditModal(id: string, title: string) {


### PR DESCRIPTION
## Summary
Adds ability to delete published articles from both admin UIs.

## Changes
- **Next.js admin**: New `/published` page with search and delete
- **Next.js admin**: `DELETE /api/publications/[id]` endpoint
- **Astro admin**: Delete button added to `/admin/publications`
- Updated sidebar navigation

## Testing
- Navigate to Published in either admin
- Click delete button on any article
- Confirm deletion in dialog

Part of KB-175