### PR TITLE
fix(KB-201): align status/status_code for MECE pipeline counts

### DIFF
--- a/admin-next/src/app/(dashboard)/page.tsx
+++ b/admin-next/src/app/(dashboard)/page.tsx
@@ -73,7 +73,6 @@ async function getStats() {
   // Legacy status counts for backward compatibility
   const statusCounts = {
     pending: pendingEnrichment || 0,
-    queued: pendingEnrichment || 0, // Alias for pending
     processing: inEnrichment || 0,
     enriched: pendingReview || 0,
     approved: approved || 0,
@@ -270,7 +269,6 @@ export default async function DashboardPage() {
             <p className="text-xs md:text-sm text-neutral-400">Total in Pipeline</p>
             <p className="mt-1 text-xl md:text-2xl font-bold text-sky-400">
               {(statusCounts.pending || 0) +
-                (statusCounts.queued || 0) +
                 (statusCounts.processing || 0) +
                 (statusCounts.enriched || 0)}
             </p>

--- a/admin-next/src/app/(dashboard)/review/[id]/actions.tsx
+++ b/admin-next/src/app/(dashboard)/review/[id]/actions.tsx
@@ -100,7 +100,7 @@ export function ReviewActions({ item }: { item: QueueItem }) {
     try {
       const { error } = await supabase
         .from('ingestion_queue')
-        .update({ status: 'queued' })
+        .update({ status: 'queued', status_code: 200 }) // 200 = PENDING_ENRICHMENT
         .eq('id', item.id);
 
       if (error) throw error;

--- a/admin-next/src/app/(dashboard)/review/actions.ts
+++ b/admin-next/src/app/(dashboard)/review/actions.ts
@@ -8,7 +8,7 @@ export async function bulkReenrichAction(ids: string[]) {
 
   const { error } = await supabase
     .from('ingestion_queue')
-    .update({ status: 'queued' })
+    .update({ status: 'queued', status_code: 200 }) // 200 = PENDING_ENRICHMENT
     .in('id', ids);
 
   if (error) {

--- a/admin-next/src/app/(dashboard)/review/carousel/carousel-review.tsx
+++ b/admin-next/src/app/(dashboard)/review/carousel/carousel-review.tsx
@@ -153,7 +153,10 @@ export function CarouselReview({
     setProcessing(true);
 
     try {
-      await supabase.from('ingestion_queue').update({ status: 'queued' }).eq('id', currentItem.id);
+      await supabase
+        .from('ingestion_queue')
+        .update({ status: 'queued', status_code: 200 }) // 200 = PENDING_ENRICHMENT
+        .eq('id', currentItem.id);
 
       const newItems = items.filter((_, i) => i !== currentIndex);
       setItems(newItems);

--- a/services/agent-api/src/agents/enrich-item.js
+++ b/services/agent-api/src/agents/enrich-item.js
@@ -228,11 +228,12 @@ export async function processQueue(options = {}) {
 
   console.log('🔄 Processing queue...\n');
 
-  // Process both 'pending' (from discovery) and 'queued' (from admin)
+  // Process items with status_code = PENDING_ENRICHMENT (200)
+  // This includes both discovery items and manual submissions
   const { data: items, error } = await supabase
     .from('ingestion_queue')
     .select('*')
-    .in('status', ['pending', 'queued'])
+    .eq('status_code', STATUS.PENDING_ENRICHMENT)
     .order('discovered_at', { ascending: true })
     .limit(limit);
 


### PR DESCRIPTION
## Changes
- Fix double-counting in 'Total in Pipeline' (removed queued alias that duplicated pending count)
- `processQueue()` now uses `status_code=200` instead of string `status IN ('pending', 'queued')`
- Re-enrich actions now set `status_code=200` alongside `status='queued'`
- Fix discovery-relevance test to mock valid prompt (suppress warning)

## Result
- 'Total in Pipeline' now shows correct count: **pending + processing + enriched**
- Pills in Pipeline Status Grid match the items that 'Process Queue' will pick up