### PR TITLE
fix(KB-177): Add disabled_reason column and disable SSRN

### DIFF
--- a/supabase/migrations/20251208124900_add_disabled_reason_column.sql
+++ b/supabase/migrations/20251208124900_add_disabled_reason_column.sql
@@ -1,0 +1,16 @@
+-- KB-177: Add disabled_reason column to kb_source
+-- Allows documenting why a source is disabled
+
+-- Add column for explaining why a source is disabled
+ALTER TABLE kb_source
+ADD COLUMN disabled_reason TEXT;
+
+-- Add comment explaining the column
+COMMENT ON COLUMN kb_source.disabled_reason IS 'Brief explanation of why source is disabled (e.g., "HTTP 403 blocked", "RSS feed removed")';
+
+-- Disable SSRN with reason
+UPDATE kb_source
+SET 
+  enabled = FALSE,
+  disabled_reason = 'HTTP 403 - SSRN blocks automated access. May need proxy or alternative academic source.'
+WHERE name = 'SSRN';


### PR DESCRIPTION
## Changes

1. **New column**: `disabled_reason` on `kb_source` table
   - Documents why a source is disabled
   - Helpful for future debugging

2. **Disable SSRN**: HTTP 403 blocks all automated access
   - `enabled = FALSE`
   - `disabled_reason = 'HTTP 403 - SSRN blocks automated access...'`

## Migration
`20251208124900_add_disabled_reason_column.sql`

Fixes KB-177