### PR TITLE
feat(KB-175): Day 3 Complete - Evaluation UI & Enrichment Logs

### DIFF
--- a/admin-next/src/app/(dashboard)/prompts/page.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/page.tsx
@@ -347,7 +347,12 @@ interface PromptEditModalProps {
   onSave: () => void;
 }
 
-function PromptEditModal({ prompt, allVersions, onClose, onSave }: PromptEditModalProps) {
+function PromptEditModal({
+  prompt,
+  allVersions: _allVersions,
+  onClose,
+  onSave,
+}: PromptEditModalProps) {
   const [promptText, setPromptText] = useState(prompt.prompt_text);
   const [notes, setNotes] = useState('');
   const [newVersion, setNewVersion] = useState('');


### PR DESCRIPTION
## KB-175 Day 3: Evaluation UI Complete

### New Features

**Evaluation Panel** (`/review/[id]`)
- **Compare Tab** (default): Side-by-side original content vs AI summaries
- **Enrichment Logs Tab**: Agent execution details with aggregate stats
- **Raw Data Tab**: Full JSON payload

**Summary Length Validation**
- Shows actual vs spec for each summary type
- Visual indicators: ✓ (ok), ↓ (short), ↑ (long)
- Specs: short (100-150), medium (250-350), long (600-800) chars

**Compression Stats**
- Compression percentage
- Ratio (e.g., 10:1)
- Word count reduction

**Enrichment Logs Aggregate Stats**
- Agents run count
- Success/fail counts
- Total processing time
- Total tokens used

**Re-run Enrichment** (existing from Day 2)
- Button to queue item for reprocessing

### Day 3 Checklist
- [x] Side-by-side original vs AI summary
- [x] Summary length validation
- [x] Enrichment logs with duration, model, tokens
- [x] Aggregate stats
- [x] Re-run enrichment button