### PR TITLE
feat(KB-179): Collapsible filter summary for better mobile UX

### DIFF
--- a/src/features/publications/multi-select-filters.ts
+++ b/src/features/publications/multi-select-filters.ts
@@ -233,15 +233,46 @@ export default function initMultiSelectFilters() {
     }
   }
 
-  // Update filter chips below search
+  // Collapse threshold - show summary when more than this many filters
+  const COLLAPSE_THRESHOLD = 3;
+  let filtersExpanded = false;
+
+  // Update filter chips below search - collapsible when many filters
   function updateFilterChips(state: FilterState, query: string) {
     if (!filterChipsEl) return;
 
     filterChipsEl.innerHTML = '';
 
-    // Add search chip
+    // Count filters by category
+    const categoryCounts: Record<string, number> = {};
+    let totalFilters = 0;
+
+    for (const [key, values] of Object.entries(state)) {
+      if (values.size > 0) {
+        categoryCounts[key] = values.size;
+        totalFilters += values.size;
+      }
+    }
+
+    const hasSearch = !!query;
+    const totalItems = totalFilters + (hasSearch ? 1 : 0);
+
+    // If few filters, show them all as chips (original behavior)
+    if (totalItems <= COLLAPSE_THRESHOLD) {
+      renderAllChips(state, query);
+      return;
+    }
+
+    // Many filters: show collapsible summary
+    renderCollapsibleSummary(state, query, categoryCounts, totalFilters, hasSearch);
+  }
+
+  // Render all chips inline (for few filters)
+  function renderAllChips(state: FilterState, query: string) {
+    if (!filterChipsEl) return;
+
     if (query) {
-      const chip = createChip(`Search: ${query}`, () => {
+      const chip = createChip(`search: ${query}`, () => {
         if (qEl) qEl.value = '';
         searchQuery = '';
         applyFilters(filterState, searchQuery, true);
@@ -249,7 +280,6 @@ export default function initMultiSelectFilters() {
       filterChipsEl.appendChild(chip);
     }
 
-    // Add filter chips
     for (const [key, values] of Object.entries(state)) {
       values.forEach((value) => {
         const chip = createChip(`${key}: ${value}`, () => {
@@ -261,6 +291,164 @@ export default function initMultiSelectFilters() {
         filterChipsEl.appendChild(chip);
       });
     }
+  }
+
+  // Render collapsible summary (for many filters)
+  function renderCollapsibleSummary(
+    state: FilterState,
+    query: string,
+    categoryCounts: Record<string, number>,
+    totalFilters: number,
+    hasSearch: boolean,
+  ) {
+    if (!filterChipsEl) return;
+
+    // Build summary text: "26 filters: 1 role, 25 industries"
+    const parts: string[] = [];
+    const categoryLabels: Record<string, string> = {
+      role: 'role',
+      industry: 'industry',
+      topic: 'topic',
+      geography: 'geography',
+      content_type: 'type',
+      regulator: 'regulator',
+      regulation: 'regulation',
+      obligation: 'obligation',
+      process: 'process',
+    };
+
+    for (const [key, count] of Object.entries(categoryCounts)) {
+      const label = categoryLabels[key] || key;
+      const plural =
+        count > 1 ? (label.endsWith('y') ? label.slice(0, -1) + 'ies' : label + 's') : label;
+      parts.push(`${count} ${plural}`);
+    }
+
+    if (hasSearch) {
+      parts.unshift('1 search');
+    }
+
+    const totalItems = totalFilters + (hasSearch ? 1 : 0);
+
+    // Create summary container
+    const container = document.createElement('div');
+    container.className = 'w-full';
+
+    // Summary row
+    const summaryRow = document.createElement('div');
+    summaryRow.className = 'flex items-center justify-between gap-2 flex-wrap';
+
+    // Summary text + expand button
+    const summaryLeft = document.createElement('div');
+    summaryLeft.className = 'flex items-center gap-2 flex-wrap';
+
+    const summaryBadge = document.createElement('span');
+    summaryBadge.className =
+      'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-sky-500/10 text-sky-300 border border-sky-500/20';
+    summaryBadge.innerHTML = `
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/>
+      </svg>
+      ${totalItems} filters
+    `;
+
+    const summaryText = document.createElement('span');
+    summaryText.className = 'text-xs text-neutral-400';
+    summaryText.textContent = parts.join(', ');
+
+    summaryLeft.appendChild(summaryBadge);
+    summaryLeft.appendChild(summaryText);
+
+    // Action buttons
+    const actions = document.createElement('div');
+    actions.className = 'flex items-center gap-2';
+
+    const clearBtn = document.createElement('button');
+    clearBtn.className =
+      'text-xs text-neutral-400 hover:text-neutral-200 underline underline-offset-2 transition-colors';
+    clearBtn.textContent = 'Clear all';
+    clearBtn.addEventListener('click', () => {
+      filterCheckboxes.forEach((cb) => (cb.checked = false));
+      filterState = {};
+      initFilterState();
+      if (qEl) qEl.value = '';
+      searchQuery = '';
+      applyFilters(filterState, searchQuery, true);
+      saveFilters();
+    });
+
+    const expandBtn = document.createElement('button');
+    expandBtn.className =
+      'inline-flex items-center gap-1 text-xs text-sky-300 hover:text-sky-200 transition-colors';
+    expandBtn.innerHTML = filtersExpanded
+      ? `Collapse <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/></svg>`
+      : `Expand <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>`;
+
+    expandBtn.addEventListener('click', () => {
+      filtersExpanded = !filtersExpanded;
+      updateFilterChips(state, query);
+    });
+
+    actions.appendChild(clearBtn);
+    actions.appendChild(expandBtn);
+
+    summaryRow.appendChild(summaryLeft);
+    summaryRow.appendChild(actions);
+    container.appendChild(summaryRow);
+
+    // Expanded chips (if expanded)
+    if (filtersExpanded) {
+      const expandedContainer = document.createElement('div');
+      expandedContainer.className = 'mt-3 pt-3 border-t border-neutral-800';
+
+      // Group chips by category
+      const categories = Object.entries(state).filter(([, values]) => values.size > 0);
+
+      // Add search first if present
+      if (query) {
+        const searchGroup = document.createElement('div');
+        searchGroup.className = 'mb-2';
+
+        const searchChip = createChip(`search: ${query}`, () => {
+          if (qEl) qEl.value = '';
+          searchQuery = '';
+          applyFilters(filterState, searchQuery, true);
+        });
+        searchGroup.appendChild(searchChip);
+        expandedContainer.appendChild(searchGroup);
+      }
+
+      // Add filter chips grouped by category
+      categories.forEach(([key, values]) => {
+        const group = document.createElement('div');
+        group.className = 'mb-2';
+
+        const label = document.createElement('span');
+        label.className = 'text-xs text-neutral-500 mr-2';
+        label.textContent = `${key}:`;
+        group.appendChild(label);
+
+        const chipsWrapper = document.createElement('span');
+        chipsWrapper.className = 'inline-flex flex-wrap gap-1.5';
+
+        values.forEach((value) => {
+          const chip = createChip(value, () => {
+            filterState[key].delete(value);
+            applyFilterStateToCheckboxes(filterState);
+            applyFilters(filterState, searchQuery, true);
+            saveFilters();
+          });
+          chipsWrapper.appendChild(chip);
+        });
+
+        group.appendChild(chipsWrapper);
+        expandedContainer.appendChild(group);
+      });
+
+      container.appendChild(expandedContainer);
+    }
+
+    filterChipsEl.appendChild(container);
   }
 
   // Create a removable chip


### PR DESCRIPTION
## Problem
When many filters are applied (e.g., 26 filters), individual chips consume most of the mobile viewport before any results are visible.

## Solution
Implemented a collapsible filter summary using Airbnb/Shopify-style UX pattern:

### Collapsed State (default when >3 filters)
```
🔍 26 filters | 1 role, 25 industries | [Clear all] [Expand ▼]
```

### Expanded State
Shows all filters grouped by category:
- **role:** executive ×
- **industry:** banking × banking-retail × ...

### Behavior
- **≤3 filters**: Original chip display (no change)
- **>3 filters**: Compact summary with expand/collapse toggle
- **Clear all**: Removes all filters + search query
- **Individual removal**: Still works in expanded view

## Screenshots
_Test locally at /publications with multiple filters_

Fixes KB-179