### PR TITLE
fix: playwright install with system deps

### DIFF
--- a/services/agent-api/package.json
+++ b/services/agent-api/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "postinstall": "npx playwright install chromium || true"
+    "postinstall": "npx playwright install chromium --with-deps"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",


### PR DESCRIPTION
## Problem
Thumbnail generation fails because Playwright browsers aren't properly installed on Render.

## Root Cause
The postinstall script had `|| true` which silently ignored install failures, and was missing `--with-deps` flag.

## Solution
- Add `--with-deps` to install system dependencies (libgbm, libnss3, etc.)
- Remove `|| true` so errors are visible

## After merge
1. Go to Render → bfsi-insights → Manual Deploy → **Clear build cache & deploy**
2. This will force a fresh install of Playwright with system deps