### PR TITLE
fix(KB-193): handle duplicate URL constraint silently in premium discover

### DIFF
--- a/services/agent-api/src/agents/discover.js
+++ b/services/agent-api/src/agents/discover.js
@@ -582,6 +582,11 @@ async function processPremiumCandidates(candidates, source, dryRun, limit, stats
       .single();
 
     if (error) {
+      // Duplicate is expected (race condition with URL normalization)
+      if (error.code === '23505') {
+        stats.duplicate = (stats.duplicate || 0) + 1;
+        continue;
+      }
       console.error(`   ❌ Failed to queue: ${error.message}`);
       continue;
     }


### PR DESCRIPTION
Fixes KB-193

Premium source inserts now handle duplicate key errors (23505) silently like regular inserts do, instead of showing alarming error messages.

The issue was a race condition where `checkExists()` uses JS URL normalization but the database uses its own trigger-based normalization, which can differ slightly.