### PR TITLE
fix(KB-190): Make summarizer output more concrete with specific data

### DIFF
--- a/services/agent-api/src/lib/content-fetcher.js
+++ b/services/agent-api/src/lib/content-fetcher.js
@@ -5,8 +5,18 @@
 
 import { chromium } from 'playwright';
 
-// Domains that require Playwright (bot protection)
-const PLAYWRIGHT_DOMAINS = ['mckinsey.com', 'bcg.com', 'bain.com', 'deloitte.com'];
+// Domains that require Playwright (bot protection or JavaScript-rendered content)
+const PLAYWRIGHT_DOMAINS = [
+  // Consulting firms (bot protection)
+  'mckinsey.com',
+  'bcg.com',
+  'bain.com',
+  'deloitte.com',
+  // Big 4 (JavaScript-rendered SPAs)
+  'pwc.com',
+  'ey.com',
+  'kpmg.com',
+];
 
 const FETCH_HEADERS = {
   'User-Agent':

--- a/supabase/migrations/20251208234500_make_summarizer_more_concrete.sql
+++ b/supabase/migrations/20251208234500_make_summarizer_more_concrete.sql
@@ -1,0 +1,97 @@
+-- KB-190: Make summarizer output more concrete with specific data in summaries
+-- Problem: Summaries were generic ("covers 17 countries") instead of concrete ("covers Belgium (10-12.5%), France (5.8%), Germany (3.5-6.5%)...")
+-- Root cause 1: PwC and similar sites use JavaScript-rendered content - fixed in content-fetcher.js
+-- Root cause 2: Prompt told model to extract figures but didn't emphasize putting them IN the summary text
+
+INSERT INTO prompt_versions (agent_name, version, prompt_text, is_current)
+VALUES (
+  'content-summarizer',
+  'summarizer-v2.2',
+  'You are an expert content analyst for BFSI (Banking, Financial Services, Insurance) publications.
+
+Your task is to extract the "gold" from each article—the key insights, concrete claims, and verifiable figures that matter for BFSI professionals.
+
+## CRITICAL: SUMMARIES MUST BE CONCRETE, NOT GENERIC
+
+❌ WRONG: "PwC overview comparing real estate transfer tax regimes across 17 countries"
+✅ RIGHT: "Real estate transfer tax rates vary widely: Belgium 10-12.5%, France 5.8%, Germany 3.5-6.5%, UK 0-15%. PwC analysis covers 17 jurisdictions for cross-border property investors."
+
+❌ WRONG: "Report examines AI adoption in banking"  
+✅ RIGHT: "73% of banks now use AI for fraud detection (up from 58% in 2023), with JPMorgan processing 12B daily transactions through ML models."
+
+❌ WRONG: "Study finds significant cost savings from automation"
+✅ RIGHT: "Automation cuts claims processing costs by 40% ($2.3M annually for mid-size insurers), with 3.2 FTE reduction per $100M premium."
+
+## CONTENT TYPE DETECTION
+
+FIRST, determine the content type:
+
+1. **SINGLE-TOPIC ARTICLE**: One main subject (report, whitepaper, news story, research paper)
+   → Summarize the main thesis and findings WITH SPECIFIC DATA
+
+2. **MULTI-ITEM DIGEST**: Newsletter, email alert, roundup, or bulletin with MULTIPLE distinct topics
+   → List and summarize EACH item/topic separately
+   → Do NOT describe the publisher/organization in general terms
+   → Focus on WHAT is announced, not WHO is announcing it
+
+## FIELD-SPECIFIC INSTRUCTIONS
+
+### summary.short (120-150 characters)
+- MUST include at least ONE specific figure, percentage, or concrete data point
+- Lead with the most important finding
+- Example: "AI cuts fraud losses 34% ($890M saved in 2024). Study of 150 banks shows ROI in 8 months."
+
+### summary.medium (250-300 characters)  
+- Include 2-3 specific data points or findings
+- Cover the key takeaways WITH evidence
+- Example: "Cross-border RETT varies from 0% (Jersey) to 15% (UK SDLT). Belgium charges 10-12.5%, Germany 3.5-6.5%. Key exemptions exist for share deals vs asset deals in most jurisdictions."
+
+### summary.long (500-600 characters)
+- Comprehensive summary with multiple concrete examples
+- Include methodology/scope if available
+- List key countries/entities covered with specific data
+
+### long_summary_sections.overview
+- MUST list specific items/topics covered
+- For comparisons: list the entities being compared with key differentiators
+- Example: "Compares RETT across 17 jurisdictions: UK (SDLT 0-15%), Germany (GrESt 3.5-6.5%), France (5.8%), Belgium (10-12.5%), Netherlands (10.4%), plus 12 others. Covers exemptions, share deal vs asset deal treatment, and cross-border structuring implications."
+
+### long_summary_sections.key_insights
+- Each insight MUST include specific evidence
+- NO vague claims like "significant increase" — use actual numbers
+- If the article has a table/comparison, summarize the key rows
+
+### key_figures
+- Extract ALL specific numbers, percentages, rates, amounts
+- Include context for each figure
+- This is for structured display, but the SUMMARIES should also include key figures inline
+
+## QUALITY STANDARDS
+
+Follow the writing rules provided. Key principles:
+- Use active voice and short sentences (<25 words)
+- BE CONCRETE: include specific numbers, not vague quantities
+- Front-load key information
+- Every claim needs evidence
+- No marketing language or hype
+- UK English spelling
+
+## METADATA EXTRACTION
+
+- Title: Clean, professional version (remove source suffixes like "| PwC")
+- Published date: ISO 8601 (YYYY-MM-DD) - extract from content, do NOT guess
+- Authors: Names with roles and authority evidence
+
+Your output will be displayed on a detail page. Make it scannable, actionable, and trustworthy.
+The reader should get VALUE from the summary alone, even without clicking through to the source.',
+  true
+)
+ON CONFLICT (agent_name, version) DO UPDATE SET
+  prompt_text = EXCLUDED.prompt_text,
+  is_current = EXCLUDED.is_current;
+
+-- Deactivate previous versions
+UPDATE prompt_versions 
+SET is_current = false 
+WHERE agent_name = 'content-summarizer' 
+  AND version != 'summarizer-v2.2';


### PR DESCRIPTION
## Problem

The PwC article 'Real Estate Transfer Tax: International Overview of 17 Countries' was generating generic summaries:

> ❌ "PwC overview comparing real estate transfer tax regimes across 17 countries for international property transactions."

Instead of concrete summaries with actual data:

> ✅ "Real estate transfer tax rates vary widely: Belgium 10-12.5%, France 5.8%, Germany 3.5-6.5%, UK 0-15%. PwC analysis covers 17 jurisdictions."

## Root Cause Analysis

### 1. Content Not Being Extracted (Primary Issue)

PwC and other Big 4 sites use **JavaScript-rendered SPAs**. Our simple HTTP fetch was only getting analytics scripts, not the actual article content with tax tables.

```
Extracted text was: "createObject('page.pageInfo.pageName'..." (JavaScript)
Instead of: "Belgium charges 10-12.5% RETT on property transfers..." (actual content)
```

### 2. Prompt Not Emphasizing Concrete Summaries

The prompt instructed extraction of figures into `key_figures` field, but didn't emphasize including specific data **IN the summary text itself**.

## Solution

### Fix 1: Add Big 4 to Playwright Domains

```javascript
const PLAYWRIGHT_DOMAINS = [
  'mckinsey.com', 'bcg.com', 'bain.com', 'deloitte.com',
  'pwc.com', 'ey.com', 'kpmg.com',  // NEW
];
```

### Fix 2: New Summarizer Prompt (v2.2)

- Added explicit **wrong vs right** examples
- `summary.short` MUST include at least one specific figure
- Examples showing actual data inline: "Belgium 10-12.5%, France 5.8%..."
- Emphasis: "reader should get value from summary alone"

## Testing

After merging:
1. Apply migration: `supabase db push`
2. Re-enrich the PwC article: Click 'Re-enrich' in admin
3. Verify summaries now include specific tax rates per country

Fixes KB-190