### PR TITLE
fix(KB-177): Switch Big 4 + Strategy consultancies to Google News RSS

### DIFF
--- a/supabase/migrations/20251208123500_google_news_rss_for_consultancies.sql
+++ b/supabase/migrations/20251208123500_google_news_rss_for_consultancies.sql
@@ -1,0 +1,62 @@
+-- KB-177: Switch Big 4 + Strategy 3 to Google News RSS feeds
+-- Google News RSS handles crawling sites that block scrapers
+
+-- PwC: Replace broken scraper with Google News RSS
+UPDATE kb_source
+SET 
+  rss_feed = 'https://news.google.com/rss/search?q=site:pwc.com+banking+OR+insurance+OR+"financial+services"&hl=en-US&gl=US&ceid=US:en',
+  scraper_config = NULL
+WHERE name = 'PwC';
+
+-- EY: Replace broken scraper with Google News RSS
+UPDATE kb_source
+SET 
+  rss_feed = 'https://news.google.com/rss/search?q=site:ey.com+banking+OR+insurance+OR+"financial+services"&hl=en-US&gl=US&ceid=US:en',
+  scraper_config = NULL
+WHERE name = 'EY';
+
+-- KPMG: Replace broken scraper with Google News RSS
+UPDATE kb_source
+SET 
+  rss_feed = 'https://news.google.com/rss/search?q=site:kpmg.com+banking+OR+insurance+OR+"financial+services"&hl=en-US&gl=US&ceid=US:en',
+  scraper_config = NULL
+WHERE name = 'KPMG';
+
+-- Deloitte: Replace broken scraper with Google News RSS
+UPDATE kb_source
+SET 
+  rss_feed = 'https://news.google.com/rss/search?q=site:deloitte.com+banking+OR+insurance+OR+"financial+services"&hl=en-US&gl=US&ceid=US:en',
+  scraper_config = NULL
+WHERE name = 'Deloitte';
+
+-- BCG: Update existing source with Google News RSS
+UPDATE kb_source
+SET 
+  rss_feed = 'https://news.google.com/rss/search?q=site:bcg.com+banking+OR+insurance+OR+"financial+services"&hl=en-US&gl=US&ceid=US:en'
+WHERE slug = 'bcg';
+
+-- Bain: Update existing source with Google News RSS
+UPDATE kb_source
+SET 
+  rss_feed = 'https://news.google.com/rss/search?q=site:bain.com+banking+OR+insurance+OR+"financial+services"&hl=en-US&gl=US&ceid=US:en'
+WHERE name = 'Bain & Company';
+
+-- Anthropic: RSS is 404, add scraper for /research page
+UPDATE kb_source
+SET 
+  rss_feed = NULL,
+  scraper_config = jsonb_build_object(
+    'url', 'https://www.anthropic.com/research',
+    'waitFor', '[class*="PublicationList"]',
+    'waitMs', 3000,
+    'selectors', jsonb_build_object(
+      'article', '[class*="PublicationList"][class*="listItem"]',
+      'title', '[class*="title"]',
+      'link', 'a',
+      'date', '[class*="date"]'
+    )
+  )
+WHERE name = 'Anthropic';
+
+-- SSRN: Keep RSS but add fallback note (blocked by 403)
+-- For now, just leave as-is - may need proxy solution later


### PR DESCRIPTION
## Problem

Big 4 and Strategy consulting sites block scrapers or use dynamic JS content:
- **PwC**: AngularJS, content loads dynamically
- **EY**: URL returns error page  
- **KPMG**: URL is category page, not articles
- **Deloitte**: Generic selectors not matching
- **SSRN**: HTTP 403 (blocked)
- **Anthropic**: RSS feed removed (404)

## Solution

**Google News RSS** - Google crawls these sites for us, providing reliable RSS feeds.

Query format:
```
https://news.google.com/rss/search?q=site:{domain}+banking+OR+insurance+OR+"financial+services"
```

## Changes

| Source | Before | After |
|--------|--------|-------|
| PwC | Broken scraper | Google News RSS |
| EY | Broken scraper | Google News RSS |
| KPMG | Broken scraper | Google News RSS |
| Deloitte | Broken scraper | Google News RSS |
| BCG | (existing) | Google News RSS |
| Bain | (existing) | Google News RSS |
| Anthropic | Dead RSS | Playwright scraper for /research |

## Benefits

- Google handles crawling complex JS sites
- Reliable and consistent
- Our relevance filter removes noise (job listings, etc.)
- No maintenance of custom scrapers

Fixes KB-177