### PR TITLE
feat(KB-207): Phase 3 - golden test sets with Supabase eval tables

### DIFF
--- a/services/agent-api/tests/evals/run-eval.js
+++ b/services/agent-api/tests/evals/run-eval.js
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+/**
+ * Eval Runner for BFSI Insights Agents
+ * KB-207 Phase 3: Golden Test Sets
+ *
+ * Uses Supabase tables: eval_golden_set, eval_run, eval_result
+ *
+ * Usage:
+ *   node tests/evals/run-eval.js discovery-relevance
+ *   node tests/evals/run-eval.js discovery-relevance --verbose
+ *   node tests/evals/run-eval.js discovery-relevance --dry-run
+ */
+
+import process from 'node:process';
+import { createClient } from '@supabase/supabase-js';
+
+// Initialize Supabase client
+const supabase = createClient(
+  process.env.PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_KEY,
+);
+
+// Colors for terminal output
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+};
+
+function log(message, color = 'reset') {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+// Dynamically import the agent based on name
+async function loadAgent(agentName) {
+  const agentMap = {
+    'discovery-relevance': '../../src/agents/discovery-relevance.js',
+    'relevance-filter': '../../src/agents/filter.js',
+    'content-summarizer': '../../src/agents/summarize.js',
+    'taxonomy-tagger': '../../src/agents/tag.js',
+  };
+
+  const agentPath = agentMap[agentName];
+  if (!agentPath) {
+    throw new Error(`Unknown agent: ${agentName}. Available: ${Object.keys(agentMap).join(', ')}`);
+  }
+
+  return import(agentPath);
+}
+
+// Load dataset from Supabase eval_golden_set table
+async function loadDataset(agentName) {
+  const { data, error } = await supabase
+    .from('eval_golden_set')
+    .select('*')
+    .eq('agent_name', agentName)
+    .order('created_at');
+
+  if (error) {
+    throw new Error(`Failed to load golden set for ${agentName}: ${error.message}`);
+  }
+
+  if (!data || data.length === 0) {
+    throw new Error(`No golden set examples found for ${agentName}. Seed data first.`);
+  }
+
+  // Transform to eval format
+  return data.map((row) => ({
+    id: row.name,
+    input: row.input,
+    expected: row.expected_output,
+  }));
+}
+
+// Evaluate a single example
+async function evaluateExample(agent, agentName, example, options) {
+  const { verbose, dryRun } = options;
+  const { id, input, expected } = example;
+
+  if (verbose) {
+    log(`\n  Testing: ${id}`, 'blue');
+    log(`    Input: ${input.title?.slice(0, 60)}...`, 'dim');
+  }
+
+  if (dryRun) {
+    return { id, status: 'skipped', reason: 'dry-run' };
+  }
+
+  try {
+    let result;
+
+    // Call the appropriate agent function
+    if (agentName === 'discovery-relevance') {
+      result = await agent.scoreRelevance({
+        title: input.title,
+        description: input.description,
+        source: input.source,
+        publishedDate: input.publishedDate,
+      });
+    } else {
+      throw new Error(`Eval not implemented for agent: ${agentName}`);
+    }
+
+    // Evaluate against expected
+    const checks = [];
+    let passed = true;
+
+    // Check min_score
+    if (expected.min_score !== undefined) {
+      const scoreOk = result.relevance_score >= expected.min_score;
+      checks.push({
+        check: 'min_score',
+        expected: `>= ${expected.min_score}`,
+        actual: result.relevance_score,
+        passed: scoreOk,
+      });
+      if (!scoreOk) passed = false;
+    }
+
+    // Check max_score
+    if (expected.max_score !== undefined) {
+      const scoreOk = result.relevance_score <= expected.max_score;
+      checks.push({
+        check: 'max_score',
+        expected: `<= ${expected.max_score}`,
+        actual: result.relevance_score,
+        passed: scoreOk,
+      });
+      if (!scoreOk) passed = false;
+    }
+
+    // Check must_queue
+    if (expected.must_queue !== undefined) {
+      const queueOk = result.should_queue === expected.must_queue;
+      checks.push({
+        check: 'must_queue',
+        expected: expected.must_queue,
+        actual: result.should_queue,
+        passed: queueOk,
+      });
+      if (!queueOk) passed = false;
+    }
+
+    // Check primary_audience (if expected is not null)
+    if (expected.primary_audience !== undefined && expected.primary_audience !== null) {
+      const audienceOk = result.primary_audience === expected.primary_audience;
+      checks.push({
+        check: 'primary_audience',
+        expected: expected.primary_audience,
+        actual: result.primary_audience,
+        passed: audienceOk,
+      });
+      // Audience mismatch is a warning, not a failure
+      if (!audienceOk && verbose) {
+        log(
+          `    ⚠️ Audience mismatch: expected ${expected.primary_audience}, got ${result.primary_audience}`,
+          'yellow',
+        );
+      }
+    }
+
+    if (verbose) {
+      const icon = passed ? '✓' : '✗';
+      const color = passed ? 'green' : 'red';
+      log(`    ${icon} Score: ${result.relevance_score}, Queue: ${result.should_queue}`, color);
+    }
+
+    return {
+      id,
+      status: passed ? 'passed' : 'failed',
+      checks,
+      result: {
+        relevance_score: result.relevance_score,
+        should_queue: result.should_queue,
+        primary_audience: result.primary_audience,
+        executive_summary: result.executive_summary,
+      },
+    };
+  } catch (err) {
+    if (verbose) {
+      log(`    ✗ Error: ${err.message}`, 'red');
+    }
+    return {
+      id,
+      status: 'error',
+      error: err.message,
+    };
+  }
+}
+
+// Main eval runner
+async function runEval(agentName, options = {}) {
+  const { verbose = false, dryRun = false } = options;
+
+  log(`\n${'='.repeat(60)}`, 'blue');
+  log(`  EVAL: ${agentName}`, 'bold');
+  log(`${'='.repeat(60)}`, 'blue');
+
+  // Load agent and dataset
+  const agent = await loadAgent(agentName);
+  const dataset = await loadDataset(agentName);
+
+  log(`\n  Dataset: ${dataset.length} examples`, 'dim');
+  if (dryRun) {
+    log('  Mode: DRY RUN (no LLM calls)', 'yellow');
+  }
+
+  // Run evaluations
+  const results = [];
+  for (const example of dataset) {
+    const result = await evaluateExample(agent, agentName, example, { verbose, dryRun });
+    results.push(result);
+  }
+
+  // Summary
+  const passed = results.filter((r) => r.status === 'passed').length;
+  const failed = results.filter((r) => r.status === 'failed').length;
+  const errors = results.filter((r) => r.status === 'error').length;
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+
+  // Save eval run to Supabase (unless dry-run)
+  if (!dryRun) {
+    const total = passed + failed + errors;
+    const score = total > 0 ? passed / total : 0;
+
+    const { error: runError } = await supabase.from('eval_run').insert({
+      agent_name: agentName,
+      prompt_version: 'current',
+      eval_type: 'golden',
+      status: failed > 0 || errors > 0 ? 'failed' : 'success',
+      total_examples: total,
+      passed,
+      failed: failed + errors,
+      score,
+      results: results,
+      finished_at: new Date().toISOString(),
+    });
+
+    if (runError) {
+      log(`  ⚠️ Failed to save eval run: ${runError.message}`, 'yellow');
+    } else {
+      log('  📊 Eval run saved to Supabase', 'dim');
+    }
+  }
+
+  log(`\n${'─'.repeat(60)}`, 'dim');
+  log('  SUMMARY', 'bold');
+  log(`${'─'.repeat(60)}`, 'dim');
+
+  log(`  ✓ Passed:  ${passed}`, passed > 0 ? 'green' : 'dim');
+  log(`  ✗ Failed:  ${failed}`, failed > 0 ? 'red' : 'dim');
+  log(`  ⚠ Errors:  ${errors}`, errors > 0 ? 'yellow' : 'dim');
+  if (skipped > 0) {
+    log(`  ○ Skipped: ${skipped}`, 'dim');
+  }
+
+  const total = passed + failed + errors;
+  const passRate = total > 0 ? Math.round((passed / total) * 100) : 0;
+  log(`\n  Pass Rate: ${passRate}%`, passRate >= 80 ? 'green' : passRate >= 50 ? 'yellow' : 'red');
+
+  // Show failures
+  if (failed > 0 && verbose) {
+    log('\n  FAILURES:', 'red');
+    for (const r of results.filter((r) => r.status === 'failed')) {
+      log(`    - ${r.id}`, 'red');
+      for (const check of r.checks.filter((c) => !c.passed)) {
+        log(`      ${check.check}: expected ${check.expected}, got ${check.actual}`, 'dim');
+      }
+    }
+  }
+
+  log('\n');
+
+  // Return exit code based on results
+  return failed > 0 || errors > 0 ? 1 : 0;
+}
+
+// CLI entry point
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help')) {
+    log('\nUsage: node run-eval.js <agent-name> [options]', 'blue');
+    log('\nAgents:');
+    log('  discovery-relevance  - Content relevance scoring');
+    log('  relevance-filter     - Second-pass relevance filter');
+    log('  content-summarizer   - Summary generation');
+    log('  taxonomy-tagger      - Taxonomy classification');
+    log('\nOptions:');
+    log('  --verbose    Show detailed output');
+    log('  --dry-run    Load dataset but skip LLM calls');
+    log('  --help       Show this help');
+    log('\nExamples:');
+    log('  node run-eval.js discovery-relevance');
+    log('  node run-eval.js discovery-relevance --verbose');
+    log('');
+    process.exit(0);
+  }
+
+  const agentName = args.find((a) => !a.startsWith('--'));
+  const verbose = args.includes('--verbose');
+  const dryRun = args.includes('--dry-run');
+
+  if (!agentName) {
+    log('Error: Please specify an agent name', 'red');
+    process.exit(1);
+  }
+
+  try {
+    const exitCode = await runEval(agentName, { verbose, dryRun });
+    process.exit(exitCode);
+  } catch (err) {
+    log(`\nError: ${err.message}`, 'red');
+    process.exit(1);
+  }
+}
+
+main();

--- a/supabase/migrations/20251211143000_seed_discovery_relevance_golden_set.sql
+++ b/supabase/migrations/20251211143000_seed_discovery_relevance_golden_set.sql
@@ -1,0 +1,68 @@
+-- KB-207 Phase 3: Seed golden test set for discovery-relevance agent
+-- These examples are used by the eval runner to test prompt quality
+
+INSERT INTO eval_golden_set (agent_name, name, description, input, expected_output) VALUES
+
+-- High relevance: ECB regulatory
+('discovery-relevance', 'ecb-digital-euro-2024', 'ECB regulatory announcement - should score high for executives',
+ '{"title": "ECB publishes new digital euro framework for retail payments", "description": "The European Central Bank has released comprehensive guidelines for the digital euro implementation, covering privacy, offline payments, and merchant adoption requirements.", "source": "ecb", "publishedDate": "2024-11-15"}',
+ '{"min_score": 7, "primary_audience": "executive", "must_queue": true}'),
+
+-- High relevance: FDIC banking
+('discovery-relevance', 'fdic-bank-failure-2024', 'FDIC resolution announcement - relevant for executives',
+ '{"title": "FDIC announces resolution of regional bank with $2B in assets", "description": "The Federal Deposit Insurance Corporation has completed the resolution of First Community Bank, transferring all deposits to acquiring institution.", "source": "fdic", "publishedDate": "2024-10-20"}',
+ '{"min_score": 6, "primary_audience": "executive", "must_queue": true}'),
+
+-- High relevance: BIS AI risk
+('discovery-relevance', 'bis-ai-risk-management', 'BIS AI framework - high relevance for risk specialists',
+ '{"title": "BIS publishes principles for AI risk management in banking", "description": "Bank for International Settlements releases new framework addressing model risk, explainability requirements, and governance structures for AI adoption in financial institutions.", "source": "bis", "publishedDate": "2024-09-01"}',
+ '{"min_score": 8, "primary_audience": "functional_specialist", "must_queue": true}'),
+
+-- High relevance: McKinsey GenAI
+('discovery-relevance', 'mckinsey-genai-banking', 'McKinsey analysis - executive-level strategic content',
+ '{"title": "Generative AI in banking: A $340 billion opportunity", "description": "McKinsey analysis reveals how banks can capture value through GenAI in customer service, fraud detection, and back-office automation.", "source": "mckinsey", "publishedDate": "2024-08-15"}',
+ '{"min_score": 7, "primary_audience": "executive", "must_queue": true}'),
+
+-- Low relevance: Academic theory
+('discovery-relevance', 'academic-theoretical-finance', 'Pure academic paper - low relevance for most audiences',
+ '{"title": "A Theoretical Framework for Stochastic Volatility Models Under Jump Diffusion", "description": "This paper presents a novel mathematical framework for analyzing option pricing under combined stochastic volatility and jump diffusion processes.", "source": "arxiv", "publishedDate": "2024-07-01"}',
+ '{"max_score": 5, "primary_audience": "researcher", "must_queue": false}'),
+
+-- Not relevant: Consumer finance
+('discovery-relevance', 'personal-finance-tips', 'Consumer content - not relevant for BFSI professionals',
+ '{"title": "10 Tips to Save Money on Your Next Mortgage", "description": "Consumer guide to getting the best mortgage rates, including tips on credit scores, down payments, and shopping around for lenders.", "source": "unknown", "publishedDate": "2024-06-01"}',
+ '{"max_score": 3, "must_queue": false}'),
+
+-- High relevance: DORA regulation
+('discovery-relevance', 'dora-implementation-guide', 'DORA implementation - critical for compliance specialists',
+ '{"title": "DORA Implementation: Technical Requirements for ICT Risk Management", "description": "Detailed guidance on implementing the Digital Operational Resilience Act, covering incident reporting, third-party risk management, and testing requirements.", "source": "eba", "publishedDate": "2024-05-15"}',
+ '{"min_score": 8, "primary_audience": "functional_specialist", "must_queue": true}'),
+
+-- High relevance: Technical API security
+('discovery-relevance', 'api-security-banking', 'Technical deep-dive - relevant for engineers',
+ '{"title": "Securing Open Banking APIs: OAuth 2.0 Implementation Patterns", "description": "Technical deep-dive into implementing secure OAuth flows for PSD2 compliance, including token management, consent handling, and API gateway configurations.", "source": "unknown", "publishedDate": "2024-04-01"}',
+ '{"min_score": 7, "primary_audience": "engineer", "must_queue": true}'),
+
+-- Not relevant: Job posting
+('discovery-relevance', 'job-posting-fintech', 'Job posting - should be rejected',
+ '{"title": "Senior Software Engineer - Payments Platform", "description": "Join our team building the next generation payment infrastructure. Requirements: 5+ years experience, Java/Kotlin, microservices architecture.", "source": "unknown", "publishedDate": "2024-03-01"}',
+ '{"max_score": 2, "must_queue": false}'),
+
+-- High relevance: Fed monetary policy
+('discovery-relevance', 'fed-rate-decision-2024', 'Fed rate decision - high impact for executives',
+ '{"title": "Federal Reserve maintains rates, signals potential cuts in 2025", "description": "FOMC holds federal funds rate steady at 5.25-5.50%, with updated dot plot suggesting three rate cuts next year amid cooling inflation.", "source": "federalreserve", "publishedDate": "2024-12-01"}',
+ '{"min_score": 8, "primary_audience": "executive", "must_queue": true}'),
+
+-- Stale content: Should be rejected
+('discovery-relevance', 'stale-fdic-1996', 'Stale FDIC content - should be rejected due to age/inactive status',
+ '{"title": "FDIC Letter: Guidance on Electronic Fund Transfers", "description": "INACTIVE - This 1996 guidance has been superseded by subsequent regulatory updates.", "source": "fdic", "publishedDate": "1996-03-15"}',
+ '{"max_score": 3, "must_queue": false}'),
+
+-- High relevance: InsurTech case study
+('discovery-relevance', 'insurtech-claims-ai', 'InsurTech AI case study - relevant for executives',
+ '{"title": "How AI is Transforming Insurance Claims Processing", "description": "Case study on major insurer deploying computer vision and NLP for automated claims assessment, achieving 60% reduction in processing time.", "source": "unknown", "publishedDate": "2024-10-01"}',
+ '{"min_score": 7, "primary_audience": "executive", "must_queue": true}')
+
+ON CONFLICT DO NOTHING;
+
+COMMENT ON TABLE eval_golden_set IS 'Human-verified test cases for agent evaluation. KB-207 Phase 3.';


### PR DESCRIPTION
## Problem
No automated way to test prompt quality before deploying changes. Prompt changes could introduce regressions without detection.

## Solution
Create eval framework using existing Supabase tables (`eval_golden_set`, `eval_run`, `eval_result`):

### Eval Runner (`tests/evals/run-eval.js`)
- Loads golden test examples from `eval_golden_set` table
- Runs agent against each example
- Compares output to expected values (min/max score, must_queue, primary_audience)
- Saves results to `eval_run` table for tracking
- Supports `--verbose` and `--dry-run` flags

### Golden Test Set (12 examples)
| Category | Examples |
|----------|----------|
| Regulatory | ECB digital euro, FDIC resolution, BIS AI risk, Fed rate decision, DORA |
| Strategic | McKinsey GenAI analysis, InsurTech case study |
| Technical | Open Banking API security |
| Should Reject | Academic theory, consumer finance, job posting, stale 1996 content |

## Usage
```bash
cd services/agent-api
node tests/evals/run-eval.js discovery-relevance --verbose
```

## Files Changed
- `services/agent-api/tests/evals/run-eval.js` - Eval runner script
- `supabase/migrations/20251211143000_seed_discovery_relevance_golden_set.sql` - Seed data

## Note
Run the migration in Supabase to seed the golden set data before running evals.

Closes https://linear.app/knowledge-base/issue/KB-207