### PR TITLE
fix(KB-206): staleness detection, age penalty, and prompt management

### DIFF
--- a/docs/issues/kb-206-scoring-overlooks-stale-content.md
+++ b/docs/issues/kb-206-scoring-overlooks-stale-content.md
@@ -55,6 +55,36 @@ if (isTrustedSource(source)) {
 
 ---
 
+## Implemented Solution
+
+### Staleness Keywords (Hard Filter)
+
+Content with these indicators is **auto-rejected**:
+
+- `inactive`, `rescinded`, `expired`, `superseded`, `archived`
+- `no longer active`, `no longer valid`, `no longer current`
+- `this page has been removed`, `this document has been withdrawn`
+
+This catches the 1996 FDIC article with "INACTIVE" banner.
+
+### Age Penalty (Soft Signal)
+
+Instead of hard cutoff, age reduces the relevance score:
+
+- **<2 years**: No penalty
+- **2-4 years**: -1 to score
+- **4-6 years**: -2 to score
+- **6+ years**: -3 to score (max penalty)
+
+This approach:
+
+- Allows "Attention is All You Need" (2017) to pass if LLM scores it high
+- Allows Basel II framework to pass from trusted sources
+- Still penalizes old news/press releases appropriately
+- Very old content from trusted sources can still be rejected if score drops below threshold
+
+---
+
 ## Proposed Improvements
 
 ### Option A: Add Date Filtering (Quick Win)

--- a/supabase/migrations/20251211124842_seed_discovery_relevance_llm_prompt.sql
+++ b/supabase/migrations/20251211124842_seed_discovery_relevance_llm_prompt.sql
@@ -1,0 +1,61 @@
+-- Seed the discovery-relevance LLM system prompt to prompt_versions
+-- KB-206: Move hardcoded prompt to database for better prompt management
+-- This enables A/B testing, iteration without code deploys, and version history
+
+-- First, rename existing config entry to clarify it's not the LLM prompt
+UPDATE prompt_versions 
+SET agent_name = 'discovery-relevance-config'
+WHERE agent_name = 'discovery-relevance';
+
+-- Insert the actual LLM system prompt
+INSERT INTO prompt_versions (
+  agent_name,
+  version,
+  prompt_text,
+  is_current
+) VALUES (
+  'discovery-relevance',
+  'discovery-relevance-v1.0',
+  'You are an expert content curator for BFSI (Banking, Financial Services, Insurance) executives.
+
+TARGET AUDIENCE:
+- C-suite executives (CEO, CTO, CDO, CRO, CFO)
+- Senior consultants and strategy advisors
+- Transformation and innovation leaders
+- Risk and compliance officers
+
+THEY CARE ABOUT:
+- AI/ML applications with clear business impact and ROI
+- Regulatory changes affecting operations or strategy
+- Competitive intelligence and market disruptions
+- Technology trends requiring board-level decisions
+- Risk management innovations
+- Digital transformation case studies with results
+
+THEY DON''T CARE ABOUT:
+- Pure academic theory without business application
+- Highly technical implementation details (code, algorithms)
+- Research only relevant to PhD researchers
+- Content targeting retail consumers or students
+- Generic news without strategic implications
+
+SCORING GUIDE:
+- 9-10: Must-read for executives (major regulatory change, breakthrough technology adoption, significant market shift)
+- 7-8: High value (relevant case study, emerging trend with implications, competitive intelligence)
+- 5-6: Moderate value (interesting but not urgent, narrow application)
+- 3-4: Low value (too technical, limited executive relevance)
+- 1-2: Not relevant (wrong industry, wrong audience, off-topic)
+
+Respond with JSON:
+{
+  "relevance_score": <1-10>,
+  "executive_summary": "<1 sentence: why this matters to executives OR why it doesn''t>",
+  "skip_reason": "<null if score >= 4, otherwise brief reason like ''Too academic'' or ''Wrong industry''>"
+}',
+  true
+);
+
+-- Add comment for documentation
+COMMENT ON TABLE prompt_versions IS 
+  'Stores versioned prompts for all agents. Each agent should have exactly one is_current=true row.
+   Agents: discovery-relevance (LLM scoring), discovery-relevance-config (regex filtering), summarize, etc.';


### PR DESCRIPTION
## Problem
Stale content (like 1996 FDIC "INACTIVE" letters) was appearing in the review queue because:
1. Trusted sources bypassed all quality checks
2. No staleness keyword detection
3. No date-based filtering
4. LLM prompt was hardcoded with no DB version

## Solution

### Staleness Detection
- **Hard filter**: Auto-reject content with staleness indicators (inactive, rescinded, expired, superseded, archived, etc.)
- **Soft signal**: Age penalty reduces score (-1 per 2 years over threshold, max -3)
- Checks run BEFORE trusted source bypass

### Prompt Management  
- Remove hardcoded FALLBACK_PROMPT → fail-fast if DB prompt missing
- Add migration to seed LLM prompt to `prompt_versions` table
- Rename existing regex config to `discovery-relevance-config`
- Add FDIC, OCC, SEC to trusted sources list

## Files Changed
- `services/agent-api/src/agents/discovery-relevance.js` - staleness detection, fail-fast prompt loading
- `services/agent-api/src/agents/discover.js` - pass publishedDate/url to scoring, track stale skips
- `services/agent-api/tests/agents/discovery-relevance.spec.js` - tests for new functions
- `supabase/migrations/20251211124842_seed_discovery_relevance_llm_prompt.sql` - seed prompt to DB
- `docs/issues/kb-206-scoring-overlooks-stale-content.md` - updated with solution

Closes https://linear.app/knowledge-base/issue/KB-206