### PR TITLE
fix(KB-211): fix broken import after agent rename

### DIFF
--- a/services/agent-api/src/agents/discoverer.js
+++ b/services/agent-api/src/agents/discoverer.js
@@ -8,7 +8,7 @@ import process from 'node:process';
 import { createClient } from '@supabase/supabase-js';
 import { scrapeWebsite } from '../lib/scrapers.js';
 import { fetchFromSitemap, fetchPageMetadata } from '../lib/sitemap.js';
-import { scoreRelevance } from './discovery-relevance.js';
+import { scoreRelevance } from './scorer.js';
 import {
   getReferenceEmbedding,
   scoreWithEmbedding,


### PR DESCRIPTION
## Problem
The KB-211 agent rename PR broke the agent-api deployment - `discoverer.js` was still importing `discovery-relevance.js` which was renamed to `scorer.js`.

## Root Cause
Import path wasn't updated during the rename.

## Solution
Update import from `./discovery-relevance.js` to `./scorer.js`

## Files Changed
- `services/agent-api/src/agents/discoverer.js` - fix import path

Closes https://linear.app/knowledge-base/issue/KB-211