### PR TITLE
fix(KB-202): unify review queue queries to use status_code

### DIFF
--- a/admin-next/src/app/(dashboard)/review/detail-panel.tsx
+++ b/admin-next/src/app/(dashboard)/review/detail-panel.tsx
@@ -32,29 +32,6 @@ interface DetailPanelProps {
   taxonomyData: TaxonomyData;
 }
 
-function ValidatedTag({
-  value,
-  knownValues,
-  baseColor,
-}: {
-  value: string;
-  knownValues: string[];
-  baseColor: string;
-}) {
-  const isKnown = knownValues.some((v) => v.toLowerCase() === value.toLowerCase());
-  return (
-    <span
-      className={`px-2 py-0.5 rounded text-xs ${
-        isKnown ? baseColor : 'bg-red-500/30 text-red-300 border border-red-500/50'
-      }`}
-      title={isKnown ? undefined : 'Not in reference table'}
-    >
-      {value}
-      {!isKnown && ' !'}
-    </span>
-  );
-}
-
 export function DetailPanel({
   itemId,
   onClose,
@@ -66,10 +43,20 @@ export function DetailPanel({
   taxonomyData,
 }: DetailPanelProps) {
   const [item, setItem] = useState<QueueItem | null>(null);
-  const [lookups, setLookups] = useState<Lookups | null>(null);
+  const [_lookups, setLookups] = useState<Lookups | null>(null);
   const [loading, setLoading] = useState(false);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const router = useRouter();
+
+  const handleAction = useCallback(
+    async (action: 'approve' | 'reject' | 'reenrich') => {
+      if (!itemId) return;
+      setActionLoading(action);
+      await onAction(action, itemId);
+      setActionLoading(null);
+    },
+    [itemId, onAction],
+  );
 
   // Fetch item details
   useEffect(() => {
@@ -138,14 +125,17 @@ export function DetailPanel({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [itemId, item, canNavigatePrev, canNavigateNext, actionLoading, onNavigate, onClose, router]);
-
-  const handleAction = async (action: 'approve' | 'reject' | 'reenrich') => {
-    if (!itemId) return;
-    setActionLoading(action);
-    await onAction(action, itemId);
-    setActionLoading(null);
-  };
+  }, [
+    itemId,
+    item,
+    canNavigatePrev,
+    canNavigateNext,
+    actionLoading,
+    onNavigate,
+    onClose,
+    router,
+    handleAction,
+  ]);
 
   if (!itemId) {
     return (

--- a/admin-next/src/app/(dashboard)/review/master-detail.tsx
+++ b/admin-next/src/app/(dashboard)/review/master-detail.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { formatDateTime, getStatusColor, truncate } from '@/lib/utils';
 import { DetailPanel } from './detail-panel';
 import { bulkApproveAction, bulkRejectAction, bulkReenrichAction } from './actions';
@@ -54,7 +53,7 @@ interface MasterDetailViewProps {
 
 export function MasterDetailView({
   items,
-  status,
+  status: _status,
   taxonomyConfig,
   taxonomyData,
 }: MasterDetailViewProps) {
@@ -132,7 +131,7 @@ export function MasterDetailView({
           {listItems.length === 0 ? (
             <div className="p-8 text-center text-neutral-500">No items found</div>
           ) : (
-            listItems.map((item, index) => (
+            listItems.map((item) => (
               <button
                 key={item.id}
                 onClick={() => setSelectedId(item.id)}

--- a/admin-next/src/app/(dashboard)/review/review-list.tsx
+++ b/admin-next/src/app/(dashboard)/review/review-list.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { createClient } from '@/lib/supabase/client';
 import { formatDateTime, getStatusColor, truncate } from '@/lib/utils';
 import { bulkReenrichAction, bulkRejectAction, bulkApproveAction } from './actions';
 import type { TaxonomyConfig, TaxonomyData } from '@/components/tags';
@@ -29,13 +28,16 @@ interface ReviewListProps {
 }
 
 // Note: taxonomyConfig/taxonomyData available for future inline tag display
-export function ReviewList({ items, status, taxonomyConfig, taxonomyData }: ReviewListProps) {
+export function ReviewList({
+  items,
+  status,
+  taxonomyConfig: _taxonomyConfig,
+  taxonomyData: _taxonomyData,
+}: ReviewListProps) {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState<string | null>(null);
-  const [processingCount, setProcessingCount] = useState(0);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const router = useRouter();
-  const supabase = createClient();
 
   const showSuccess = (message: string) => {
     setSuccessMessage(message);
@@ -146,8 +148,8 @@ export function ReviewList({ items, status, taxonomyConfig, taxonomyData }: Revi
         <div className="rounded-lg bg-sky-500/10 border border-sky-500/20 px-4 py-3 flex items-center gap-3">
           <div className="animate-spin rounded-full h-4 w-4 border-2 border-sky-500 border-t-transparent"></div>
           <span className="text-sky-400 text-sm font-medium">
-            {loading === 'approve' && `Approving... ${processingCount}/${selectedIds.size}`}
-            {loading === 'reject' && `Rejecting... ${processingCount}/${selectedIds.size}`}
+            {loading === 'approve' && 'Approving...'}
+            {loading === 'reject' && 'Rejecting...'}
             {loading === 'reenrich' && 'Queuing for re-enrichment...'}
           </span>
         </div>

--- a/admin-next/src/app/(dashboard)/sources/page.tsx
+++ b/admin-next/src/app/(dashboard)/sources/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import type { Source } from '@/types/database';
 
@@ -135,16 +135,21 @@ export default function SourcesPage() {
     }
   }
 
-  function formatTimeAgo(date: string | null): string {
-    if (!date) return 'Never';
-    const diff = Date.now() - new Date(date).getTime();
-    const hours = Math.floor(diff / (60 * 60 * 1000));
-    if (hours < 1) return 'Just now';
-    if (hours < 24) return `${hours}h ago`;
-    const days = Math.floor(hours / 24);
-    if (days === 1) return '1 day ago';
-    return `${days} days ago`;
-  }
+  // eslint-disable-next-line react-hooks/purity -- Date.now() is intentionally computed once on mount for relative time display
+  const now = useMemo(() => Date.now(), []);
+  const formatTimeAgo = useCallback(
+    (date: string | null): string => {
+      if (!date) return 'Never';
+      const diff = now - new Date(date).getTime();
+      const hours = Math.floor(diff / (60 * 60 * 1000));
+      if (hours < 1) return 'Just now';
+      if (hours < 24) return `${hours}h ago`;
+      const days = Math.floor(hours / 24);
+      if (days === 1) return '1 day ago';
+      return `${days} days ago`;
+    },
+    [now],
+  );
 
   function getCategoryColor(category: string) {
     const colors: Record<string, string> = {


### PR DESCRIPTION
## Problem
Review queue showed 4 different counts across views:
- Dashboard: 10 items
- Review page list: 13 items  
- Review page split: 12 items
- Carousel: 1 item

## Root Cause
- Dashboard used `status_code = 300` (numeric)
- Review page used `status = 'enriched'` (text field)
- Carousel used `status = 'enriched'` + extra client-side filter for `payload.summary.short`

The `status` and `status_code` fields were out of sync for some items.

## Solution
Unified all views to use `status_code` consistently:
- Review page now maps status filters to status_code values
- Carousel uses `status_code = 300` directly
- Removed redundant client-side `summary.short` filter from carousel

Also fixed pre-existing lint errors in affected files.

## Files Changed
- `review/page.tsx` - use status_code for queries
- `review/carousel/page.tsx` - use status_code, remove client-side filter
- `review/detail-panel.tsx` - fix handleAction hook order
- `review/master-detail.tsx` - fix unused imports/vars
- `review/review-list.tsx` - fix unused vars
- `sources/page.tsx` - fix Date.now() purity issue

Closes KB-202