### PR TITLE
fix: Add unique index for prompt_versions ON CONFLICT

### DIFF
--- a/supabase/migrations/20251208234500_make_summarizer_more_concrete.sql
+++ b/supabase/migrations/20251208234500_make_summarizer_more_concrete.sql
@@ -3,6 +3,10 @@
 -- Root cause 1: PwC and similar sites use JavaScript-rendered content - fixed in content-fetcher.js
 -- Root cause 2: Prompt told model to extract figures but didn't emphasize putting them IN the summary text
 
+-- Add unique constraint for ON CONFLICT to work
+CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_versions_agent_version 
+ON prompt_versions(agent_name, version);
+
 INSERT INTO prompt_versions (agent_name, version, prompt_text, is_current)
 VALUES (
   'content-summarizer',


### PR DESCRIPTION
Adds a unique index on `(agent_name, version)` to `prompt_versions` table so that `INSERT ... ON CONFLICT` works for prompt upserts.

Without this, migrations using `ON CONFLICT (agent_name, version)` fail with:
```
ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

This was needed for the summarizer prompt update migration.