### PR TITLE
fix: use Number.parseInt instead of global parseInt

### DIFF
--- a/src/features/publications/hierarchy-cascade.ts
+++ b/src/features/publications/hierarchy-cascade.ts
@@ -82,8 +82,8 @@ function updateParentState(parentCode: string, parentLevel: string, selector: st
   // Recursively update ancestors
   const grandparentCode = parentCheckbox.dataset.parent;
   if (grandparentCode) {
-    const grandparentLevel = String(parseInt(parentLevel) - 1);
-    if (parseInt(grandparentLevel) >= 1) {
+    const grandparentLevel = String(Number.parseInt(parentLevel) - 1);
+    if (Number.parseInt(grandparentLevel) >= 1) {
       updateParentState(grandparentCode, grandparentLevel, selector);
     }
   }


### PR DESCRIPTION
## Summary
Fix 2 SonarCloud code smell issues.

## Changes
Replace `parseInt()` with `Number.parseInt()` in `hierarchy-cascade.ts` (lines 85-86).

This follows ES2015+ best practices - using the namespaced version is more explicit and avoids potential issues with the global function.

## Files Changed
- `src/features/publications/hierarchy-cascade.ts`