### PR TITLE
feat(KB-198): update tagger schema to use audience_scores

### DIFF
--- a/admin-next/src/components/tags/TagDisplay.tsx
+++ b/admin-next/src/components/tags/TagDisplay.tsx
@@ -36,7 +36,7 @@ interface TagDisplayProps {
 }
 
 /**
- * Extract values from a payload field path (e.g., "industry_codes" or "persona_scores.executive")
+ * Extract values from a payload field path (e.g., "industry_codes" or "audience_scores.executive")
  */
 function getPayloadValue(payload: TagPayload, fieldPath: string): unknown {
   const parts = fieldPath.split('.');

--- a/admin-next/src/types/database.ts
+++ b/admin-next/src/types/database.ts
@@ -29,7 +29,7 @@ export interface QueuePayload {
   geography_codes?: string[];
   regulator_codes?: string[];
   regulation_codes?: string[];
-  persona_scores?: Record<string, number>;
+  audience_scores?: Record<string, number>;
   relevance_confidence?: number;
   rejection_reason?: string;
   thumbnail_url?: string;

--- a/services/agent-api/src/agents/enrich-item.js
+++ b/services/agent-api/src/agents/enrich-item.js
@@ -140,7 +140,7 @@ async function stepTag(queueId, payload) {
     process_codes: extractCodes(result.process_codes),
     organization_names: result.organization_names || [],
     vendor_names: result.vendor_names || [],
-    persona_scores: result.persona_scores || {},
+    audience_scores: result.audience_scores || {},
     tagging_metadata: {
       overall_confidence: result.overall_confidence,
       reasoning: result.reasoning,

--- a/services/agent-api/src/agents/tag.js
+++ b/services/agent-api/src/agents/tag.js
@@ -72,26 +72,37 @@ const TaggingSchema = z.object({
     .describe('BFSI organizations mentioned (banks, insurers, asset managers)'),
   vendor_names: z.array(z.string()).describe('AI/tech vendors mentioned'),
 
-  // Persona relevance scores (0-1 for each audience type)
-  persona_scores: z
+  // Audience relevance scores (0-1 for each audience type)
+  audience_scores: z
     .object({
       executive: z
         .number()
         .min(0)
         .max(1)
-        .describe('Relevance for C-suite/executives (strategy, business impact)'),
-      technical: z
+        .describe('Relevance for C-suite/executives (strategy, business impact, market trends)'),
+      functional_specialist: z
         .number()
         .min(0)
         .max(1)
-        .describe('Relevance for technical roles (implementation, architecture)'),
-      compliance: z
+        .describe(
+          'Relevance for product managers, risk/compliance/legal specialists, auditors, business analysts',
+        ),
+      engineer: z
         .number()
         .min(0)
         .max(1)
-        .describe('Relevance for compliance/risk roles (regulatory, risk)'),
+        .describe(
+          'Relevance for developers, architects, DevOps, security engineers (implementation, APIs, technical details)',
+        ),
+      researcher: z
+        .number()
+        .min(0)
+        .max(1)
+        .describe(
+          'Relevance for academics, PhD researchers, analysts (methodology, data, peer-reviewed findings)',
+        ),
     })
-    .describe('Relevance scores per persona/audience type'),
+    .describe('Relevance scores per audience type'),
 
   // Overall metadata
   overall_confidence: z.number().min(0).max(1).describe('Overall confidence in classification 0-1'),


### PR DESCRIPTION
## Summary
Updates the tagger agent schema to produce `audience_scores` instead of `persona_scores` with the new 4 audience types.

## Changes

### Schema Update (tag.js)
```js
// Before
persona_scores: { executive, technical, compliance }

// After  
audience_scores: { executive, functional_specialist, engineer, researcher }
```

### Audience Type Descriptions
- **executive**: C-suite (strategy, business impact, market trends)
- **functional_specialist**: Product managers, risk/compliance/legal, auditors, BAs
- **engineer**: Developers, architects, DevOps, security engineers
- **researcher**: Academics, PhD researchers, analysts

### Files Changed
- `services/agent-api/src/agents/tag.js` - schema update
- `services/agent-api/src/agents/enrich-item.js` - use audience_scores
- `admin-next/src/types/database.ts` - TypeScript type
- `admin-next/src/components/tags/TagDisplay.tsx` - comment

## Deployment
After merge, redeploy agent-api to activate new schema.

Part of KB-198