### PR TITLE
feat(KB-198): dynamic taxonomy UI with reusable TagDisplay component

### DIFF
--- a/admin-next/src/components/tags/TagDisplay.tsx
+++ b/admin-next/src/components/tags/TagDisplay.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { TaxonomyConfig, TaxonomyData, TagPayload } from './types';
+
+// Color map for Tailwind classes
+const COLOR_MAP: Record<string, { bg: string; text: string }> = {
+  blue: { bg: 'bg-blue-500/10', text: 'text-blue-300' },
+  purple: { bg: 'bg-purple-500/10', text: 'text-purple-300' },
+  emerald: { bg: 'bg-emerald-500/10', text: 'text-emerald-300' },
+  amber: { bg: 'bg-amber-500/10', text: 'text-amber-300' },
+  red: { bg: 'bg-red-500/10', text: 'text-red-300' },
+  orange: { bg: 'bg-orange-500/10', text: 'text-orange-300' },
+  cyan: { bg: 'bg-cyan-500/10', text: 'text-cyan-300' },
+  pink: { bg: 'bg-pink-500/10', text: 'text-pink-300' },
+  violet: { bg: 'bg-violet-500/10', text: 'text-violet-300' },
+  neutral: { bg: 'bg-neutral-500/10', text: 'text-neutral-300' },
+};
+
+interface TaggedCode {
+  code: string;
+  confidence?: number;
+}
+
+interface TagDisplayProps {
+  payload: TagPayload;
+  taxonomyConfig: TaxonomyConfig[];
+  taxonomyData: TaxonomyData;
+  /** Show as compact inline tags or full table */
+  variant?: 'table' | 'inline';
+  /** Label width for table variant */
+  labelWidth?: string;
+}
+
+/**
+ * Extract values from a payload field path (e.g., "industry_codes" or "persona_scores.executive")
+ */
+function getPayloadValue(payload: TagPayload, fieldPath: string): unknown {
+  const parts = fieldPath.split('.');
+  let value: unknown = payload;
+  for (const part of parts) {
+    if (value && typeof value === 'object' && part in value) {
+      value = (value as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return value;
+}
+
+/**
+ * Extract codes from tagged items (handles both string[] and {code, confidence}[])
+ */
+function extractCodes(items: unknown): string[] {
+  if (!items || !Array.isArray(items)) return [];
+  return items
+    .map((item) =>
+      typeof item === 'object' && item !== null ? (item as TaggedCode).code : (item as string),
+    )
+    .filter((c): c is string => typeof c === 'string' && c !== 'null' && c !== '');
+}
+
+/**
+ * Extract string array (for expandable types like vendor_names)
+ */
+function extractStrings(items: unknown): string[] {
+  if (!items || !Array.isArray(items)) return [];
+  return items.filter((s): s is string => typeof s === 'string' && s !== 'null' && s !== '');
+}
+
+/**
+ * Renders a single tag category row
+ */
+function TagCategoryRow({
+  config,
+  payload,
+  taxonomyData,
+  labelWidth = 'w-24',
+}: {
+  config: TaxonomyConfig;
+  payload: TagPayload;
+  taxonomyData: TaxonomyData;
+  labelWidth?: string;
+}) {
+  const colors = COLOR_MAP[config.color] || COLOR_MAP.neutral;
+  const lookupMap = taxonomyData[config.slug]
+    ? new Map(taxonomyData[config.slug].map((i) => [i.code, i.name]))
+    : null;
+
+  // Handle different behavior types
+  if (config.behavior_type === 'scoring') {
+    const score = getPayloadValue(payload, config.payload_field) as number | undefined;
+    const threshold = config.score_threshold ?? 0.5;
+    const showScore = score !== undefined && score >= threshold;
+
+    return (
+      <div className="flex items-start justify-between gap-2">
+        <span className={`text-neutral-500 shrink-0 ${labelWidth}`}>{config.display_name}</span>
+        <div className="flex flex-wrap gap-1 justify-end">
+          {showScore ? (
+            <span className={`px-1.5 py-0.5 rounded ${colors.bg} ${colors.text}`}>
+              {(score * 100).toFixed(0)}%
+            </span>
+          ) : (
+            <span className="text-neutral-600 italic">—</span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (config.behavior_type === 'expandable') {
+    // Free-text values (vendor_names, organization_names)
+    const values = extractStrings(getPayloadValue(payload, config.payload_field));
+    return (
+      <div className="flex items-start justify-between gap-2">
+        <span className={`text-neutral-500 shrink-0 ${labelWidth}`}>{config.display_name}</span>
+        <div className="flex flex-wrap gap-1 justify-end">
+          {values.length > 0 ? (
+            values.map((name, i) => (
+              <span key={i} className={`px-1.5 py-0.5 rounded ${colors.bg} ${colors.text}`}>
+                {name}
+              </span>
+            ))
+          ) : (
+            <span className="text-neutral-600 italic">—</span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Guardrail: code-based taxonomy
+  const codes = extractCodes(getPayloadValue(payload, config.payload_field));
+  return (
+    <div className="flex items-start justify-between gap-2">
+      <span className={`text-neutral-500 shrink-0 ${labelWidth}`}>{config.display_name}</span>
+      <div className="flex flex-wrap gap-1 justify-end">
+        {codes.length > 0 ? (
+          codes.map((code) => (
+            <span key={code} className={`px-1.5 py-0.5 rounded ${colors.bg} ${colors.text}`}>
+              {lookupMap?.get(code) || code}
+            </span>
+          ))
+        ) : (
+          <span className="text-neutral-600 italic">—</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Dynamic tag display component that renders all taxonomy categories from config
+ */
+export function TagDisplay({
+  payload,
+  taxonomyConfig,
+  taxonomyData,
+  variant = 'table',
+  labelWidth = 'w-24',
+}: TagDisplayProps) {
+  // Group scoring configs by parent for persona grouping
+  const personaConfigs = taxonomyConfig.filter(
+    (c) => c.behavior_type === 'scoring' && c.score_parent_slug === 'persona',
+  );
+  const nonPersonaConfigs = taxonomyConfig.filter(
+    (c) => !(c.behavior_type === 'scoring' && c.score_parent_slug === 'persona'),
+  );
+
+  if (variant === 'inline') {
+    // Compact inline view - just show tags without labels
+    return (
+      <div className="flex flex-wrap gap-1">
+        {taxonomyConfig
+          .filter((c) => c.behavior_type !== 'scoring')
+          .map((config) => {
+            const colors = COLOR_MAP[config.color] || COLOR_MAP.neutral;
+            const codes =
+              config.behavior_type === 'expandable'
+                ? extractStrings(getPayloadValue(payload, config.payload_field))
+                : extractCodes(getPayloadValue(payload, config.payload_field));
+            const lookupMap = taxonomyData[config.slug]
+              ? new Map(taxonomyData[config.slug].map((i) => [i.code, i.name]))
+              : null;
+
+            return codes.slice(0, 2).map((code, i) => (
+              <span
+                key={`${config.slug}-${i}`}
+                className={`px-1.5 py-0.5 rounded text-xs ${colors.bg} ${colors.text}`}
+              >
+                {lookupMap?.get(code) || code}
+              </span>
+            ));
+          })}
+      </div>
+    );
+  }
+
+  // Table view - full display with labels
+  return (
+    <div className="space-y-2 text-xs">
+      {/* Non-persona categories */}
+      {nonPersonaConfigs.map((config) => (
+        <TagCategoryRow
+          key={config.slug}
+          config={config}
+          payload={payload}
+          taxonomyData={taxonomyData}
+          labelWidth={labelWidth}
+        />
+      ))}
+
+      {/* Persona scores grouped together */}
+      {personaConfigs.length > 0 && (
+        <div className="flex items-start justify-between gap-2">
+          <span className={`text-neutral-500 shrink-0 ${labelWidth}`}>Persona</span>
+          <div className="flex flex-wrap gap-1 justify-end">
+            {(() => {
+              const colors = COLOR_MAP.violet;
+              const hasAnyScore = personaConfigs.some((c) => {
+                const score = getPayloadValue(payload, c.payload_field) as number | undefined;
+                return score !== undefined && score >= (c.score_threshold ?? 0.5);
+              });
+
+              if (!hasAnyScore) {
+                return <span className="text-neutral-600 italic">—</span>;
+              }
+
+              return personaConfigs.map((c) => {
+                const score = getPayloadValue(payload, c.payload_field) as number | undefined;
+                if (score === undefined || score < (c.score_threshold ?? 0.5)) return null;
+                return (
+                  <span
+                    key={c.slug}
+                    className={`px-1.5 py-0.5 rounded ${colors.bg} ${colors.text}`}
+                  >
+                    {c.display_name} ({(score * 100).toFixed(0)}%)
+                  </span>
+                );
+              });
+            })()}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-next/src/components/tags/index.ts
+++ b/admin-next/src/components/tags/index.ts
@@ -1,0 +1,2 @@
+export { TagDisplay } from './TagDisplay';
+export type { TaxonomyConfig, TaxonomyData, TaxonomyItem, TagPayload } from './types';

--- a/admin-next/src/components/tags/types.ts
+++ b/admin-next/src/components/tags/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared types for dynamic taxonomy display
+ */
+
+export interface TaxonomyItem {
+  code: string;
+  name: string;
+}
+
+export interface TaxonomyConfig {
+  slug: string;
+  display_name: string;
+  display_order: number;
+  behavior_type: 'guardrail' | 'expandable' | 'scoring';
+  source_table: string | null;
+  payload_field: string;
+  color: string;
+  score_parent_slug: string | null;
+  score_threshold: number | null;
+}
+
+// Dynamic taxonomy data keyed by slug
+export type TaxonomyData = Record<string, TaxonomyItem[]>;
+
+// Payload with dynamic tag fields
+export type TagPayload = Record<string, unknown>;


### PR DESCRIPTION
## Summary
Phase 2 of KB-198: Create reusable TagDisplay component that renders tags dynamically from `taxonomy_config`.

## New Components

### `TagDisplay` (`components/tags/TagDisplay.tsx`)
A flexible component that renders any payload's tags using the taxonomy config:
- **Variants**: `table` (full view with labels) and `inline` (compact chips)
- **Behavior types**: Handles guardrail, expandable, and scoring categories
- **Dynamic colors**: Uses color from config
- **Persona grouping**: Groups persona scores together with threshold display

## Carousel View Updates
- Fetches `taxonomy_config` from database
- Dynamically loads source tables based on config
- Replaces ~200 lines of hardcoded tag rendering with `<TagDisplay />`

## Benefits
- **Add new taxonomy**: Just INSERT into `taxonomy_config` → UI auto-updates
- **Single source of truth**: One component for all tag display
- **Reusable**: Can be used in detail-panel, review-list, etc.

## Files Changed
- `admin-next/src/components/tags/TagDisplay.tsx` - new component
- `admin-next/src/components/tags/types.ts` - shared types
- `admin-next/src/components/tags/index.ts` - exports
- `admin-next/.../carousel/page.tsx` - dynamic taxonomy loading
- `admin-next/.../carousel/carousel-review.tsx` - uses TagDisplay

## TODO (can be follow-up)
- [ ] Update detail-panel.tsx to use TagDisplay
- [ ] Update review-list.tsx to use TagDisplay
- [ ] Update review/[id]/page.tsx to use TagDisplay

Part of KB-198