### PR TITLE
feat(KB-175): Add Sources and Prompts pages to Next.js admin

### DIFF
--- a/admin-next/src/app/(dashboard)/prompts/page.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/page.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { PromptVersion } from '@/types/database';
+
+export default function PromptsPage() {
+  const [prompts, setPrompts] = useState<PromptVersion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedPrompt, setSelectedPrompt] = useState<PromptVersion | null>(null);
+  const [editingPrompt, setEditingPrompt] = useState<PromptVersion | null>(null);
+
+  const supabase = createClient();
+
+  const loadPrompts = useCallback(
+    async function loadPrompts() {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from('prompt_versions')
+        .select('*')
+        .order('agent_name')
+        .order('is_current', { ascending: false });
+
+      if (error) {
+        console.error('Error loading prompts:', error);
+      } else {
+        setPrompts(data || []);
+      }
+      setLoading(false);
+    },
+    [supabase],
+  );
+
+  useEffect(() => {
+    loadPrompts();
+  }, [loadPrompts]);
+
+  // Group prompts by agent
+  const promptsByAgent = prompts.reduce(
+    (acc, prompt) => {
+      if (!acc[prompt.agent_name]) {
+        acc[prompt.agent_name] = [];
+      }
+      acc[prompt.agent_name].push(prompt);
+      return acc;
+    },
+    {} as Record<string, PromptVersion[]>,
+  );
+
+  const agents = Object.keys(promptsByAgent);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-neutral-400">Loading prompts...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-white">Prompts</h1>
+        <p className="mt-1 text-sm text-neutral-400">View and manage LLM prompts for each agent</p>
+      </header>
+
+      {/* Agent list */}
+      <div className="grid gap-4">
+        {agents.map((agentName) => {
+          const agentPrompts = promptsByAgent[agentName];
+          const currentPrompt = agentPrompts.find((p) => p.is_current);
+          const historyCount = agentPrompts.length - 1;
+
+          return (
+            <div
+              key={agentName}
+              className="rounded-lg border border-neutral-800 bg-neutral-900/60 overflow-hidden"
+            >
+              {/* Agent header */}
+              <div
+                className="flex items-center justify-between p-4 cursor-pointer hover:bg-neutral-800/50"
+                onClick={() =>
+                  setSelectedPrompt(
+                    selectedPrompt?.agent_name === agentName ? null : currentPrompt || null,
+                  )
+                }
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-lg">
+                    {agentName.includes('tagger')
+                      ? '🏷️'
+                      : agentName.includes('summar')
+                        ? '📝'
+                        : '🤖'}
+                  </span>
+                  <div>
+                    <div className="font-medium text-white">{agentName}</div>
+                    <div className="text-xs text-neutral-400">
+                      {currentPrompt?.version || 'No version'} •{' '}
+                      {currentPrompt?.prompt_text.length.toLocaleString()} chars •{' '}
+                      {historyCount > 0 ? `${historyCount} previous versions` : 'No history'}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {currentPrompt && (
+                    <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-2 py-0.5 text-xs">
+                      Active
+                    </span>
+                  )}
+                  <svg
+                    className={`w-5 h-5 text-neutral-400 transition-transform ${
+                      selectedPrompt?.agent_name === agentName ? 'rotate-180' : ''
+                    }`}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </div>
+              </div>
+
+              {/* Expanded content */}
+              {selectedPrompt?.agent_name === agentName && currentPrompt && (
+                <div className="border-t border-neutral-800 p-4">
+                  {/* Prompt metadata */}
+                  <div className="flex flex-wrap gap-4 mb-4 text-sm">
+                    <div>
+                      <span className="text-neutral-400">Version:</span>{' '}
+                      <span className="text-white">{currentPrompt.version}</span>
+                    </div>
+                    <div>
+                      <span className="text-neutral-400">Model:</span>{' '}
+                      <span className="text-white">
+                        {currentPrompt.model_id || 'Not specified'}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-neutral-400">Stage:</span>{' '}
+                      <span className="text-white">{currentPrompt.stage || 'Not specified'}</span>
+                    </div>
+                    <div>
+                      <span className="text-neutral-400">Created:</span>{' '}
+                      <span className="text-white">
+                        {new Date(currentPrompt.created_at).toLocaleDateString()}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Notes */}
+                  {currentPrompt.notes && (
+                    <div className="mb-4 p-3 rounded-md bg-neutral-800/50 text-sm">
+                      <span className="text-neutral-400">Notes: </span>
+                      <span className="text-neutral-300">{currentPrompt.notes}</span>
+                    </div>
+                  )}
+
+                  {/* Prompt text */}
+                  <div className="relative">
+                    <div className="absolute top-2 right-2 flex gap-2">
+                      <button
+                        onClick={() => setEditingPrompt(currentPrompt)}
+                        className="rounded px-2 py-1 text-xs bg-sky-600 text-white hover:bg-sky-500"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => navigator.clipboard.writeText(currentPrompt.prompt_text)}
+                        className="rounded px-2 py-1 text-xs bg-neutral-700 text-neutral-300 hover:bg-neutral-600"
+                      >
+                        Copy
+                      </button>
+                    </div>
+                    <pre className="p-4 rounded-md bg-neutral-950 text-sm text-neutral-300 overflow-x-auto max-h-96 overflow-y-auto whitespace-pre-wrap">
+                      {currentPrompt.prompt_text}
+                    </pre>
+                  </div>
+
+                  {/* Version history */}
+                  {historyCount > 0 && (
+                    <div className="mt-4">
+                      <h4 className="text-sm font-medium text-neutral-400 mb-2">Version History</h4>
+                      <div className="space-y-1">
+                        {agentPrompts
+                          .filter((p) => !p.is_current)
+                          .map((p) => (
+                            <div
+                              key={p.version}
+                              className="flex items-center justify-between p-2 rounded bg-neutral-800/30 text-sm"
+                            >
+                              <div>
+                                <span className="text-neutral-300">{p.version}</span>
+                                <span className="text-neutral-500 ml-2">
+                                  {new Date(p.created_at).toLocaleDateString()}
+                                </span>
+                              </div>
+                              <button
+                                onClick={() => setSelectedPrompt(p)}
+                                className="text-sky-400 hover:text-sky-300 text-xs"
+                              >
+                                View
+                              </button>
+                            </div>
+                          ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Edit modal */}
+      {editingPrompt && (
+        <PromptEditModal
+          prompt={editingPrompt}
+          onClose={() => setEditingPrompt(null)}
+          onSave={() => {
+            setEditingPrompt(null);
+            loadPrompts();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+interface PromptEditModalProps {
+  prompt: PromptVersion;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+function PromptEditModal({ prompt, onClose, onSave }: PromptEditModalProps) {
+  const [promptText, setPromptText] = useState(prompt.prompt_text);
+  const [notes, setNotes] = useState(prompt.notes || '');
+  const [saving, setSaving] = useState(false);
+
+  const supabase = createClient();
+
+  async function handleSave() {
+    setSaving(true);
+
+    // Update existing prompt
+    const { error } = await supabase
+      .from('prompt_versions')
+      .update({
+        prompt_text: promptText,
+        notes: notes || null,
+      })
+      .eq('agent_name', prompt.agent_name)
+      .eq('version', prompt.version);
+
+    setSaving(false);
+
+    if (error) {
+      alert('Failed to save: ' + error.message);
+    } else {
+      onSave();
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-4xl max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-bold text-white">Edit Prompt</h2>
+            <p className="text-sm text-neutral-400">
+              {prompt.agent_name} • {prompt.version}
+            </p>
+          </div>
+          <div className="text-sm text-neutral-400">
+            {promptText.length.toLocaleString()} characters
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto p-4 space-y-4">
+          <div>
+            <label className="block text-sm text-neutral-400 mb-1">Notes</label>
+            <input
+              type="text"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Describe changes..."
+              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+            />
+          </div>
+
+          <div className="flex-1">
+            <label className="block text-sm text-neutral-400 mb-1">Prompt Text</label>
+            <textarea
+              value={promptText}
+              onChange={(e) => setPromptText(e.target.value)}
+              className="w-full h-96 rounded-md border border-neutral-700 bg-neutral-950 px-4 py-3 text-sm text-neutral-300 font-mono resize-none"
+            />
+          </div>
+        </div>
+
+        <div className="p-4 border-t border-neutral-800 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/admin-next/src/app/(dashboard)/sources/page.tsx
+++ b/admin-next/src/app/(dashboard)/sources/page.tsx
@@ -1,0 +1,503 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { Source } from '@/types/database';
+
+type FilterCategory = 'all' | string;
+type FilterTier = 'all' | 'standard' | 'premium';
+type FilterEnabled = 'all' | 'true' | 'false';
+
+export default function SourcesPage() {
+  const [sources, setSources] = useState<Source[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filterCategory, setFilterCategory] = useState<FilterCategory>('all');
+  const [filterTier, setFilterTier] = useState<FilterTier>('all');
+  const [filterEnabled, setFilterEnabled] = useState<FilterEnabled>('all');
+  const [editingSource, setEditingSource] = useState<Source | null>(null);
+  const [showModal, setShowModal] = useState(false);
+
+  const supabase = createClient();
+
+  const loadSources = useCallback(
+    async function loadSources() {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from('kb_source')
+        .select('*')
+        .order('sort_order', { ascending: true });
+
+      if (error) {
+        console.error('Error loading sources:', error);
+      } else {
+        setSources(data || []);
+      }
+      setLoading(false);
+    },
+    [supabase],
+  );
+
+  useEffect(() => {
+    loadSources();
+  }, [loadSources]);
+
+  async function toggleEnabled(source: Source) {
+    const { error } = await supabase
+      .from('kb_source')
+      .update({ enabled: !source.enabled })
+      .eq('slug', source.slug);
+
+    if (error) {
+      alert('Failed to update: ' + error.message);
+    } else {
+      loadSources();
+    }
+  }
+
+  // Filter sources
+  const filteredSources = sources.filter((s) => {
+    if (filterCategory !== 'all' && s.category !== filterCategory) return false;
+    if (filterTier !== 'all' && s.tier !== filterTier) return false;
+    if (filterEnabled !== 'all' && String(s.enabled) !== filterEnabled) return false;
+    return true;
+  });
+
+  // Get unique categories
+  const categories = [...new Set(sources.map((s) => s.category).filter(Boolean))];
+
+  // Stats
+  const stats = {
+    total: sources.length,
+    enabled: sources.filter((s) => s.enabled).length,
+    premium: sources.filter((s) => s.tier === 'premium').length,
+    withRss: sources.filter((s) => s.rss_feed).length,
+    withScraper: sources.filter((s) => s.scraper_config).length,
+  };
+
+  function getDiscoveryIcon(source: Source) {
+    const icons = [];
+    if (source.rss_feed) icons.push('📡');
+    if (source.sitemap_url) icons.push('🗺️');
+    if (source.scraper_config) icons.push('🤖');
+    return icons.length > 0 ? icons.join('') : '❌';
+  }
+
+  function getCategoryColor(category: string) {
+    const colors: Record<string, string> = {
+      regulator: 'bg-red-500/20 text-red-300',
+      central_bank: 'bg-amber-500/20 text-amber-300',
+      vendor: 'bg-orange-500/20 text-orange-300',
+      research: 'bg-pink-500/20 text-pink-300',
+      consulting: 'bg-teal-500/20 text-teal-300',
+      media_outlet: 'bg-sky-500/20 text-sky-300',
+      standards_body: 'bg-purple-500/20 text-purple-300',
+      academic: 'bg-indigo-500/20 text-indigo-300',
+      government_body: 'bg-slate-500/20 text-slate-300',
+    };
+    return colors[category] || 'bg-neutral-700 text-neutral-300';
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-neutral-400">Loading sources...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Sources</h1>
+          <p className="mt-1 text-sm text-neutral-400">
+            Configure discovery sources and priorities
+          </p>
+        </div>
+        <button
+          onClick={() => {
+            setEditingSource(null);
+            setShowModal(true);
+          }}
+          className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500"
+        >
+          + Add Source
+        </button>
+      </header>
+
+      {/* Stats */}
+      <div className="mb-6 flex flex-wrap gap-3 text-sm">
+        <span className="rounded-full bg-neutral-800 px-3 py-1">{stats.total} total</span>
+        <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-3 py-1">
+          {stats.enabled} enabled
+        </span>
+        <span className="rounded-full bg-amber-500/20 text-amber-300 px-3 py-1">
+          {stats.premium} premium
+        </span>
+        <span className="rounded-full bg-sky-500/20 text-sky-300 px-3 py-1">
+          {stats.withRss} RSS
+        </span>
+        <span className="rounded-full bg-purple-500/20 text-purple-300 px-3 py-1">
+          {stats.withScraper} scrapers
+        </span>
+      </div>
+
+      {/* Filters */}
+      <div className="mb-6 flex flex-wrap gap-4 rounded-lg border border-neutral-800 bg-neutral-900/60 p-4">
+        <div>
+          <label className="block text-xs text-neutral-400 mb-1">Category</label>
+          <select
+            value={filterCategory}
+            onChange={(e) => setFilterCategory(e.target.value)}
+            className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-white"
+          >
+            <option value="all">All categories</option>
+            {categories.map((cat) => (
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-neutral-400 mb-1">Tier</label>
+          <select
+            value={filterTier}
+            onChange={(e) => setFilterTier(e.target.value as FilterTier)}
+            className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-white"
+          >
+            <option value="all">All tiers</option>
+            <option value="standard">Standard</option>
+            <option value="premium">Premium</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-neutral-400 mb-1">Status</label>
+          <select
+            value={filterEnabled}
+            onChange={(e) => setFilterEnabled(e.target.value as FilterEnabled)}
+            className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-white"
+          >
+            <option value="all">All</option>
+            <option value="true">Enabled</option>
+            <option value="false">Disabled</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-lg border border-neutral-800">
+        <table className="w-full">
+          <thead className="bg-neutral-900">
+            <tr className="text-left text-xs font-medium uppercase tracking-wider text-neutral-400">
+              <th className="px-4 py-3">Priority</th>
+              <th className="px-4 py-3">Source</th>
+              <th className="px-4 py-3">Category</th>
+              <th className="px-4 py-3">Tier</th>
+              <th className="px-4 py-3">Discovery</th>
+              <th className="px-4 py-3">Enabled</th>
+              <th className="px-4 py-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-800">
+            {filteredSources.map((source) => (
+              <tr key={source.slug} className="hover:bg-neutral-800/50">
+                <td className="px-4 py-3">
+                  <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-neutral-700 text-xs font-medium">
+                    {source.sort_order ? Math.ceil(source.sort_order / 100) : '-'}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="font-medium text-white">{source.name}</div>
+                  <div className="text-xs text-neutral-500">{source.domain}</div>
+                  {source.disabled_reason && (
+                    <div className="text-xs text-red-400 mt-1">⚠️ {source.disabled_reason}</div>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs ${getCategoryColor(source.category)}`}
+                  >
+                    {source.category || '-'}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`text-xs ${source.tier === 'premium' ? 'text-amber-400' : 'text-neutral-400'}`}
+                  >
+                    {source.tier}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span title={source.rss_feed || source.sitemap_url || 'No config'}>
+                    {getDiscoveryIcon(source)}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <button
+                    onClick={() => toggleEnabled(source)}
+                    className={`w-10 h-5 rounded-full transition-colors ${
+                      source.enabled ? 'bg-emerald-500' : 'bg-neutral-700'
+                    }`}
+                  >
+                    <span
+                      className={`block w-4 h-4 rounded-full bg-white transform transition-transform ${
+                        source.enabled ? 'translate-x-5' : 'translate-x-0.5'
+                      }`}
+                    />
+                  </button>
+                </td>
+                <td className="px-4 py-3">
+                  <button
+                    onClick={() => {
+                      setEditingSource(source);
+                      setShowModal(true);
+                    }}
+                    className="text-sky-400 hover:text-sky-300 text-sm mr-3"
+                  >
+                    Edit
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Modal */}
+      {showModal && (
+        <SourceModal
+          source={editingSource}
+          onClose={() => {
+            setShowModal(false);
+            setEditingSource(null);
+          }}
+          onSave={() => {
+            setShowModal(false);
+            setEditingSource(null);
+            loadSources();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+interface SourceModalProps {
+  source: Source | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+function SourceModal({ source, onClose, onSave }: SourceModalProps) {
+  const [formData, setFormData] = useState<Partial<Source>>(
+    source || {
+      name: '',
+      slug: '',
+      domain: '',
+      category: 'vendor',
+      tier: 'standard',
+      enabled: true,
+      sort_order: 500,
+      rss_feed: '',
+      sitemap_url: '',
+      description: '',
+      show_on_external_page: false,
+    },
+  );
+  const [saving, setSaving] = useState(false);
+
+  const supabase = createClient();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+
+    const dataToSave = {
+      ...formData,
+      rss_feed: formData.rss_feed || null,
+      sitemap_url: formData.sitemap_url || null,
+      description: formData.description || null,
+    };
+
+    let error;
+    if (source) {
+      const { error: updateError } = await supabase
+        .from('kb_source')
+        .update(dataToSave)
+        .eq('slug', source.slug);
+      error = updateError;
+    } else {
+      const { error: insertError } = await supabase.from('kb_source').insert(dataToSave);
+      error = insertError;
+    }
+
+    setSaving(false);
+
+    if (error) {
+      alert('Failed to save: ' + error.message);
+    } else {
+      onSave();
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold text-white mb-4">
+          {source ? 'Edit Source' : 'Add Source'}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-neutral-400 mb-1">Name</label>
+              <input
+                type="text"
+                value={formData.name || ''}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm text-neutral-400 mb-1">Slug</label>
+              <input
+                type="text"
+                value={formData.slug || ''}
+                onChange={(e) => setFormData({ ...formData, slug: e.target.value })}
+                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+                required
+                disabled={!!source}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm text-neutral-400 mb-1">Domain</label>
+            <input
+              type="text"
+              value={formData.domain || ''}
+              onChange={(e) => setFormData({ ...formData, domain: e.target.value })}
+              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+              placeholder="example.com"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-neutral-400 mb-1">Category</label>
+              <select
+                value={formData.category || ''}
+                onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+              >
+                <option value="regulator">Regulator</option>
+                <option value="central_bank">Central Bank</option>
+                <option value="vendor">Vendor</option>
+                <option value="research">Research</option>
+                <option value="consulting">Consulting</option>
+                <option value="media_outlet">Media Outlet</option>
+                <option value="standards_body">Standards Body</option>
+                <option value="academic">Academic</option>
+                <option value="government_body">Government Body</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm text-neutral-400 mb-1">Tier</label>
+              <select
+                value={formData.tier || 'standard'}
+                onChange={(e) =>
+                  setFormData({ ...formData, tier: e.target.value as 'standard' | 'premium' })
+                }
+                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+              >
+                <option value="standard">Standard</option>
+                <option value="premium">Premium</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm text-neutral-400 mb-1">RSS Feed URL</label>
+            <input
+              type="text"
+              value={formData.rss_feed || ''}
+              onChange={(e) => setFormData({ ...formData, rss_feed: e.target.value })}
+              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+              placeholder="https://..."
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-neutral-400 mb-1">Sitemap URL</label>
+            <input
+              type="text"
+              value={formData.sitemap_url || ''}
+              onChange={(e) => setFormData({ ...formData, sitemap_url: e.target.value })}
+              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+              placeholder="https://..."
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-neutral-400 mb-1">Priority (sort order)</label>
+            <input
+              type="number"
+              value={formData.sort_order || 500}
+              onChange={(e) => setFormData({ ...formData, sort_order: parseInt(e.target.value) })}
+              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+            />
+          </div>
+
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-2 text-sm text-neutral-400">
+              <input
+                type="checkbox"
+                checked={formData.enabled || false}
+                onChange={(e) => setFormData({ ...formData, enabled: e.target.checked })}
+                className="rounded border-neutral-700 bg-neutral-800"
+              />
+              Enabled
+            </label>
+            <label className="flex items-center gap-2 text-sm text-neutral-400">
+              <input
+                type="checkbox"
+                checked={formData.show_on_external_page || false}
+                onChange={(e) =>
+                  setFormData({ ...formData, show_on_external_page: e.target.checked })
+                }
+                className="rounded border-neutral-700 bg-neutral-800"
+              />
+              Show on external page
+            </label>
+          </div>
+
+          <div className="flex justify-end gap-3 pt-4 border-t border-neutral-800">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/admin-next/src/types/database.ts
+++ b/admin-next/src/types/database.ts
@@ -80,9 +80,13 @@ export interface Source {
   description?: string;
   rss_feed?: string;
   sitemap_url?: string;
+  scraper_config?: Record<string, unknown>;
   enabled: boolean;
   sort_order: number;
   show_on_external_page: boolean;
+  disabled_reason?: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface PromptVersion {


### PR DESCRIPTION
## KB-175 Day 2: Sources & Prompts Pages

### New Pages

**Sources Page** (`/sources`)
- List all sources with filters (category, tier, enabled)
- Stats bar showing totals
- Toggle enabled/disabled inline
- Edit modal for source configuration
- Shows `disabled_reason` for blocked sources (like SSRN)

**Prompts Page** (`/prompts`)
- List all agents with current prompts
- Expandable accordion view
- Full prompt text with syntax highlighting
- Version history per agent
- Edit modal for prompt modifications
- Copy to clipboard

### Type Updates
Added missing fields to `Source` interface:
- `scraper_config`
- `disabled_reason`
- `created_at`/`updated_at`

### Screenshots
Test at `http://localhost:3000/sources` and `http://localhost:3000/prompts`

### Remaining for KB-175
- [ ] Evaluate page
- [ ] Compare page
- [ ] Playground page
- [ ] Deploy to admin.bfsiinsights.com