### PR TITLE
feat(KB-195): add granular pipeline status numbering system

### DIFF
--- a/docs/architecture/pipeline-status-codes.md
+++ b/docs/architecture/pipeline-status-codes.md
@@ -1,0 +1,198 @@
+# Pipeline Status Codes
+
+This document defines the granular status numbering system for the ingestion pipeline.
+
+## Overview
+
+The pipeline uses a layered numeric status system where:
+
+- **100s** = Discovery stages
+- **200s** = Enrichment stages
+- **300s** = Review stages
+- **400s** = Published states
+- **500s** = Terminal/Error states
+
+Each processing step has three states:
+
+- `X0` = Ready/waiting (e.g., `210 = to_summarize`)
+- `X1` = In progress (e.g., `211 = summarizing`)
+- `X2` = Complete (e.g., `212 = summarized`)
+
+## Benefits
+
+1. **Reorder pipeline** - Can run tagging before summarization
+2. **Parallel processing** - Items at different `to_*` states can run simultaneously
+3. **Resume from failure** - If `211 summarizing` fails, retry from `210 to_summarize`
+4. **Metrics** - Measure duration of each step
+5. **Bottleneck detection** - See where items pile up
+6. **History tracking** - Know exactly what changed and when
+
+## Status Codes
+
+### 100s - Discovery
+
+| Code | Name         | Description                       |
+| ---- | ------------ | --------------------------------- |
+| 100  | `discovered` | URL found in RSS/sitemap          |
+| 110  | `to_fetch`   | Ready to fetch content            |
+| 111  | `fetching`   | Fetch in progress                 |
+| 112  | `fetched`    | Content retrieved                 |
+| 120  | `to_score`   | Ready for relevance scoring       |
+| 121  | `scoring`    | LLM/embedding scoring in progress |
+| 122  | `scored`     | Score assigned, ready to route    |
+
+### 200s - Enrichment
+
+| Code | Name                 | Description                   |
+| ---- | -------------------- | ----------------------------- |
+| 200  | `pending_enrichment` | In queue, awaiting first step |
+| 210  | `to_summarize`       | Ready for summary generation  |
+| 211  | `summarizing`        | Summary agent working         |
+| 212  | `summarized`         | Summary complete              |
+| 220  | `to_tag`             | Ready for tagging             |
+| 221  | `tagging`            | Tag agent working             |
+| 222  | `tagged`             | Tags extracted                |
+| 230  | `to_thumbnail`       | Ready for thumbnail           |
+| 231  | `thumbnailing`       | Thumbnail agent working       |
+| 232  | `thumbnailed`        | Thumbnail generated           |
+| 240  | `enriched`           | All enrichment complete       |
+
+### 300s - Review
+
+| Code | Name             | Description                |
+| ---- | ---------------- | -------------------------- |
+| 300  | `pending_review` | Awaiting curator           |
+| 310  | `in_review`      | Curator opened item        |
+| 320  | `editing`        | Curator making changes     |
+| 330  | `approved`       | Approved, ready to publish |
+
+### 400s - Published
+
+| Code | Name        | Description                           |
+| ---- | ----------- | ------------------------------------- |
+| 400  | `published` | Live on site                          |
+| 410  | `updated`   | Republished after edit (with history) |
+
+### 500s - Terminal/Error
+
+| Code | Name          | Description                 |
+| ---- | ------------- | --------------------------- |
+| 500  | `failed`      | Technical error (retryable) |
+| 510  | `unreachable` | URL 404/timeout             |
+| 520  | `duplicate`   | Duplicate URL/content       |
+| 530  | `irrelevant`  | Auto-filtered by scoring    |
+| 540  | `rejected`    | Human rejected              |
+
+## State Transitions
+
+```
+Discovery Flow:
+100 → 110 → 111 → 112 → 120 → 121 → 122 → 200
+                                      ↓
+                                     530 (irrelevant)
+
+Enrichment Flow (configurable order):
+200 → 210 → 211 → 212 → 220 → 221 → 222 → 230 → 231 → 232 → 240 → 300
+
+Review Flow:
+300 → 310 → 320 → 330 → 400
+        ↓
+       540 (rejected)
+
+Update Flow:
+400 → 320 (editing) → 410 (updated)
+```
+
+## Database Schema
+
+### status_lookup table
+
+```sql
+CREATE TABLE status_lookup (
+  code smallint PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  description text,
+  category text NOT NULL,  -- 'discovery', 'enrichment', 'review', 'published', 'terminal'
+  is_terminal boolean DEFAULT false,
+  sort_order smallint
+);
+```
+
+### status_history table
+
+```sql
+CREATE TABLE status_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  queue_id uuid REFERENCES ingestion_queue(id) ON DELETE CASCADE,
+  from_status smallint REFERENCES status_lookup(code),
+  to_status smallint REFERENCES status_lookup(code),
+  changed_at timestamptz DEFAULT now(),
+  changed_by text,  -- 'agent:summarize', 'user:rick', 'system:auto'
+  changes jsonb,    -- {"summary": {"old": "...", "new": "..."}}
+  duration_ms int   -- time spent in previous status
+);
+
+CREATE INDEX idx_status_history_queue ON status_history(queue_id);
+CREATE INDEX idx_status_history_time ON status_history(changed_at);
+```
+
+### Migration of existing status column
+
+```sql
+-- Add new column
+ALTER TABLE ingestion_queue ADD COLUMN status_code smallint;
+
+-- Migrate existing values
+UPDATE ingestion_queue SET status_code = CASE status
+  WHEN 'pending' THEN 200
+  WHEN 'queued' THEN 200
+  WHEN 'processing' THEN 211
+  WHEN 'enriched' THEN 300
+  WHEN 'approved' THEN 330
+  WHEN 'rejected' THEN 540
+  WHEN 'failed' THEN 500
+  ELSE 200
+END;
+
+-- Eventually: drop old column, rename new
+```
+
+## Usage Examples
+
+### Query items by category
+
+```sql
+-- All items in enrichment
+SELECT * FROM ingestion_queue WHERE status_code BETWEEN 200 AND 299;
+
+-- All terminal states
+SELECT * FROM ingestion_queue WHERE status_code >= 500;
+
+-- Ready for any processing step
+SELECT * FROM ingestion_queue WHERE status_code % 10 = 0 AND status_code < 500;
+```
+
+### Track time in each state
+
+```sql
+SELECT
+  sl.name,
+  AVG(sh.duration_ms) as avg_duration_ms,
+  COUNT(*) as transitions
+FROM status_history sh
+JOIN status_lookup sl ON sl.code = sh.from_status
+GROUP BY sl.name
+ORDER BY avg_duration_ms DESC;
+```
+
+## Agent Updates Required
+
+| Agent         | Current      | New Flow               |
+| ------------- | ------------ | ---------------------- |
+| discover      | -            | 100 → 122              |
+| enrich (main) | `processing` | Orchestrates 200 → 240 |
+| summarize     | -            | 210 → 212              |
+| tag           | -            | 220 → 222              |
+| thumbnail     | -            | 230 → 232              |
+| review UI     | -            | 300 → 330              |
+| publish       | -            | 330 → 400              |

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@bfsi/shared",
+  "version": "1.0.0",
+  "description": "Shared constants and utilities for BFSI Insights",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./pipeline-status": "./src/pipeline-status.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './pipeline-status';

--- a/packages/shared/src/pipeline-status.ts
+++ b/packages/shared/src/pipeline-status.ts
@@ -1,0 +1,194 @@
+/**
+ * Pipeline Status Codes
+ * See docs/architecture/pipeline-status-codes.md for full documentation
+ */
+
+// =============================================================================
+// Status Code Constants
+// =============================================================================
+
+export const STATUS = {
+  // 100s: Discovery
+  DISCOVERED: 100,
+  TO_FETCH: 110,
+  FETCHING: 111,
+  FETCHED: 112,
+  TO_SCORE: 120,
+  SCORING: 121,
+  SCORED: 122,
+
+  // 200s: Enrichment
+  PENDING_ENRICHMENT: 200,
+  TO_SUMMARIZE: 210,
+  SUMMARIZING: 211,
+  SUMMARIZED: 212,
+  TO_TAG: 220,
+  TAGGING: 221,
+  TAGGED: 222,
+  TO_THUMBNAIL: 230,
+  THUMBNAILING: 231,
+  THUMBNAILED: 232,
+  ENRICHED: 240,
+
+  // 300s: Review
+  PENDING_REVIEW: 300,
+  IN_REVIEW: 310,
+  EDITING: 320,
+  APPROVED: 330,
+
+  // 400s: Published
+  PUBLISHED: 400,
+  UPDATED: 410,
+
+  // 500s: Terminal/Error
+  FAILED: 500,
+  UNREACHABLE: 510,
+  DUPLICATE: 520,
+  IRRELEVANT: 530,
+  REJECTED: 540,
+} as const;
+
+export type StatusCode = (typeof STATUS)[keyof typeof STATUS];
+
+// =============================================================================
+// Status Names (for display)
+// =============================================================================
+
+export const STATUS_NAMES: Record<StatusCode, string> = {
+  [STATUS.DISCOVERED]: 'Discovered',
+  [STATUS.TO_FETCH]: 'To Fetch',
+  [STATUS.FETCHING]: 'Fetching',
+  [STATUS.FETCHED]: 'Fetched',
+  [STATUS.TO_SCORE]: 'To Score',
+  [STATUS.SCORING]: 'Scoring',
+  [STATUS.SCORED]: 'Scored',
+
+  [STATUS.PENDING_ENRICHMENT]: 'Pending Enrichment',
+  [STATUS.TO_SUMMARIZE]: 'To Summarize',
+  [STATUS.SUMMARIZING]: 'Summarizing',
+  [STATUS.SUMMARIZED]: 'Summarized',
+  [STATUS.TO_TAG]: 'To Tag',
+  [STATUS.TAGGING]: 'Tagging',
+  [STATUS.TAGGED]: 'Tagged',
+  [STATUS.TO_THUMBNAIL]: 'To Thumbnail',
+  [STATUS.THUMBNAILING]: 'Thumbnailing',
+  [STATUS.THUMBNAILED]: 'Thumbnailed',
+  [STATUS.ENRICHED]: 'Enriched',
+
+  [STATUS.PENDING_REVIEW]: 'Pending Review',
+  [STATUS.IN_REVIEW]: 'In Review',
+  [STATUS.EDITING]: 'Editing',
+  [STATUS.APPROVED]: 'Approved',
+
+  [STATUS.PUBLISHED]: 'Published',
+  [STATUS.UPDATED]: 'Updated',
+
+  [STATUS.FAILED]: 'Failed',
+  [STATUS.UNREACHABLE]: 'Unreachable',
+  [STATUS.DUPLICATE]: 'Duplicate',
+  [STATUS.IRRELEVANT]: 'Irrelevant',
+  [STATUS.REJECTED]: 'Rejected',
+};
+
+// =============================================================================
+// Status Categories
+// =============================================================================
+
+export type StatusCategory = 'discovery' | 'enrichment' | 'review' | 'published' | 'terminal';
+
+export const STATUS_CATEGORY: Record<StatusCode, StatusCategory> = {
+  [STATUS.DISCOVERED]: 'discovery',
+  [STATUS.TO_FETCH]: 'discovery',
+  [STATUS.FETCHING]: 'discovery',
+  [STATUS.FETCHED]: 'discovery',
+  [STATUS.TO_SCORE]: 'discovery',
+  [STATUS.SCORING]: 'discovery',
+  [STATUS.SCORED]: 'discovery',
+
+  [STATUS.PENDING_ENRICHMENT]: 'enrichment',
+  [STATUS.TO_SUMMARIZE]: 'enrichment',
+  [STATUS.SUMMARIZING]: 'enrichment',
+  [STATUS.SUMMARIZED]: 'enrichment',
+  [STATUS.TO_TAG]: 'enrichment',
+  [STATUS.TAGGING]: 'enrichment',
+  [STATUS.TAGGED]: 'enrichment',
+  [STATUS.TO_THUMBNAIL]: 'enrichment',
+  [STATUS.THUMBNAILING]: 'enrichment',
+  [STATUS.THUMBNAILED]: 'enrichment',
+  [STATUS.ENRICHED]: 'enrichment',
+
+  [STATUS.PENDING_REVIEW]: 'review',
+  [STATUS.IN_REVIEW]: 'review',
+  [STATUS.EDITING]: 'review',
+  [STATUS.APPROVED]: 'review',
+
+  [STATUS.PUBLISHED]: 'published',
+  [STATUS.UPDATED]: 'published',
+
+  [STATUS.FAILED]: 'terminal',
+  [STATUS.UNREACHABLE]: 'terminal',
+  [STATUS.DUPLICATE]: 'terminal',
+  [STATUS.IRRELEVANT]: 'terminal',
+  [STATUS.REJECTED]: 'terminal',
+};
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/** Check if status is in discovery phase (100s) */
+export const isDiscovery = (code: number): boolean => code >= 100 && code < 200;
+
+/** Check if status is in enrichment phase (200s) */
+export const isEnrichment = (code: number): boolean => code >= 200 && code < 300;
+
+/** Check if status is in review phase (300s) */
+export const isReview = (code: number): boolean => code >= 300 && code < 400;
+
+/** Check if status is published (400s) */
+export const isPublished = (code: number): boolean => code >= 400 && code < 500;
+
+/** Check if status is terminal/error (500s) */
+export const isTerminal = (code: number): boolean => code >= 500;
+
+/** Check if status is a "ready" state (ends in 0) */
+export const isReady = (code: number): boolean => code % 10 === 0 && code < 500;
+
+/** Check if status is "in progress" (ends in 1) */
+export const isInProgress = (code: number): boolean => code % 10 === 1;
+
+/** Check if status is "complete" (ends in 2) */
+export const isComplete = (code: number): boolean => code % 10 === 2;
+
+/** Get category for a status code */
+export const getCategory = (code: number): StatusCategory => {
+  if (code >= 500) return 'terminal';
+  if (code >= 400) return 'published';
+  if (code >= 300) return 'review';
+  if (code >= 200) return 'enrichment';
+  return 'discovery';
+};
+
+/** Get display name for a status code */
+export const getStatusName = (code: number): string => {
+  return STATUS_NAMES[code as StatusCode] || `Unknown (${code})`;
+};
+
+// =============================================================================
+// Legacy Status Mapping (for migration)
+// =============================================================================
+
+export const LEGACY_STATUS_MAP: Record<string, StatusCode> = {
+  pending: STATUS.PENDING_ENRICHMENT,
+  queued: STATUS.PENDING_ENRICHMENT,
+  processing: STATUS.SUMMARIZING,
+  enriched: STATUS.PENDING_REVIEW,
+  approved: STATUS.APPROVED,
+  rejected: STATUS.REJECTED,
+  failed: STATUS.FAILED,
+};
+
+/** Convert legacy text status to new numeric code */
+export const fromLegacyStatus = (status: string): StatusCode => {
+  return LEGACY_STATUS_MAP[status] || STATUS.PENDING_ENRICHMENT;
+};

--- a/supabase/migrations/20251209172922_granular_pipeline_status.sql
+++ b/supabase/migrations/20251209172922_granular_pipeline_status.sql
@@ -1,0 +1,203 @@
+-- Migration: Granular Pipeline Status Numbering System
+-- See docs/architecture/pipeline-status-codes.md for full documentation
+
+-- =============================================================================
+-- STEP 1: Create status_lookup table
+-- =============================================================================
+
+CREATE TABLE public.status_lookup (
+  code smallint PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  description text,
+  category text NOT NULL CHECK (category IN ('discovery', 'enrichment', 'review', 'published', 'terminal')),
+  is_terminal boolean DEFAULT false,
+  sort_order smallint
+);
+
+-- Enable RLS
+ALTER TABLE public.status_lookup ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Service role full access on status_lookup" ON public.status_lookup
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "Authenticated read access on status_lookup" ON public.status_lookup
+  FOR SELECT TO authenticated USING (true);
+
+-- Insert all status codes
+INSERT INTO public.status_lookup (code, name, description, category, is_terminal, sort_order) VALUES
+  -- 100s: Discovery
+  (100, 'discovered', 'URL found in RSS/sitemap', 'discovery', false, 100),
+  (110, 'to_fetch', 'Ready to fetch content', 'discovery', false, 110),
+  (111, 'fetching', 'Fetch in progress', 'discovery', false, 111),
+  (112, 'fetched', 'Content retrieved', 'discovery', false, 112),
+  (120, 'to_score', 'Ready for relevance scoring', 'discovery', false, 120),
+  (121, 'scoring', 'LLM/embedding scoring in progress', 'discovery', false, 121),
+  (122, 'scored', 'Score assigned, ready to route', 'discovery', false, 122),
+  
+  -- 200s: Enrichment
+  (200, 'pending_enrichment', 'In queue, awaiting first step', 'enrichment', false, 200),
+  (210, 'to_summarize', 'Ready for summary generation', 'enrichment', false, 210),
+  (211, 'summarizing', 'Summary agent working', 'enrichment', false, 211),
+  (212, 'summarized', 'Summary complete', 'enrichment', false, 212),
+  (220, 'to_tag', 'Ready for tagging', 'enrichment', false, 220),
+  (221, 'tagging', 'Tag agent working', 'enrichment', false, 221),
+  (222, 'tagged', 'Tags extracted', 'enrichment', false, 222),
+  (230, 'to_thumbnail', 'Ready for thumbnail', 'enrichment', false, 230),
+  (231, 'thumbnailing', 'Thumbnail agent working', 'enrichment', false, 231),
+  (232, 'thumbnailed', 'Thumbnail generated', 'enrichment', false, 232),
+  (240, 'enriched', 'All enrichment complete', 'enrichment', false, 240),
+  
+  -- 300s: Review
+  (300, 'pending_review', 'Awaiting curator', 'review', false, 300),
+  (310, 'in_review', 'Curator opened item', 'review', false, 310),
+  (320, 'editing', 'Curator making changes', 'review', false, 320),
+  (330, 'approved', 'Approved, ready to publish', 'review', false, 330),
+  
+  -- 400s: Published
+  (400, 'published', 'Live on site', 'published', true, 400),
+  (410, 'updated', 'Republished after edit', 'published', true, 410),
+  
+  -- 500s: Terminal/Error
+  (500, 'failed', 'Technical error (retryable)', 'terminal', true, 500),
+  (510, 'unreachable', 'URL 404/timeout', 'terminal', true, 510),
+  (520, 'duplicate', 'Duplicate URL/content', 'terminal', true, 520),
+  (530, 'irrelevant', 'Auto-filtered by scoring', 'terminal', true, 530),
+  (540, 'rejected', 'Human rejected', 'terminal', true, 540);
+
+-- =============================================================================
+-- STEP 2: Create status_history table
+-- =============================================================================
+
+CREATE TABLE public.status_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  queue_id uuid REFERENCES public.ingestion_queue(id) ON DELETE CASCADE,
+  from_status smallint REFERENCES public.status_lookup(code),
+  to_status smallint REFERENCES public.status_lookup(code) NOT NULL,
+  changed_at timestamptz DEFAULT now(),
+  changed_by text,  -- 'agent:summarize', 'user:rick', 'system:auto'
+  changes jsonb,    -- {"field": {"old": "...", "new": "..."}}
+  duration_ms int,  -- time spent in previous status
+  created_at timestamptz DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE public.status_history ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+CREATE POLICY "Service role full access on status_history" ON public.status_history
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "Authenticated read access on status_history" ON public.status_history
+  FOR SELECT TO authenticated USING (true);
+
+-- Indexes
+CREATE INDEX idx_status_history_queue ON public.status_history(queue_id);
+CREATE INDEX idx_status_history_time ON public.status_history(changed_at DESC);
+CREATE INDEX idx_status_history_to_status ON public.status_history(to_status);
+
+-- =============================================================================
+-- STEP 3: Add status_code column to ingestion_queue
+-- =============================================================================
+
+ALTER TABLE public.ingestion_queue ADD COLUMN IF NOT EXISTS status_code smallint;
+
+-- Create index for new column
+CREATE INDEX IF NOT EXISTS idx_queue_status_code ON public.ingestion_queue(status_code);
+
+-- =============================================================================
+-- STEP 4: Migrate existing status values
+-- =============================================================================
+
+UPDATE public.ingestion_queue 
+SET status_code = CASE status
+  WHEN 'pending' THEN 200      -- pending_enrichment
+  WHEN 'queued' THEN 200       -- pending_enrichment (same as pending)
+  WHEN 'processing' THEN 211   -- summarizing (most common processing state)
+  WHEN 'enriched' THEN 300     -- pending_review
+  WHEN 'approved' THEN 330     -- approved
+  WHEN 'rejected' THEN 540     -- rejected
+  WHEN 'failed' THEN 500       -- failed
+  ELSE 200                     -- default to pending_enrichment
+END
+WHERE status_code IS NULL;
+
+-- =============================================================================
+-- STEP 5: Create helper function for status transitions
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.transition_status(
+  p_queue_id uuid,
+  p_new_status smallint,
+  p_changed_by text DEFAULT 'system:auto',
+  p_changes jsonb DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_old_status smallint;
+  v_old_updated_at timestamptz;
+  v_duration_ms int;
+BEGIN
+  -- Get current status
+  SELECT status_code, updated_at 
+  INTO v_old_status, v_old_updated_at
+  FROM public.ingestion_queue 
+  WHERE id = p_queue_id;
+  
+  -- Calculate duration in previous status
+  IF v_old_updated_at IS NOT NULL THEN
+    v_duration_ms := EXTRACT(EPOCH FROM (now() - v_old_updated_at)) * 1000;
+  END IF;
+  
+  -- Record history
+  INSERT INTO public.status_history (queue_id, from_status, to_status, changed_by, changes, duration_ms)
+  VALUES (p_queue_id, v_old_status, p_new_status, p_changed_by, p_changes, v_duration_ms);
+  
+  -- Update queue
+  UPDATE public.ingestion_queue 
+  SET status_code = p_new_status, updated_at = now()
+  WHERE id = p_queue_id;
+END;
+$$;
+
+-- =============================================================================
+-- STEP 6: Create view for queue with status names
+-- =============================================================================
+
+CREATE OR REPLACE VIEW public.ingestion_queue_with_status
+WITH (security_invoker = true)
+AS
+SELECT 
+  q.*,
+  sl.name as status_name,
+  sl.category as status_category,
+  sl.is_terminal
+FROM public.ingestion_queue q
+LEFT JOIN public.status_lookup sl ON sl.code = q.status_code;
+
+-- =============================================================================
+-- STEP 7: Insert initial history for existing items
+-- =============================================================================
+
+INSERT INTO public.status_history (queue_id, from_status, to_status, changed_by, changes)
+SELECT 
+  id,
+  NULL,  -- no previous status
+  status_code,
+  'system:migration',
+  jsonb_build_object('note', 'Initial migration from text status', 'old_status', status)
+FROM public.ingestion_queue
+WHERE status_code IS NOT NULL;
+
+-- =============================================================================
+-- COMMENTS
+-- =============================================================================
+
+COMMENT ON TABLE public.status_lookup IS 'Lookup table for pipeline status codes. See docs/architecture/pipeline-status-codes.md';
+COMMENT ON TABLE public.status_history IS 'History of all status transitions for audit and analytics';
+COMMENT ON COLUMN public.ingestion_queue.status_code IS 'Numeric status code (see status_lookup table)';
+COMMENT ON FUNCTION public.transition_status IS 'Helper function to transition status with automatic history tracking';


### PR DESCRIPTION
Fixes KB-195

## Overview
Implements a layered numeric status code system for the ingestion pipeline, enabling:
- **Granular tracking** of each processing step
- **Before/during/after states** for each agent (e.g., to_summarize → summarizing → summarized)
- **History tracking** of all status transitions
- **Flexible pipeline ordering** (can reorder enrichment steps)

## Status Code Schema

| Range | Category | Examples |
|-------|----------|----------|
| 100s | Discovery | discovered, fetching, scoring |
| 200s | Enrichment | pending_enrichment, summarizing, tagging |
| 300s | Review | pending_review, editing, approved |
| 400s | Published | published, updated |
| 500s | Terminal | failed, irrelevant, rejected |

## Files Added

- `docs/architecture/pipeline-status-codes.md` - Full documentation
- `packages/shared/src/pipeline-status.ts` - TypeScript constants & helpers
- `supabase/migrations/..._granular_pipeline_status.sql` - Database schema

## Database Changes

- `status_lookup` table - All status codes with metadata
- `status_history` table - Audit trail of transitions
- `status_code` column on `ingestion_queue`
- `transition_status()` helper function
- Migration of existing data

## Next Steps (follow-up PRs)
- Update discover agent to use new codes
- Update enrich agent to use granular states
- Update dashboard to use status_code
- Update review pages