### PR TITLE
fix: update Playwright Docker image to v1.57.0

### DIFF
--- a/services/agent-api/Dockerfile
+++ b/services/agent-api/Dockerfile
@@ -1,6 +1,6 @@
 # Use Playwright's official image with browsers pre-installed
 # Match version in package.json (^1.57.0)
-FROM mcr.microsoft.com/playwright:v1.49.1-noble
+FROM mcr.microsoft.com/playwright:v1.57.0-noble
 
 WORKDIR /app
 


### PR DESCRIPTION
Updates Docker image to match package.json Playwright version. Required for thumbnail generation to work.