### PR TITLE
fix(KB-201): MECE status counts with SQL aggregation

### DIFF
--- a/admin-next/src/components/dashboard/PipelineStatusGrid.tsx
+++ b/admin-next/src/components/dashboard/PipelineStatusGrid.tsx
@@ -38,7 +38,6 @@ interface StatusCode {
 interface CategoryData {
   category: string;
   label: string;
-  icon: string;
   color: string;
   bgColor: string;
   borderColor: string;
@@ -57,39 +56,34 @@ interface PipelineStatusGridProps {
 
 const CATEGORY_CONFIG: Record<
   string,
-  { label: string; icon: string; color: string; bgColor: string; borderColor: string }
+  { label: string; color: string; bgColor: string; borderColor: string }
 > = {
   discovery: {
     label: 'Discovery',
-    icon: '🔍',
     color: 'text-violet-400',
     bgColor: 'bg-violet-500/10',
     borderColor: 'border-violet-500/30',
   },
   enrichment: {
     label: 'Enrichment',
-    icon: '⚙️',
     color: 'text-cyan-400',
     bgColor: 'bg-cyan-500/10',
     borderColor: 'border-cyan-500/30',
   },
   review: {
     label: 'Review',
-    icon: '👁️',
     color: 'text-amber-400',
     bgColor: 'bg-amber-500/10',
     borderColor: 'border-amber-500/30',
   },
   published: {
     label: 'Published',
-    icon: '✅',
     color: 'text-emerald-400',
     bgColor: 'bg-emerald-500/10',
     borderColor: 'border-emerald-500/30',
   },
   terminal: {
     label: 'Terminal',
-    icon: '🗑️',
     color: 'text-neutral-400',
     bgColor: 'bg-neutral-500/10',
     borderColor: 'border-neutral-500/30',
@@ -119,14 +113,6 @@ export function PipelineStatusGrid({ statusData }: PipelineStatusGridProps) {
     };
   });
 
-  // Calculate summary totals
-  const inPipelineTotal = categories
-    .filter((c) => ['discovery', 'enrichment', 'review'].includes(c.category))
-    .reduce((sum, c) => sum + c.total, 0);
-
-  const publishedTotal = categories.find((c) => c.category === 'published')?.total || 0;
-  const terminalTotal = categories.find((c) => c.category === 'terminal')?.total || 0;
-
   const toggleCategory = (category: string) => {
     setExpandedCategories((prev) => {
       const next = new Set(prev);
@@ -140,80 +126,57 @@ export function PipelineStatusGrid({ statusData }: PipelineStatusGridProps) {
   };
 
   return (
-    <div className="space-y-4">
-      {/* Summary Boxes */}
-      <div className="grid grid-cols-3 gap-3">
-        <div className="rounded-xl border border-sky-500/30 bg-sky-500/10 p-4">
-          <p className="text-xs text-neutral-400">In Pipeline</p>
-          <p className="mt-1 text-2xl font-bold text-sky-400">{inPipelineTotal}</p>
-          <p className="text-[10px] text-neutral-500">Discovery + Enrichment + Review</p>
-        </div>
-        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4">
-          <p className="text-xs text-neutral-400">Published</p>
-          <p className="mt-1 text-2xl font-bold text-emerald-400">{publishedTotal}</p>
-          <p className="text-[10px] text-neutral-500">Live on site</p>
-        </div>
-        <div className="rounded-xl border border-neutral-500/30 bg-neutral-500/10 p-4">
-          <p className="text-xs text-neutral-400">Terminal</p>
-          <p className="mt-1 text-2xl font-bold text-neutral-400">{terminalTotal}</p>
-          <p className="text-[10px] text-neutral-500">Failed + Rejected</p>
-        </div>
-      </div>
+    <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 divide-y divide-neutral-800">
+      {categories.map((cat) => {
+        const isExpanded = expandedCategories.has(cat.category);
+        const isTerminal = cat.category === 'terminal';
 
-      {/* Category Rows */}
-      <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 divide-y divide-neutral-800">
-        {categories.map((cat) => {
-          const isExpanded = expandedCategories.has(cat.category);
-          const isTerminal = cat.category === 'terminal';
+        return (
+          <div key={cat.category} className={cn(isTerminal && 'opacity-60')}>
+            {/* Category Header */}
+            <button
+              onClick={() => toggleCategory(cat.category)}
+              className="w-full flex items-center gap-3 p-3 hover:bg-neutral-800/50 transition-colors"
+            >
+              <span className={cn('font-medium', cat.color)}>{cat.label}</span>
+              <span className={cn('text-xl font-bold ml-auto', cat.color)}>{cat.total}</span>
+              <span className="text-neutral-500 ml-2">
+                {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+              </span>
+            </button>
 
-          return (
-            <div key={cat.category} className={cn(isTerminal && 'opacity-60')}>
-              {/* Category Header */}
-              <button
-                onClick={() => toggleCategory(cat.category)}
-                className="w-full flex items-center gap-3 p-3 hover:bg-neutral-800/50 transition-colors"
-              >
-                <span className="text-lg">{cat.icon}</span>
-                <span className={cn('font-medium', cat.color)}>{cat.label}</span>
-                <span className={cn('text-xl font-bold ml-auto', cat.color)}>{cat.total}</span>
-                <span className="text-neutral-500 ml-2">
-                  {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-                </span>
-              </button>
-
-              {/* Status Pills */}
-              {isExpanded && cat.statuses.length > 0 && (
-                <div className="px-3 pb-3 pl-10">
-                  <div className="flex flex-wrap gap-2">
-                    {cat.statuses.map((status) => (
-                      <div
-                        key={status.code}
+            {/* Status Pills */}
+            {isExpanded && cat.statuses.length > 0 && (
+              <div className="px-3 pb-3 pl-10">
+                <div className="flex flex-wrap gap-2">
+                  {cat.statuses.map((status) => (
+                    <div
+                      key={status.code}
+                      className={cn(
+                        'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs',
+                        status.count > 0 ? cat.bgColor : 'bg-neutral-800/50',
+                        status.count > 0 ? cat.borderColor : 'border-neutral-700',
+                        'border',
+                      )}
+                      title={`Code ${status.code}: ${status.name}`}
+                    >
+                      <span className="text-neutral-400">{status.name.replace(/_/g, ' ')}</span>
+                      <span
                         className={cn(
-                          'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs',
-                          status.count > 0 ? cat.bgColor : 'bg-neutral-800/50',
-                          status.count > 0 ? cat.borderColor : 'border-neutral-700',
-                          'border',
+                          'font-semibold',
+                          status.count > 0 ? cat.color : 'text-neutral-500',
                         )}
-                        title={`Code ${status.code}: ${status.name}`}
                       >
-                        <span className="text-neutral-400">{status.name.replace(/_/g, ' ')}</span>
-                        <span
-                          className={cn(
-                            'font-semibold',
-                            status.count > 0 ? cat.color : 'text-neutral-500',
-                          )}
-                        >
-                          {status.count}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
+                        {status.count}
+                      </span>
+                    </div>
+                  ))}
                 </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/supabase/migrations/20251210214000_status_counts_function.sql
+++ b/supabase/migrations/20251210214000_status_counts_function.sql
@@ -1,0 +1,33 @@
+-- Function to get status code counts directly from the database
+-- This ensures MECE counts straight from Supabase
+
+CREATE OR REPLACE FUNCTION get_status_code_counts()
+RETURNS TABLE (
+  code smallint,
+  name text,
+  category text,
+  count bigint
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    sl.code,
+    sl.name,
+    sl.category,
+    COALESCE(counts.cnt, 0) AS count
+  FROM status_lookup sl
+  LEFT JOIN (
+    SELECT 
+      iq.status_code,
+      COUNT(*) AS cnt
+    FROM ingestion_queue iq
+    WHERE iq.status_code IS NOT NULL
+    GROUP BY iq.status_code
+  ) counts ON sl.code = counts.status_code
+  ORDER BY sl.sort_order;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant execute to authenticated and service_role
+GRANT EXECUTE ON FUNCTION get_status_code_counts() TO authenticated;
+GRANT EXECUTE ON FUNCTION get_status_code_counts() TO service_role;


### PR DESCRIPTION
## Changes
- Remove icons from category headers
- Remove redundant top summary boxes (In Pipeline, Published, Terminal)  
- Add `get_status_code_counts()` database function for accurate counting
- Counts come directly from Supabase with GROUP BY
- Rename section from 'Pipeline Flow' to 'Activity Today'

## Migration Required
After merge, apply the migration in Supabase:
```sql
-- Run this in Supabase SQL Editor
-- Function to get status code counts directly from the database
-- This ensures MECE counts straight from Supabase

CREATE OR REPLACE FUNCTION get_status_code_counts()
RETURNS TABLE (
  code smallint,
  name text,
  category text,
  count bigint
) AS $$
BEGIN
  RETURN QUERY
  SELECT 
    sl.code,
    sl.name,
    sl.category,
    COALESCE(counts.cnt, 0) AS count
  FROM status_lookup sl
  LEFT JOIN (
    SELECT 
      iq.status_code,
      COUNT(*) AS cnt
    FROM ingestion_queue iq
    WHERE iq.status_code IS NOT NULL
    GROUP BY iq.status_code
  ) counts ON sl.code = counts.status_code
  ORDER BY sl.sort_order;
END;
$$ LANGUAGE plpgsql SECURITY DEFINER;

-- Grant execute to authenticated and service_role
GRANT EXECUTE ON FUNCTION get_status_code_counts() TO authenticated;
GRANT EXECUTE ON FUNCTION get_status_code_counts() TO service_role;
```

Closes KB-201