### PR TITLE
improve(KB-189): Add prompt testing playground and stage badges

### DIFF
--- a/admin-next/src/app/api/test-prompt/route.ts
+++ b/admin-next/src/app/api/test-prompt/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// Agent API URL (same one used for processing)
+const AGENT_API_URL = process.env.AGENT_API_URL || 'https://bfsi-insights.onrender.com';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { agentName, promptText, testInput } = body;
+
+    if (!agentName || !promptText || !testInput) {
+      return NextResponse.json(
+        { error: 'Missing required fields: agentName, promptText, testInput' },
+        { status: 400 },
+      );
+    }
+
+    // Call the agent API's test endpoint
+    const response = await fetch(`${AGENT_API_URL}/api/test-prompt`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        agent_name: agentName,
+        prompt_text: promptText,
+        test_input: testInput,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return NextResponse.json(
+        { error: `Agent API error: ${errorText}` },
+        { status: response.status },
+      );
+    }
+
+    const result = await response.json();
+    return NextResponse.json({ result });
+  } catch (error) {
+    console.error('Test prompt error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Phase 3 of admin UX improvements - prompt engineering enhancements.

## Features

### Stage Badges
- Visual stage indicators next to Active status: **Live** (green), **Staged** (amber), **Draft** (gray)
- Uses existing `stage` field from `prompt_versions` table

### Test Playground
- New **Test** button in prompt table and agent detail view
- Modal with:
  - Prompt preview (first 500 chars)
  - Test input textarea for sample content
  - Run test button → calls agent API
  - Output display with JSON formatting

### API
- New `/api/test-prompt` route that proxies to agent API

## Screenshots
_(Will add after testing)_

## Deferred
- Golden Set integration (requires backend work)
- Draft → Staged → Live workflow (needs DB schema changes)

Continues KB-189