### PR TITLE
feat: create reusable HierarchicalFilter component

### DIFF
--- a/src/components/HierarchicalFilter.astro
+++ b/src/components/HierarchicalFilter.astro
@@ -1,0 +1,294 @@
+---
+/**
+ * HierarchicalFilter - Reusable hierarchical filter with collapsible sections
+ *
+ * Renders a multi-level collapsible filter with cascading checkboxes.
+ * Used for Industry, Geography, and Process filters.
+ */
+
+interface TaxonomyItem {
+  code: string;
+  name: string;
+  level: number;
+  parent_code: string | null;
+  children?: TaxonomyItem[];
+  count?: number;
+}
+
+interface Props {
+  /** Filter key used in checkbox name, e.g. "industry" -> name="filter-industry" */
+  filterKey: string;
+  /** Hierarchical data to display */
+  items: TaxonomyItem[];
+  /** Color scheme for selected state */
+  color?: 'cyan' | 'sky' | 'emerald' | 'amber' | 'purple';
+  /** Empty state message */
+  emptyMessage?: string;
+  /** CSS class prefix for cascade behavior (e.g. "industry" for .industry-checkbox) */
+  cascadeClass?: string;
+  /** L1 codes to flatten - item stays at L1 (no children), its children become L1 siblings */
+  flattenRoots?: string[];
+}
+
+const {
+  filterKey,
+  items,
+  color = 'cyan',
+  emptyMessage = 'No items available',
+  cascadeClass,
+  flattenRoots = [],
+} = Astro.props;
+
+// Flatten specified roots: item becomes childless L1, its children become L1 siblings
+const flattenItems = (items: TaxonomyItem[], rootsToFlatten: string[]): TaxonomyItem[] => {
+  if (rootsToFlatten.length === 0) return items;
+  const result: TaxonomyItem[] = [];
+  for (const item of items) {
+    if (rootsToFlatten.includes(item.code)) {
+      // Promote children to L1 level as siblings
+      if (item.children && item.children.length > 0) {
+        result.push(...item.children.map((child) => ({ ...child, level: 1, parent_code: null })));
+      }
+      // Keep the item itself as childless L1
+      result.push({ ...item, children: [], level: 1, parent_code: null });
+    } else {
+      result.push(item);
+    }
+  }
+  return result;
+};
+
+const displayItems = flattenItems(items, flattenRoots);
+
+// Color scheme mappings
+const colorClasses: Record<string, { checkbox: string; pill: string }> = {
+  cyan: {
+    checkbox: 'text-cyan-500 focus:ring-cyan-500',
+    pill: 'peer-checked:border-cyan-500 peer-checked:bg-cyan-500/10 peer-checked:text-cyan-300',
+  },
+  sky: {
+    checkbox: 'text-sky-500 focus:ring-sky-500',
+    pill: 'peer-checked:border-sky-500 peer-checked:bg-sky-500/10 peer-checked:text-sky-300',
+  },
+  emerald: {
+    checkbox: 'text-emerald-500 focus:ring-emerald-500',
+    pill: 'peer-checked:border-emerald-500 peer-checked:bg-emerald-500/10 peer-checked:text-emerald-300',
+  },
+  amber: {
+    checkbox: 'text-amber-500 focus:ring-amber-500',
+    pill: 'peer-checked:border-amber-500 peer-checked:bg-amber-500/10 peer-checked:text-amber-300',
+  },
+  purple: {
+    checkbox: 'text-purple-500 focus:ring-purple-500',
+    pill: 'peer-checked:border-purple-500 peer-checked:bg-purple-500/10 peer-checked:text-purple-300',
+  },
+};
+
+const colors = colorClasses[color] || colorClasses.cyan;
+const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
+---
+
+{
+  displayItems.length > 0 ? (
+    <div class="space-y-2">
+      {displayItems.map((l1) => (
+        <details
+          class={`${cascadeClass}-l1 border border-neutral-800/50 rounded-md overflow-hidden`}
+          data-code={l1.code}
+        >
+          <summary class="flex items-center justify-between px-3 py-2 cursor-pointer bg-neutral-900/30 hover:bg-neutral-800/30 transition-colors text-xs">
+            <div class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                name={`filter-${filterKey}`}
+                value={l1.code}
+                class:list={[
+                  checkboxClass,
+                  'h-3.5 w-3.5 rounded border-neutral-600 bg-neutral-800 focus:ring-offset-0 cursor-pointer',
+                  colors.checkbox,
+                ]}
+                data-level="1"
+                data-code={l1.code}
+                onclick="event.stopPropagation()"
+              />
+              <span class="font-medium text-neutral-400 uppercase tracking-wider">{l1.name}</span>
+            </div>
+            <svg
+              class="w-3.5 h-3.5 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </summary>
+          <div class="px-3 py-2 bg-neutral-950/30 space-y-1.5">
+            {/* L2 items - always rows with checkboxes, collapsible if they have children */}
+            {l1.children?.map((l2) => (
+              <details
+                class={`${cascadeClass}-l2 ml-2 border border-neutral-800/40 rounded overflow-hidden`}
+                data-code={l2.code}
+                data-parent={l1.code}
+              >
+                <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-neutral-900/20 hover:bg-neutral-800/30 transition-colors">
+                  <div class="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name={`filter-${filterKey}`}
+                      value={l2.code}
+                      class:list={[
+                        checkboxClass,
+                        'h-3 w-3 rounded border-neutral-600 bg-neutral-800 focus:ring-offset-0 cursor-pointer',
+                        colors.checkbox,
+                      ]}
+                      data-level="2"
+                      data-code={l2.code}
+                      data-parent={l1.code}
+                      onclick="event.stopPropagation()"
+                    />
+                    <span class="text-[11px] font-medium text-neutral-400 uppercase tracking-wide">
+                      {l2.name}
+                      {l2.count ? (
+                        <span class="text-neutral-500 font-normal normal-case ml-1">
+                          {l2.count}
+                        </span>
+                      ) : null}
+                    </span>
+                  </div>
+                  {l2.children && l2.children.length > 0 && (
+                    <svg
+                      class="w-3 h-3 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M19 9l-7 7-7-7"
+                      />
+                    </svg>
+                  )}
+                </summary>
+                {l2.children && l2.children.length > 0 && (
+                  <div class="px-2.5 py-2 bg-neutral-950/20 flex flex-wrap gap-1.5">
+                    {l2.children?.map((l3) =>
+                      l3.children && l3.children.length > 0 ? (
+                        // L3 with children - collapsible (e.g. European Union → countries)
+                        <details
+                          class={`${cascadeClass}-l3 w-full border border-neutral-800/40 rounded overflow-hidden`}
+                          data-code={l3.code}
+                          data-parent={l2.code}
+                        >
+                          <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-neutral-900/20 hover:bg-neutral-800/30 transition-colors">
+                            <div class="flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                name={`filter-${filterKey}`}
+                                value={l3.code}
+                                class:list={[
+                                  checkboxClass,
+                                  'h-3 w-3 rounded border-neutral-600 bg-neutral-800 focus:ring-offset-0 cursor-pointer',
+                                  colors.checkbox,
+                                ]}
+                                data-level="3"
+                                data-code={l3.code}
+                                data-parent={l2.code}
+                                onclick="event.stopPropagation()"
+                              />
+                              <span class="text-[11px] font-medium text-neutral-400 uppercase tracking-wide">
+                                {l3.name}
+                                {l3.count ? (
+                                  <span class="text-neutral-500 font-normal normal-case ml-1">
+                                    {l3.count}
+                                  </span>
+                                ) : null}
+                              </span>
+                            </div>
+                            <svg
+                              class="w-3 h-3 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M19 9l-7 7-7-7"
+                              />
+                            </svg>
+                          </summary>
+                          <div class="px-2.5 py-2 bg-neutral-950/20 flex flex-wrap gap-1.5">
+                            {l3.children?.map((l4) => (
+                              <label class="filter-checkbox cursor-pointer">
+                                <input
+                                  type="checkbox"
+                                  name={`filter-${filterKey}`}
+                                  value={l4.code}
+                                  class:list={[checkboxClass, 'sr-only peer']}
+                                  data-level="4"
+                                  data-code={l4.code}
+                                  data-parent={l3.code}
+                                />
+                                <span
+                                  class:list={[
+                                    'inline-flex items-center gap-1 px-2 py-1 rounded text-xs',
+                                    'border border-neutral-700/70 bg-neutral-900/70 text-neutral-400',
+                                    'transition-all hover:border-neutral-600 hover:bg-neutral-800',
+                                    colors.pill,
+                                  ]}
+                                >
+                                  {l4.name}
+                                  {l4.count ? (
+                                    <span class="text-neutral-500">{l4.count}</span>
+                                  ) : null}
+                                </span>
+                              </label>
+                            ))}
+                          </div>
+                        </details>
+                      ) : (
+                        // L3 without children - pill
+                        <label class="filter-checkbox cursor-pointer">
+                          <input
+                            type="checkbox"
+                            name={`filter-${filterKey}`}
+                            value={l3.code}
+                            class:list={[checkboxClass, 'sr-only peer']}
+                            data-level="3"
+                            data-code={l3.code}
+                            data-parent={l2.code}
+                          />
+                          <span
+                            class:list={[
+                              'inline-flex items-center gap-1 px-2 py-1 rounded text-xs',
+                              'border border-neutral-700/70 bg-neutral-900/70 text-neutral-400',
+                              'transition-all hover:border-neutral-600 hover:bg-neutral-800',
+                              colors.pill,
+                            ]}
+                          >
+                            {l3.name}
+                            {l3.count ? <span class="text-neutral-500">{l3.count}</span> : null}
+                          </span>
+                        </label>
+                      ),
+                    )}
+                  </div>
+                )}
+              </details>
+            ))}
+          </div>
+        </details>
+      ))}
+    </div>
+  ) : (
+    <p class="text-xs text-neutral-500 italic">{emptyMessage}</p>
+  )
+}

--- a/src/features/publications/hierarchy-cascade.ts
+++ b/src/features/publications/hierarchy-cascade.ts
@@ -1,0 +1,101 @@
+/**
+ * Hierarchical filter cascading selection logic
+ *
+ * When a parent checkbox (L1/L2) is checked/unchecked, all children cascade.
+ * When a child is changed, parent shows indeterminate state if partial selection.
+ *
+ * Generic version that works with any hierarchical filter (industry, geography, process).
+ */
+
+export function initHierarchyCascade(classPrefix: string): void {
+  const selector = `.${classPrefix}-checkbox`;
+  const checkboxes = document.querySelectorAll(selector);
+
+  checkboxes.forEach((checkbox) => {
+    checkbox.addEventListener('change', (e) => {
+      const target = e.target as HTMLInputElement;
+      const level = target.dataset.level;
+      const code = target.dataset.code;
+      const isChecked = target.checked;
+
+      if (level === '1') {
+        // L1 checked/unchecked: cascade to all descendants
+        cascadeDown(code!, isChecked, selector);
+      } else if (level === '2') {
+        // L2 checked/unchecked: cascade to all L3s and L4s
+        cascadeDown(code!, isChecked, selector);
+        // Update parent L1 state
+        updateParentState(target.dataset.parent!, '1', selector);
+      } else if (level === '3') {
+        // L3 checked/unchecked: cascade to all L4s
+        cascadeDown(code!, isChecked, selector);
+        // Update parent L2 and L1 states
+        updateParentState(target.dataset.parent!, '2', selector);
+      } else if (level === '4') {
+        // L4 changed: update parent L3, L2, L1 states
+        updateParentState(target.dataset.parent!, '3', selector);
+      }
+
+      // Trigger change event for filter system
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  });
+}
+
+// Cascade check state down to all descendants
+function cascadeDown(parentCode: string, isChecked: boolean, selector: string): void {
+  const children = document.querySelectorAll(`${selector}[data-parent="${parentCode}"]`);
+  children.forEach((child) => {
+    (child as HTMLInputElement).checked = isChecked;
+    const childCode = (child as HTMLInputElement).dataset.code;
+    if (childCode) cascadeDown(childCode, isChecked, selector);
+  });
+}
+
+function updateParentState(parentCode: string, parentLevel: string, selector: string): void {
+  const parentCheckbox = document.querySelector(
+    `${selector}[data-code="${parentCode}"][data-level="${parentLevel}"]`,
+  ) as HTMLInputElement;
+  if (!parentCheckbox) return;
+
+  const childCheckboxes = document.querySelectorAll(`${selector}[data-parent="${parentCode}"]`);
+  const children = Array.from(childCheckboxes) as HTMLInputElement[];
+
+  const checkedCount = children.filter((c) => c.checked).length;
+  const indeterminateCount = children.filter((c) => c.indeterminate).length;
+  const totalChildren = children.length;
+
+  if (checkedCount === 0 && indeterminateCount === 0) {
+    // No children checked or indeterminate
+    parentCheckbox.checked = false;
+    parentCheckbox.indeterminate = false;
+  } else if (checkedCount === totalChildren && indeterminateCount === 0) {
+    // All children fully checked
+    parentCheckbox.checked = true;
+    parentCheckbox.indeterminate = false;
+  } else {
+    // Some children checked or some indeterminate
+    parentCheckbox.checked = false;
+    parentCheckbox.indeterminate = true;
+  }
+
+  // Recursively update ancestors
+  const grandparentCode = parentCheckbox.dataset.parent;
+  if (grandparentCode) {
+    const grandparentLevel = String(parseInt(parentLevel) - 1);
+    if (parseInt(grandparentLevel) >= 1) {
+      updateParentState(grandparentCode, grandparentLevel, selector);
+    }
+  }
+}
+
+/**
+ * Initialize cascade behavior for all hierarchical filters
+ */
+export function initAllHierarchyCascades(): void {
+  initHierarchyCascade('industry');
+  initHierarchyCascade('geography');
+  initHierarchyCascade('process');
+}
+
+export default initHierarchyCascade;

--- a/src/features/publications/industry-cascade.ts
+++ b/src/features/publications/industry-cascade.ts
@@ -1,89 +1,14 @@
 /**
  * Industry filter cascading selection logic
  *
- * When a parent checkbox (L1/L2) is checked/unchecked, all children cascade.
- * When a child is changed, parent shows indeterminate state if partial selection.
- *
- * Extracted from publications.astro for reusability
+ * @deprecated Use initHierarchyCascade from hierarchy-cascade.ts instead
+ * This file is kept for backward compatibility.
  */
 
+import { initHierarchyCascade } from './hierarchy-cascade';
+
 export function initIndustryCascade(): void {
-  const checkboxes = document.querySelectorAll('.industry-checkbox');
-
-  checkboxes.forEach((checkbox) => {
-    checkbox.addEventListener('change', (e) => {
-      const target = e.target as HTMLInputElement;
-      const level = target.dataset.level;
-      const code = target.dataset.code;
-      const isChecked = target.checked;
-
-      if (level === '1') {
-        // L1 checked/unchecked: cascade to all L2s and L3s
-        const l2Checkboxes = document.querySelectorAll(`.industry-checkbox[data-parent="${code}"]`);
-        l2Checkboxes.forEach((l2) => {
-          (l2 as HTMLInputElement).checked = isChecked;
-          // Also cascade to L3s under this L2
-          const l2Code = (l2 as HTMLInputElement).dataset.code;
-          const l3Checkboxes = document.querySelectorAll(
-            `.industry-checkbox[data-parent="${l2Code}"]`,
-          );
-          l3Checkboxes.forEach((l3) => {
-            (l3 as HTMLInputElement).checked = isChecked;
-          });
-        });
-      } else if (level === '2') {
-        // L2 checked/unchecked: cascade to all L3s
-        const l3Checkboxes = document.querySelectorAll(`.industry-checkbox[data-parent="${code}"]`);
-        l3Checkboxes.forEach((l3) => {
-          (l3 as HTMLInputElement).checked = isChecked;
-        });
-        // Update parent L1 state
-        updateParentState(target.dataset.parent!, '1');
-      } else if (level === '3') {
-        // L3 changed: update parent L2 and L1 states
-        updateParentState(target.dataset.parent!, '2');
-      }
-
-      // Trigger change event for filter system
-      target.dispatchEvent(new Event('input', { bubbles: true }));
-    });
-  });
-
-  function updateParentState(parentCode: string, parentLevel: string): void {
-    const parentCheckbox = document.querySelector(
-      `.industry-checkbox[data-code="${parentCode}"][data-level="${parentLevel}"]`,
-    ) as HTMLInputElement;
-    if (!parentCheckbox) return;
-
-    const childCheckboxes = document.querySelectorAll(
-      `.industry-checkbox[data-parent="${parentCode}"]`,
-    );
-    const children = Array.from(childCheckboxes) as HTMLInputElement[];
-
-    const checkedCount = children.filter((c) => c.checked).length;
-    const indeterminateCount = children.filter((c) => c.indeterminate).length;
-    const totalChildren = children.length;
-
-    if (checkedCount === 0 && indeterminateCount === 0) {
-      // No children checked or indeterminate
-      parentCheckbox.checked = false;
-      parentCheckbox.indeterminate = false;
-    } else if (checkedCount === totalChildren && indeterminateCount === 0) {
-      // All children fully checked
-      parentCheckbox.checked = true;
-      parentCheckbox.indeterminate = false;
-    } else {
-      // Some children checked or some indeterminate
-      parentCheckbox.checked = false;
-      parentCheckbox.indeterminate = true;
-    }
-
-    // If this was L2, also update L1
-    if (parentLevel === '2') {
-      const l1Code = parentCheckbox.dataset.parent;
-      if (l1Code) updateParentState(l1Code, '1');
-    }
-  }
+  initHierarchyCascade('industry');
 }
 
 export default initIndustryCascade;

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -9,6 +9,7 @@ import { createClient } from '@supabase/supabase-js';
 import PublicationCard from '../features/publications/PublicationCard.astro';
 import FloatingFilterButton from '../components/FloatingFilterButton.astro';
 import BackToTopButton from '../components/BackToTopButton.astro';
+import HierarchicalFilter from '../components/HierarchicalFilter.astro';
 
 // Fetch all publications
 const publications: Publication[] = await getAllPublications();
@@ -38,10 +39,10 @@ const { data: processTaxonomy } = await supabase
   .select('code, name, level, parent_code, sort_order')
   .order('sort_order');
 
-// Load geography lookup
+// Load geography hierarchy
 const { data: geographyData } = await supabase
   .from('kb_geography')
-  .select('code, name, sort_order')
+  .select('code, name, level, parent_code, sort_order')
   .order('sort_order');
 
 // geographyLookup used when displaying geography names in filter chips
@@ -81,6 +82,7 @@ const buildHierarchy = (items: TaxonomyItem[] | null): TaxonomyItem[] => {
 
 const industryHierarchy = buildHierarchy(industryTaxonomy as TaxonomyItem[] | null);
 const processHierarchy = buildHierarchy(processTaxonomy as TaxonomyItem[] | null);
+const geographyHierarchy = buildHierarchy(geographyData as TaxonomyItem[] | null);
 
 // Count publications per taxonomy code
 const countByIndustry = new Map<string, number>();
@@ -108,17 +110,6 @@ publications.forEach((p) => {
   }
 });
 
-// Build geography filter options with counts, sorted by sort_order
-const geographyFilterOptions = (geographyData || [])
-  .filter((g) => countByGeography.has(g.code))
-  .map((g) => ({
-    code: g.code,
-    name: g.name,
-    count: countByGeography.get(g.code) || 0,
-    sort_order: g.sort_order,
-  }))
-  .sort((a, b) => a.sort_order - b.sort_order);
-
 // Add counts to hierarchy
 const addCounts = (items: TaxonomyItem[], countMap: Map<string, number>): TaxonomyItem[] => {
   return items.map((item) => ({
@@ -127,6 +118,9 @@ const addCounts = (items: TaxonomyItem[], countMap: Map<string, number>): Taxono
     children: item.children ? addCounts(item.children, countMap) : [],
   }));
 };
+
+// Add counts to geography hierarchy
+const geographyWithCounts = addCounts(geographyHierarchy, countByGeography);
 
 const industryWithCounts = addCounts(industryHierarchy, countByIndustry);
 const processWithCounts = addCounts(processHierarchy, countByProcess);
@@ -383,116 +377,14 @@ const expandItemThumb = (t: string | undefined) => {
                   d="M19 9l-7 7-7-7"></path>
               </svg>
             </summary>
-            <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800 space-y-2">
-              {
-                industryWithCounts.map((l1) => (
-                  <details
-                    class="industry-l1 border border-neutral-800/50 rounded-md overflow-hidden"
-                    data-code={l1.code}
-                  >
-                    <summary class="flex items-center justify-between px-3 py-2 cursor-pointer bg-neutral-900/30 hover:bg-neutral-800/30 transition-colors text-xs">
-                      <div class="flex items-center gap-2">
-                        <input
-                          type="checkbox"
-                          name="filter-industry"
-                          value={l1.code}
-                          class="industry-checkbox h-3.5 w-3.5 rounded border-neutral-600 bg-neutral-800 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 cursor-pointer"
-                          data-level="1"
-                          data-code={l1.code}
-                          onclick="event.stopPropagation()"
-                        />
-                        <span class="font-medium text-neutral-400 uppercase tracking-wider">
-                          {l1.name}
-                        </span>
-                      </div>
-                      <svg
-                        class="w-3.5 h-3.5 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M19 9l-7 7-7-7"
-                        />
-                      </svg>
-                    </summary>
-                    <div class="px-3 py-2 bg-neutral-950/30 space-y-1.5">
-                      {/* L2 items - collapsible sections */}
-                      {l1.children?.map((l2) => (
-                        <details
-                          class="industry-l2 ml-2 border border-neutral-800/40 rounded overflow-hidden"
-                          data-code={l2.code}
-                          data-parent={l1.code}
-                        >
-                          <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-neutral-900/20 hover:bg-neutral-800/30 transition-colors">
-                            <div class="flex items-center gap-2">
-                              <input
-                                type="checkbox"
-                                name="filter-industry"
-                                value={l2.code}
-                                class="industry-checkbox h-3 w-3 rounded border-neutral-600 bg-neutral-800 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 cursor-pointer"
-                                data-level="2"
-                                data-code={l2.code}
-                                data-parent={l1.code}
-                                onclick="event.stopPropagation()"
-                              />
-                              <span class="text-[11px] font-medium text-neutral-400 uppercase tracking-wide">
-                                {l2.name}
-                                {l2.count ? (
-                                  <span class="text-neutral-500 font-normal normal-case ml-1">
-                                    {l2.count}
-                                  </span>
-                                ) : null}
-                              </span>
-                            </div>
-                            {l2.children && l2.children.length > 0 && (
-                              <svg
-                                class="w-3 h-3 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  stroke-width="2"
-                                  d="M19 9l-7 7-7-7"
-                                />
-                              </svg>
-                            )}
-                          </summary>
-                          {l2.children && l2.children.length > 0 && (
-                            <div class="px-2.5 py-2 bg-neutral-950/20 flex flex-wrap gap-1.5">
-                              {l2.children?.map((l3) => (
-                                <label class="filter-checkbox cursor-pointer">
-                                  <input
-                                    type="checkbox"
-                                    name="filter-industry"
-                                    value={l3.code}
-                                    class="industry-checkbox sr-only peer"
-                                    data-level="3"
-                                    data-code={l3.code}
-                                    data-parent={l2.code}
-                                  />
-                                  <span class="inline-flex items-center gap-1 px-2 py-1 rounded text-xs border border-neutral-700/70 bg-neutral-900/70 text-neutral-400 transition-all peer-checked:border-cyan-500 peer-checked:bg-cyan-500/10 peer-checked:text-cyan-300 hover:border-neutral-600 hover:bg-neutral-800">
-                                    {l3.name}
-                                    {l3.count ? (
-                                      <span class="text-neutral-500">{l3.count}</span>
-                                    ) : null}
-                                  </span>
-                                </label>
-                              ))}
-                            </div>
-                          )}
-                        </details>
-                      ))}
-                    </div>
-                  </details>
-                ))
-              }
+            <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800">
+              <HierarchicalFilter
+                filterKey="industry"
+                items={industryWithCounts}
+                color="cyan"
+                emptyMessage="No industry tags yet"
+                cascadeClass="industry"
+              />
             </div>
           </details>
 
@@ -518,53 +410,14 @@ const expandItemThumb = (t: string | undefined) => {
                   d="M19 9l-7 7-7-7"></path>
               </svg>
             </summary>
-            <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800 space-y-2">
-              {
-                processWithCounts.length > 0 ? (
-                  processWithCounts.map((l1) => (
-                    <details class="border border-neutral-800/50 rounded-md overflow-hidden">
-                      <summary class="flex items-center justify-between px-3 py-2 cursor-pointer bg-neutral-900/30 hover:bg-neutral-800/30 transition-colors text-xs">
-                        <span class="font-medium text-neutral-400 uppercase tracking-wider">
-                          {l1.name}
-                        </span>
-                        <svg
-                          class="w-3.5 h-3.5 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M19 9l-7 7-7-7"
-                          />
-                        </svg>
-                      </summary>
-                      <div class="px-3 py-2 bg-neutral-950/30">
-                        <div class="flex flex-wrap gap-1.5">
-                          {l1.children?.map((l2) => (
-                            <label class="filter-checkbox cursor-pointer">
-                              <input
-                                type="checkbox"
-                                name="filter-process"
-                                value={l2.code}
-                                class="sr-only peer"
-                              />
-                              <span class="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs border border-neutral-700 bg-neutral-900 text-neutral-300 transition-all peer-checked:border-emerald-500 peer-checked:bg-emerald-500/10 peer-checked:text-emerald-300 hover:border-neutral-600 hover:bg-neutral-800">
-                                {l2.name}
-                                {l2.count ? <span class="text-neutral-500">{l2.count}</span> : null}
-                              </span>
-                            </label>
-                          ))}
-                        </div>
-                      </div>
-                    </details>
-                  ))
-                ) : (
-                  <p class="text-xs text-neutral-500 italic">No process tags yet</p>
-                )
-              }
+            <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800">
+              <HierarchicalFilter
+                filterKey="process"
+                items={processWithCounts}
+                color="emerald"
+                emptyMessage="No process tags yet"
+                cascadeClass="process"
+              />
             </div>
           </details>
 
@@ -591,28 +444,14 @@ const expandItemThumb = (t: string | undefined) => {
               </svg>
             </summary>
             <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800">
-              {
-                geographyFilterOptions.length > 0 ? (
-                  <div class="flex flex-wrap gap-2">
-                    {geographyFilterOptions.map((g) => (
-                      <label class="filter-checkbox cursor-pointer">
-                        <input
-                          type="checkbox"
-                          name="filter-geography"
-                          value={g.code}
-                          class="sr-only peer"
-                        />
-                        <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm border border-neutral-700 bg-neutral-900 text-neutral-300 transition-all peer-checked:border-sky-500 peer-checked:bg-sky-500/10 peer-checked:text-sky-300 hover:border-neutral-600 hover:bg-neutral-800">
-                          {g.name}
-                          <span class="text-xs text-neutral-500">{g.count}</span>
-                        </span>
-                      </label>
-                    ))}
-                  </div>
-                ) : (
-                  <p class="text-xs text-neutral-500 italic">No geography tags yet</p>
-                )
-              }
+              <HierarchicalFilter
+                filterKey="geography"
+                items={geographyWithCounts}
+                color="sky"
+                emptyMessage="No geography tags yet"
+                cascadeClass="geography"
+                flattenRoots={['GLOBAL']}
+              />
             </div>
           </details>
 
@@ -803,9 +642,9 @@ const expandItemThumb = (t: string | undefined) => {
     initMultiSelectFilters();
   </script>
 
-  <!-- Industry cascading selection -->
+  <!-- Hierarchical filter cascading selection (industry, geography, process) -->
   <script>
-    import initIndustryCascade from '../features/publications/industry-cascade.ts';
-    initIndustryCascade();
+    import { initAllHierarchyCascades } from '../features/publications/hierarchy-cascade.ts';
+    initAllHierarchyCascades();
   </script>
 </Base>


### PR DESCRIPTION
## Summary
- Add reusable HierarchicalFilter.astro component for Industry, Geography, Process filters
- Support up to 4 levels of hierarchy (L1 > L2 > L3 > L4)
- Add flattenRoots prop to flatten specific L1 items (e.g. GLOBAL in Geography)
- Add hierarchy-cascade.ts for generic cascading checkbox behavior
- Consistent styling and behavior across all filter types

## Changes
- `src/components/HierarchicalFilter.astro` - new reusable component
- `src/features/publications/hierarchy-cascade.ts` - generic cascade logic
- `src/features/publications/industry-cascade.ts` - now uses generic cascade
- `src/pages/publications.astro` - uses component for all hierarchical filters