### PR TITLE
feat(KB-198): add validation mode to TagDisplay and update review/[id]

### DIFF
--- a/admin-next/src/components/tags/index.ts
+++ b/admin-next/src/components/tags/index.ts
@@ -1,2 +1,8 @@
 export { TagDisplay } from './TagDisplay';
-export type { TaxonomyConfig, TaxonomyData, TaxonomyItem, TagPayload } from './types';
+export type {
+  TaxonomyConfig,
+  TaxonomyData,
+  TaxonomyItem,
+  TagPayload,
+  ValidationLookups,
+} from './types';

--- a/admin-next/src/components/tags/types.ts
+++ b/admin-next/src/components/tags/types.ts
@@ -24,3 +24,7 @@ export type TaxonomyData = Record<string, TaxonomyItem[]>;
 
 // Payload with dynamic tag fields
 export type TagPayload = Record<string, unknown>;
+
+// Validation lookups for expandable entities (keyed by slug)
+// Values should be lowercase for case-insensitive matching
+export type ValidationLookups = Record<string, Set<string>>;


### PR DESCRIPTION
## Summary
Adds validation support to TagDisplay and migrates the last review view (review/[id]) to use it.

## Changes

### TagDisplay Enhancements
- Add `ValidationLookups` type for entity validation
- Add `showValidation` and `validationLookups` props
- Expandable tags show ⚠️ warning for unknown entities when validation enabled

### review/[id] Migration
- Uses TagDisplay with validation mode enabled
- Removed ~120 lines of hardcoded tag rendering
- Removed unused `ValidatedTag` component
- Unknown entities still feed into `UnknownEntitiesPanel`

## Benefits
- All review views now use TagDisplay
- Consistent tag display across carousel, split view, detail panel, and item page
- Adding a new taxonomy = just INSERT into `taxonomy_config`

## Testing
Navigate to /review/[id] and verify:
- All taxonomy categories display
- Unknown vendors/orgs/regulators show ⚠️ warning
- UnknownEntitiesPanel still works

Part of KB-198