### PR TITLE
fix(KB-185): Auto-trigger processing after re-enrich

### DIFF
--- a/admin-next/src/app/api/process-queue/route.ts
+++ b/admin-next/src/app/api/process-queue/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+const AGENT_API_URL = process.env.AGENT_API_URL || 'https://bfsi-insights.onrender.com';
+const AGENT_API_KEY = process.env.AGENT_API_KEY;
+
+export async function POST() {
+  if (!AGENT_API_KEY) {
+    return NextResponse.json({ error: 'AGENT_API_KEY not configured' }, { status: 500 });
+  }
+
+  try {
+    const res = await fetch(`${AGENT_API_URL}/api/agents/process-queue`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': AGENT_API_KEY,
+      },
+      body: JSON.stringify({ limit: 20, includeThumbnail: true }),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return NextResponse.json({ error: data.error || 'Agent API error' }, { status: res.status });
+    }
+
+    return NextResponse.json({
+      processed: data.processed || data.results?.length || 0,
+      results: data.results,
+    });
+  } catch (error) {
+    console.error('Process queue error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Changes

- **Re-enrich now auto-triggers processing** - no extra button click needed
- Added `/api/process-queue` API route (keeps AGENT_API_KEY server-side)
- Added sidebar buttons: Process Queue + Trigger Build

## Flow
1. Click Re-enrich → items set to 'queued'
2. Automatically calls agent-api to start processing
3. Shows status: 'queued, starting enrichment...' → 'Processing started'

## Required
Add `AGENT_API_KEY` to Vercel environment variables