### PR TITLE
fix(KB-176): Add openai.com to soft-fail domains in link checker

### DIFF
--- a/scripts/utilities/check-links.mjs
+++ b/scripts/utilities/check-links.mjs
@@ -12,7 +12,7 @@ const RETRIES = 3;
 const SKIP_PATTERNS = [
   // Add patterns to skip domains if needed, e.g. /example\.com/,
 ];
-const SOFT_FAIL_DOMAINS_DEFAULT = [/mckinsey\.com/];
+const SOFT_FAIL_DOMAINS_DEFAULT = [/mckinsey\.com/, /openai\.com/];
 function parseSoftFailDomains() {
   const env = process.env.SOFT_FAIL_DOMAINS;
   if (!env) return SOFT_FAIL_DOMAINS_DEFAULT;


### PR DESCRIPTION
## Problem
Nightly link check has been failing for 3 days due to OpenAI links returning HTTP 403 (bot protection).

## Solution
Added `openai.com` to `SOFT_FAIL_DOMAINS_DEFAULT` so these links warn instead of failing CI.

## Affected URLs
- https://openai.com/index/hebbia
- https://openai.com/index/bbva-2025
- https://openai.com/index/nubank
- https://openai.com/index/new-credit-facility-enhances-financial-flexibility

Fixes KB-176