### PR TITLE
feat(KB-175): Day 3 - Prompt Engineering & Evaluation UI

### DIFF
--- a/admin-next/src/app/(dashboard)/prompts/page.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/page.tsx
@@ -4,11 +4,18 @@ import { useEffect, useState, useCallback } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import type { PromptVersion } from '@/types/database';
 
+// Estimate tokens (rough: ~4 chars per token for English)
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
 export default function PromptsPage() {
   const [prompts, setPrompts] = useState<PromptVersion[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedPrompt, setSelectedPrompt] = useState<PromptVersion | null>(null);
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const [viewingVersion, setViewingVersion] = useState<PromptVersion | null>(null);
   const [editingPrompt, setEditingPrompt] = useState<PromptVersion | null>(null);
+  const [diffMode, setDiffMode] = useState<{ a: PromptVersion; b: PromptVersion } | null>(null);
 
   const supabase = createClient();
 
@@ -19,7 +26,7 @@ export default function PromptsPage() {
         .from('prompt_versions')
         .select('*')
         .order('agent_name')
-        .order('is_current', { ascending: false });
+        .order('created_at', { ascending: false });
 
       if (error) {
         console.error('Error loading prompts:', error);
@@ -49,6 +56,32 @@ export default function PromptsPage() {
 
   const agents = Object.keys(promptsByAgent);
 
+  // Rollback function
+  async function rollbackToVersion(prompt: PromptVersion) {
+    if (!confirm(`Make "${prompt.version}" the current version for ${prompt.agent_name}?`)) {
+      return;
+    }
+
+    // First, set all versions to not current
+    await supabase
+      .from('prompt_versions')
+      .update({ is_current: false })
+      .eq('agent_name', prompt.agent_name);
+
+    // Then set the selected version as current
+    const { error } = await supabase
+      .from('prompt_versions')
+      .update({ is_current: true })
+      .eq('agent_name', prompt.agent_name)
+      .eq('version', prompt.version);
+
+    if (error) {
+      alert('Failed to rollback: ' + error.message);
+    } else {
+      loadPrompts();
+    }
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -60,169 +93,124 @@ export default function PromptsPage() {
   return (
     <div>
       {/* Header */}
-      <header className="mb-6">
-        <h1 className="text-2xl font-bold text-white">Prompts</h1>
-        <p className="mt-1 text-sm text-neutral-400">View and manage LLM prompts for each agent</p>
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Prompt Engineering</h1>
+          <p className="mt-1 text-sm text-neutral-400">
+            View, edit, and version LLM prompts for each agent
+          </p>
+        </div>
+        <div className="text-sm text-neutral-400">
+          {agents.length} agents • {prompts.length} total versions
+        </div>
       </header>
 
-      {/* Agent list */}
-      <div className="grid gap-4">
-        {agents.map((agentName) => {
-          const agentPrompts = promptsByAgent[agentName];
-          const currentPrompt = agentPrompts.find((p) => p.is_current);
-          const historyCount = agentPrompts.length - 1;
+      {/* Agent table */}
+      <div className="rounded-xl border border-neutral-800 overflow-hidden mb-6">
+        <table className="w-full">
+          <thead className="bg-neutral-900">
+            <tr className="text-left text-xs font-medium uppercase tracking-wider text-neutral-400">
+              <th className="px-4 py-3">Agent</th>
+              <th className="px-4 py-3">Current Version</th>
+              <th className="px-4 py-3">Last Updated</th>
+              <th className="px-4 py-3">Chars</th>
+              <th className="px-4 py-3">~Tokens</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-800">
+            {agents.map((agentName) => {
+              const agentPrompts = promptsByAgent[agentName];
+              const currentPrompt = agentPrompts.find((p) => p.is_current);
+              const historyCount = agentPrompts.length - (currentPrompt ? 1 : 0);
+              const isExpanded = selectedAgent === agentName;
 
-          return (
-            <div
-              key={agentName}
-              className="rounded-lg border border-neutral-800 bg-neutral-900/60 overflow-hidden"
-            >
-              {/* Agent header */}
-              <div
-                className="flex items-center justify-between p-4 cursor-pointer hover:bg-neutral-800/50"
-                onClick={() =>
-                  setSelectedPrompt(
-                    selectedPrompt?.agent_name === agentName ? null : currentPrompt || null,
-                  )
-                }
-              >
-                <div className="flex items-center gap-3">
-                  <span className="text-lg">
-                    {agentName.includes('tagger')
-                      ? '🏷️'
-                      : agentName.includes('summar')
-                        ? '📝'
-                        : '🤖'}
-                  </span>
-                  <div>
-                    <div className="font-medium text-white">{agentName}</div>
-                    <div className="text-xs text-neutral-400">
-                      {currentPrompt?.version || 'No version'} •{' '}
-                      {currentPrompt?.prompt_text.length.toLocaleString()} chars •{' '}
-                      {historyCount > 0 ? `${historyCount} previous versions` : 'No history'}
+              return (
+                <tr
+                  key={agentName}
+                  className={`hover:bg-neutral-800/50 cursor-pointer ${isExpanded ? 'bg-neutral-800/30' : ''}`}
+                  onClick={() => setSelectedAgent(isExpanded ? null : agentName)}
+                >
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <span>
+                        {agentName.includes('tagger')
+                          ? '🏷️'
+                          : agentName.includes('summar')
+                            ? '📝'
+                            : agentName.includes('filter')
+                              ? '🔍'
+                              : '🤖'}
+                      </span>
+                      <span className="font-medium text-white">{agentName}</span>
                     </div>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  {currentPrompt && (
-                    <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-2 py-0.5 text-xs">
-                      Active
-                    </span>
-                  )}
-                  <svg
-                    className={`w-5 h-5 text-neutral-400 transition-transform ${
-                      selectedPrompt?.agent_name === agentName ? 'rotate-180' : ''
-                    }`}
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
-                </div>
-              </div>
-
-              {/* Expanded content */}
-              {selectedPrompt?.agent_name === agentName && currentPrompt && (
-                <div className="border-t border-neutral-800 p-4">
-                  {/* Prompt metadata */}
-                  <div className="flex flex-wrap gap-4 mb-4 text-sm">
-                    <div>
-                      <span className="text-neutral-400">Version:</span>{' '}
-                      <span className="text-white">{currentPrompt.version}</span>
-                    </div>
-                    <div>
-                      <span className="text-neutral-400">Model:</span>{' '}
-                      <span className="text-white">
-                        {currentPrompt.model_id || 'Not specified'}
+                  </td>
+                  <td className="px-4 py-3 text-neutral-300">{currentPrompt?.version || '-'}</td>
+                  <td className="px-4 py-3 text-neutral-400 text-sm">
+                    {currentPrompt ? new Date(currentPrompt.created_at).toLocaleDateString() : '-'}
+                  </td>
+                  <td className="px-4 py-3 text-neutral-400">
+                    {currentPrompt?.prompt_text.length.toLocaleString() || '-'}
+                  </td>
+                  <td className="px-4 py-3 text-neutral-400">
+                    {currentPrompt
+                      ? `~${estimateTokens(currentPrompt.prompt_text).toLocaleString()}`
+                      : '-'}
+                  </td>
+                  <td className="px-4 py-3">
+                    {currentPrompt ? (
+                      <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-2 py-0.5 text-xs">
+                        ✅ Active
+                      </span>
+                    ) : (
+                      <span className="rounded-full bg-red-500/20 text-red-300 px-2 py-0.5 text-xs">
+                        ⚠️ Missing
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                      {currentPrompt && (
+                        <>
+                          <button
+                            onClick={() => setEditingPrompt(currentPrompt)}
+                            className="text-sky-400 hover:text-sky-300 text-xs"
+                          >
+                            Edit
+                          </button>
+                          <span className="text-neutral-600">•</span>
+                        </>
+                      )}
+                      <span className="text-neutral-500 text-xs">
+                        {historyCount} version{historyCount !== 1 ? 's' : ''}
                       </span>
                     </div>
-                    <div>
-                      <span className="text-neutral-400">Stage:</span>{' '}
-                      <span className="text-white">{currentPrompt.stage || 'Not specified'}</span>
-                    </div>
-                    <div>
-                      <span className="text-neutral-400">Created:</span>{' '}
-                      <span className="text-white">
-                        {new Date(currentPrompt.created_at).toLocaleDateString()}
-                      </span>
-                    </div>
-                  </div>
-
-                  {/* Notes */}
-                  {currentPrompt.notes && (
-                    <div className="mb-4 p-3 rounded-md bg-neutral-800/50 text-sm">
-                      <span className="text-neutral-400">Notes: </span>
-                      <span className="text-neutral-300">{currentPrompt.notes}</span>
-                    </div>
-                  )}
-
-                  {/* Prompt text */}
-                  <div className="relative">
-                    <div className="absolute top-2 right-2 flex gap-2">
-                      <button
-                        onClick={() => setEditingPrompt(currentPrompt)}
-                        className="rounded px-2 py-1 text-xs bg-sky-600 text-white hover:bg-sky-500"
-                      >
-                        Edit
-                      </button>
-                      <button
-                        onClick={() => navigator.clipboard.writeText(currentPrompt.prompt_text)}
-                        className="rounded px-2 py-1 text-xs bg-neutral-700 text-neutral-300 hover:bg-neutral-600"
-                      >
-                        Copy
-                      </button>
-                    </div>
-                    <pre className="p-4 rounded-md bg-neutral-950 text-sm text-neutral-300 overflow-x-auto max-h-96 overflow-y-auto whitespace-pre-wrap">
-                      {currentPrompt.prompt_text}
-                    </pre>
-                  </div>
-
-                  {/* Version history */}
-                  {historyCount > 0 && (
-                    <div className="mt-4">
-                      <h4 className="text-sm font-medium text-neutral-400 mb-2">Version History</h4>
-                      <div className="space-y-1">
-                        {agentPrompts
-                          .filter((p) => !p.is_current)
-                          .map((p) => (
-                            <div
-                              key={p.version}
-                              className="flex items-center justify-between p-2 rounded bg-neutral-800/30 text-sm"
-                            >
-                              <div>
-                                <span className="text-neutral-300">{p.version}</span>
-                                <span className="text-neutral-500 ml-2">
-                                  {new Date(p.created_at).toLocaleDateString()}
-                                </span>
-                              </div>
-                              <button
-                                onClick={() => setSelectedPrompt(p)}
-                                className="text-sky-400 hover:text-sky-300 text-xs"
-                              >
-                                View
-                              </button>
-                            </div>
-                          ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
+
+      {/* Expanded agent detail */}
+      {selectedAgent && promptsByAgent[selectedAgent] && (
+        <AgentDetail
+          agentName={selectedAgent}
+          prompts={promptsByAgent[selectedAgent]}
+          onEdit={setEditingPrompt}
+          onRollback={rollbackToVersion}
+          onDiff={(a, b) => setDiffMode({ a, b })}
+          onView={setViewingVersion}
+        />
+      )}
 
       {/* Edit modal */}
       {editingPrompt && (
         <PromptEditModal
           prompt={editingPrompt}
+          allVersions={promptsByAgent[editingPrompt.agent_name] || []}
           onClose={() => setEditingPrompt(null)}
           onSave={() => {
             setEditingPrompt(null);
@@ -230,43 +218,209 @@ export default function PromptsPage() {
           }}
         />
       )}
+
+      {/* Diff modal */}
+      {diffMode && <DiffModal a={diffMode.a} b={diffMode.b} onClose={() => setDiffMode(null)} />}
+
+      {/* View version modal */}
+      {viewingVersion && (
+        <ViewVersionModal
+          prompt={viewingVersion}
+          onClose={() => setViewingVersion(null)}
+          onRollback={() => {
+            rollbackToVersion(viewingVersion);
+            setViewingVersion(null);
+          }}
+        />
+      )}
     </div>
   );
 }
 
+// Agent Detail Panel (version history timeline)
+interface AgentDetailProps {
+  agentName: string;
+  prompts: PromptVersion[];
+  onEdit: (p: PromptVersion) => void;
+  onRollback: (p: PromptVersion) => void;
+  onDiff: (a: PromptVersion, b: PromptVersion) => void;
+  onView: (p: PromptVersion) => void;
+}
+
+function AgentDetail({ agentName, prompts, onEdit, onRollback, onDiff, onView }: AgentDetailProps) {
+  const currentPrompt = prompts.find((p) => p.is_current);
+
+  return (
+    <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-white">{agentName}</h2>
+        {currentPrompt && (
+          <button
+            onClick={() => onEdit(currentPrompt)}
+            className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500"
+          >
+            Edit Current
+          </button>
+        )}
+      </div>
+
+      {/* Current prompt preview */}
+      {currentPrompt && (
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-2">
+            <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-2 py-0.5 text-xs">
+              Current: {currentPrompt.version}
+            </span>
+            <span className="text-sm text-neutral-400">
+              {currentPrompt.prompt_text.length.toLocaleString()} chars • ~
+              {estimateTokens(currentPrompt.prompt_text).toLocaleString()} tokens
+            </span>
+          </div>
+          {currentPrompt.notes && (
+            <p className="text-sm text-neutral-400 mb-2">📝 {currentPrompt.notes}</p>
+          )}
+          <pre className="p-4 rounded-md bg-neutral-950 text-sm text-neutral-300 overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap">
+            {currentPrompt.prompt_text.slice(0, 500)}
+            {currentPrompt.prompt_text.length > 500 && '...'}
+          </pre>
+        </div>
+      )}
+
+      {/* Version Timeline */}
+      <h3 className="text-sm font-medium text-neutral-400 mb-3">Version History</h3>
+      <div className="space-y-2">
+        {prompts.map((p) => (
+          <div
+            key={p.version}
+            className={`flex items-center justify-between p-3 rounded-lg ${
+              p.is_current ? 'bg-emerald-500/10 border border-emerald-500/30' : 'bg-neutral-800/30'
+            }`}
+          >
+            <div className="flex items-center gap-3">
+              <div className="w-2 h-2 rounded-full bg-neutral-500" />
+              <div>
+                <span className={`font-medium ${p.is_current ? 'text-emerald-300' : 'text-white'}`}>
+                  {p.version}
+                </span>
+                {p.is_current && <span className="ml-2 text-xs text-emerald-400">(current)</span>}
+                <div className="text-xs text-neutral-500">
+                  {new Date(p.created_at).toLocaleString()}
+                  {p.notes && ` • ${p.notes}`}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <button onClick={() => onView(p)} className="text-xs text-sky-400 hover:text-sky-300">
+                View
+              </button>
+              {!p.is_current && (
+                <>
+                  <button
+                    onClick={() => onRollback(p)}
+                    className="text-xs text-amber-400 hover:text-amber-300"
+                  >
+                    Rollback
+                  </button>
+                  {currentPrompt && (
+                    <button
+                      onClick={() => onDiff(currentPrompt, p)}
+                      className="text-xs text-purple-400 hover:text-purple-300"
+                    >
+                      Diff
+                    </button>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Edit Modal with "Save as New Version" option
 interface PromptEditModalProps {
   prompt: PromptVersion;
+  allVersions: PromptVersion[];
   onClose: () => void;
   onSave: () => void;
 }
 
-function PromptEditModal({ prompt, onClose, onSave }: PromptEditModalProps) {
+function PromptEditModal({ prompt, allVersions, onClose, onSave }: PromptEditModalProps) {
   const [promptText, setPromptText] = useState(prompt.prompt_text);
-  const [notes, setNotes] = useState(prompt.notes || '');
+  const [notes, setNotes] = useState('');
+  const [newVersion, setNewVersion] = useState('');
+  const [saveMode, setSaveMode] = useState<'update' | 'new'>('update');
   const [saving, setSaving] = useState(false);
 
   const supabase = createClient();
 
+  // Generate next version suggestion
+  const suggestNextVersion = () => {
+    // Version suggestion based on current
+    const match = prompt.version.match(/v?(\d+)\.?(\d*)/);
+    if (match) {
+      const major = parseInt(match[1]);
+      const minor = match[2] ? parseInt(match[2]) + 1 : 1;
+      return `v${major}.${minor}`;
+    }
+    return `${prompt.version}-2`;
+  };
+
   async function handleSave() {
     setSaving(true);
 
-    // Update existing prompt
-    const { error } = await supabase
-      .from('prompt_versions')
-      .update({
+    if (saveMode === 'update') {
+      // Update existing prompt
+      const { error } = await supabase
+        .from('prompt_versions')
+        .update({
+          prompt_text: promptText,
+          notes: notes || prompt.notes,
+        })
+        .eq('agent_name', prompt.agent_name)
+        .eq('version', prompt.version);
+
+      if (error) {
+        alert('Failed to save: ' + error.message);
+        setSaving(false);
+        return;
+      }
+    } else {
+      // Create new version
+      if (!newVersion) {
+        alert('Please enter a version name');
+        setSaving(false);
+        return;
+      }
+
+      // Set all other versions to not current
+      await supabase
+        .from('prompt_versions')
+        .update({ is_current: false })
+        .eq('agent_name', prompt.agent_name);
+
+      // Insert new version
+      const { error } = await supabase.from('prompt_versions').insert({
+        agent_name: prompt.agent_name,
+        version: newVersion,
         prompt_text: promptText,
         notes: notes || null,
-      })
-      .eq('agent_name', prompt.agent_name)
-      .eq('version', prompt.version);
+        model_id: prompt.model_id,
+        stage: prompt.stage,
+        is_current: true,
+      });
+
+      if (error) {
+        alert('Failed to create version: ' + error.message);
+        setSaving(false);
+        return;
+      }
+    }
 
     setSaving(false);
-
-    if (error) {
-      alert('Failed to save: ' + error.message);
-    } else {
-      onSave();
-    }
+    onSave();
   }
 
   return (
@@ -281,16 +435,53 @@ function PromptEditModal({ prompt, onClose, onSave }: PromptEditModalProps) {
         <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
           <div>
             <h2 className="text-lg font-bold text-white">Edit Prompt</h2>
-            <p className="text-sm text-neutral-400">
-              {prompt.agent_name} • {prompt.version}
-            </p>
+            <p className="text-sm text-neutral-400">{prompt.agent_name}</p>
           </div>
           <div className="text-sm text-neutral-400">
-            {promptText.length.toLocaleString()} characters
+            {promptText.length.toLocaleString()} chars • ~
+            {estimateTokens(promptText).toLocaleString()} tokens
           </div>
         </div>
 
         <div className="flex-1 overflow-auto p-4 space-y-4">
+          {/* Save mode toggle */}
+          <div className="flex items-center gap-4 p-3 rounded-lg bg-neutral-800/50">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                checked={saveMode === 'update'}
+                onChange={() => setSaveMode('update')}
+                className="text-sky-500"
+              />
+              <span className="text-sm text-neutral-300">Update {prompt.version}</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                checked={saveMode === 'new'}
+                onChange={() => {
+                  setSaveMode('new');
+                  if (!newVersion) setNewVersion(suggestNextVersion());
+                }}
+                className="text-sky-500"
+              />
+              <span className="text-sm text-neutral-300">Save as new version</span>
+            </label>
+          </div>
+
+          {saveMode === 'new' && (
+            <div>
+              <label className="block text-sm text-neutral-400 mb-1">New Version Name</label>
+              <input
+                type="text"
+                value={newVersion}
+                onChange={(e) => setNewVersion(e.target.value)}
+                placeholder="e.g., v2.1"
+                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+              />
+            </div>
+          )}
+
           <div>
             <label className="block text-sm text-neutral-400 mb-1">Notes</label>
             <input
@@ -324,7 +515,139 @@ function PromptEditModal({ prompt, onClose, onSave }: PromptEditModalProps) {
             disabled={saving}
             className="rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
           >
-            {saving ? 'Saving...' : 'Save Changes'}
+            {saving ? 'Saving...' : saveMode === 'new' ? 'Create Version' : 'Save Changes'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Diff Modal
+interface DiffModalProps {
+  a: PromptVersion;
+  b: PromptVersion;
+  onClose: () => void;
+}
+
+function DiffModal({ a, b, onClose }: DiffModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-6xl max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-4 border-b border-neutral-800">
+          <h2 className="text-lg font-bold text-white">Compare Versions</h2>
+          <p className="text-sm text-neutral-400">
+            {a.version} (current) vs {b.version}
+          </p>
+        </div>
+
+        <div className="flex-1 overflow-auto grid grid-cols-2 divide-x divide-neutral-800">
+          <div className="p-4">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium text-emerald-400">{a.version} (current)</span>
+              <span className="text-xs text-neutral-500">{a.prompt_text.length} chars</span>
+            </div>
+            <pre className="p-3 rounded-md bg-neutral-950 text-xs text-neutral-300 overflow-auto max-h-[60vh] whitespace-pre-wrap">
+              {a.prompt_text}
+            </pre>
+          </div>
+          <div className="p-4">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium text-amber-400">{b.version}</span>
+              <span className="text-xs text-neutral-500">{b.prompt_text.length} chars</span>
+            </div>
+            <pre className="p-3 rounded-md bg-neutral-950 text-xs text-neutral-300 overflow-auto max-h-[60vh] whitespace-pre-wrap">
+              {b.prompt_text}
+            </pre>
+          </div>
+        </div>
+
+        <div className="p-4 border-t border-neutral-800 flex justify-between">
+          <div className="text-sm text-neutral-400">
+            Diff: {a.prompt_text.length - b.prompt_text.length > 0 ? '+' : ''}
+            {a.prompt_text.length - b.prompt_text.length} chars
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// View Version Modal
+interface ViewVersionModalProps {
+  prompt: PromptVersion;
+  onClose: () => void;
+  onRollback: () => void;
+}
+
+function ViewVersionModal({ prompt, onClose, onRollback }: ViewVersionModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-4xl max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-bold text-white">{prompt.version}</h2>
+            <p className="text-sm text-neutral-400">
+              {prompt.agent_name} • {new Date(prompt.created_at).toLocaleString()}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {prompt.is_current ? (
+              <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-2 py-0.5 text-xs">
+                Current
+              </span>
+            ) : (
+              <button
+                onClick={onRollback}
+                className="rounded-lg bg-amber-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-500"
+              >
+                Make Current
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto p-4">
+          {prompt.notes && (
+            <div className="mb-4 p-3 rounded-md bg-neutral-800/50 text-sm">
+              <span className="text-neutral-400">Notes: </span>
+              <span className="text-neutral-300">{prompt.notes}</span>
+            </div>
+          )}
+          <div className="flex gap-4 mb-4 text-sm text-neutral-400">
+            <span>{prompt.prompt_text.length.toLocaleString()} chars</span>
+            <span>~{estimateTokens(prompt.prompt_text).toLocaleString()} tokens</span>
+            {prompt.model_id && <span>Model: {prompt.model_id}</span>}
+          </div>
+          <pre className="p-4 rounded-md bg-neutral-950 text-sm text-neutral-300 overflow-auto whitespace-pre-wrap">
+            {prompt.prompt_text}
+          </pre>
+        </div>
+
+        <div className="p-4 border-t border-neutral-800 flex justify-end">
+          <button
+            onClick={onClose}
+            className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
+          >
+            Close
           </button>
         </div>
       </div>

--- a/admin-next/src/types/database.ts
+++ b/admin-next/src/types/database.ts
@@ -105,13 +105,96 @@ export interface EvalRun {
   id: string;
   agent_name: string;
   prompt_version: string;
-  model_id: string;
+  eval_type: 'golden' | 'llm_judge' | 'ab_test';
+  golden_set_id?: string;
+  compare_prompt_version?: string;
+  status: 'running' | 'success' | 'failed';
+  total_examples?: number;
+  passed?: number;
+  failed?: number;
+  score?: number;
+  results?: Record<string, unknown>;
+  started_at: string;
+  finished_at?: string;
+  duration_ms?: number;
+}
+
+export interface EvalGoldenSet {
+  id: string;
+  agent_name: string;
+  name: string;
+  description?: string;
+  input: Record<string, unknown>;
+  expected_output: Record<string, unknown>;
+  created_by?: string;
   created_at: string;
-  total_items: number;
-  passed: number;
-  failed: number;
-  scores: Record<string, number>;
+  updated_at: string;
+}
+
+export interface EvalResult {
+  id: string;
+  run_id: string;
+  input: Record<string, unknown>;
+  expected_output?: Record<string, unknown>;
+  actual_output?: Record<string, unknown>;
+  passed?: boolean;
+  score?: number;
+  judge_reasoning?: string;
+  judge_model?: string;
+  output_a?: Record<string, unknown>;
+  output_b?: Record<string, unknown>;
+  winner?: 'a' | 'b' | 'tie';
+  created_at: string;
+}
+
+export interface PromptABTest {
+  id: string;
+  agent_name: string;
+  variant_a_version: string;
+  variant_b_version: string;
+  traffic_split: number;
+  sample_size: number;
+  items_processed: number;
+  items_variant_a: number;
+  items_variant_b: number;
+  status: 'draft' | 'running' | 'paused' | 'completed' | 'cancelled';
+  results?: ABTestResults;
+  winner?: 'a' | 'b' | 'tie';
+  name?: string;
   notes?: string;
+  created_by?: string;
+  created_at: string;
+  started_at?: string;
+  completed_at?: string;
+}
+
+export interface ABTestResults {
+  variant_a: ABTestMetrics;
+  variant_b: ABTestMetrics;
+  statistical_significance?: number;
+}
+
+export interface ABTestMetrics {
+  avg_confidence: number;
+  avg_latency_ms: number;
+  error_rate: number;
+  validation_pass_rate: number;
+  total_items: number;
+}
+
+export interface PromptABTestItem {
+  id: string;
+  test_id: string;
+  queue_item_id?: string;
+  variant: 'a' | 'b';
+  output?: Record<string, unknown>;
+  latency_ms?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  confidence?: number;
+  error_count: number;
+  validation_passed?: boolean;
+  created_at: string;
 }
 
 // UI-specific types

--- a/supabase/migrations/20251208132000_prompt_ab_test_table.sql
+++ b/supabase/migrations/20251208132000_prompt_ab_test_table.sql
@@ -1,0 +1,122 @@
+-- KB-182: Prompt A/B Testing Framework
+-- Allows comparing two prompt versions with traffic splitting
+
+CREATE TABLE IF NOT EXISTS prompt_ab_test (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  
+  -- Which agent is being tested
+  agent_name TEXT NOT NULL,
+  
+  -- The two variants
+  variant_a_version TEXT NOT NULL, -- Control (usually current)
+  variant_b_version TEXT NOT NULL, -- Challenger (new prompt)
+  
+  -- Configuration
+  traffic_split NUMERIC(3,2) NOT NULL DEFAULT 0.50, -- 0.50 = 50/50 split
+  sample_size INTEGER NOT NULL DEFAULT 100, -- Target number of items
+  
+  -- Tracking
+  items_processed INTEGER DEFAULT 0,
+  items_variant_a INTEGER DEFAULT 0,
+  items_variant_b INTEGER DEFAULT 0,
+  
+  -- Status
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'running', 'paused', 'completed', 'cancelled')),
+  
+  -- Results (populated when completed)
+  results JSONB DEFAULT '{}',
+  winner TEXT CHECK (winner IN ('a', 'b', 'tie', NULL)),
+  
+  -- Metadata
+  name TEXT, -- Optional friendly name
+  notes TEXT,
+  created_by TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  
+  -- Constraints
+  CONSTRAINT different_variants CHECK (variant_a_version != variant_b_version)
+);
+
+-- Track which items were processed by which variant
+CREATE TABLE IF NOT EXISTS prompt_ab_test_item (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  test_id UUID NOT NULL REFERENCES prompt_ab_test(id) ON DELETE CASCADE,
+  
+  -- Which item was processed
+  queue_item_id UUID REFERENCES ingestion_queue(id) ON DELETE SET NULL,
+  
+  -- Which variant processed it
+  variant TEXT NOT NULL CHECK (variant IN ('a', 'b')),
+  
+  -- Results
+  output JSONB,
+  
+  -- Metrics
+  latency_ms INTEGER,
+  input_tokens INTEGER,
+  output_tokens INTEGER,
+  confidence NUMERIC(5,4),
+  
+  -- Quality indicators
+  error_count INTEGER DEFAULT 0,
+  validation_passed BOOLEAN,
+  
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX idx_prompt_ab_test_agent ON prompt_ab_test(agent_name);
+CREATE INDEX idx_prompt_ab_test_status ON prompt_ab_test(status);
+CREATE INDEX idx_prompt_ab_test_item_test ON prompt_ab_test_item(test_id);
+CREATE INDEX idx_prompt_ab_test_item_variant ON prompt_ab_test_item(test_id, variant);
+
+-- RLS
+ALTER TABLE prompt_ab_test ENABLE ROW LEVEL SECURITY;
+ALTER TABLE prompt_ab_test_item ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on prompt_ab_test" ON prompt_ab_test
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY "Service role full access on prompt_ab_test_item" ON prompt_ab_test_item
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Function to get the variant for a new item (for use during enrichment)
+CREATE OR REPLACE FUNCTION get_ab_test_variant(p_agent_name TEXT)
+RETURNS TABLE(test_id UUID, variant TEXT, prompt_version TEXT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_test prompt_ab_test;
+  v_variant TEXT;
+  v_prompt_version TEXT;
+BEGIN
+  -- Find active test for this agent
+  SELECT * INTO v_test
+  FROM prompt_ab_test
+  WHERE agent_name = p_agent_name
+    AND status = 'running'
+    AND items_processed < sample_size
+  ORDER BY created_at DESC
+  LIMIT 1;
+  
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+  
+  -- Determine variant based on traffic split
+  IF random() < v_test.traffic_split THEN
+    v_variant := 'a';
+    v_prompt_version := v_test.variant_a_version;
+  ELSE
+    v_variant := 'b';
+    v_prompt_version := v_test.variant_b_version;
+  END IF;
+  
+  RETURN QUERY SELECT v_test.id, v_variant, v_prompt_version;
+END;
+$$;
+
+COMMENT ON TABLE prompt_ab_test IS 'A/B tests for comparing prompt versions';
+COMMENT ON TABLE prompt_ab_test_item IS 'Individual items processed during an A/B test';
+COMMENT ON FUNCTION get_ab_test_variant IS 'Returns the test variant to use for a given agent (if test is running)';


### PR DESCRIPTION
## KB-175 Day 3: Prompt Engineering

### Completed

**Enhanced Prompts Page** (`/prompts`)
- Table view with all agents showing version, chars, tokens, status
- Version history timeline per agent
- Side-by-side diff view between versions
- Rollback to previous versions
- Save as new version option
- Token count estimation

**Database**
- `prompt_ab_test` table for A/B testing framework
- `prompt_ab_test_item` table for tracking test items
- `get_ab_test_variant()` function for routing

**Types**
- `PromptABTest`, `ABTestResults`, `ABTestMetrics`
- `EvalGoldenSet`, `EvalResult` (updated)

### Still TODO (Day 3)
- [ ] Side-by-side original vs AI summary in review detail
- [ ] Enrichment logs display

### Still TODO (Day 4-5)
- [ ] Re-run enrichment button
- [ ] A/B Testing page UI
- [ ] Golden Set evaluation page
- [ ] Dashboard metrics
- [ ] Bulk actions
- [ ] Deploy to admin.bfsiinsights.com