### PR TITLE
improve: add smoke test to CI for agent-api startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,14 @@ jobs:
         run: npm run test:coverage
         working-directory: services/agent-api
 
+      - name: Smoke test agent-api startup
+        run: timeout 5 npm start || [ $? -eq 124 ]
+        working-directory: services/agent-api
+        env:
+          PORT: 3000
+          PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+
       - name: Build
         if: github.actor != 'dependabot[bot]'
         run: npm run build --if-present


### PR DESCRIPTION
## Problem
The KB-211 rename PR merged with a broken import that crashed agent-api on Render. CI didn't catch it because tests don't actually start the server.

## Solution
Add a smoke test step that starts the agent-api server and verifies it doesn't crash during import/startup.

```yaml
- name: Smoke test agent-api startup
  run: timeout 5 npm start || [ $? -eq 124 ]
```

This starts the server, waits 5 seconds, and passes if it doesn't crash (exit code 124 = timeout, which is success).

## Files Changed
- `.github/workflows/ci.yml` - add smoke test step after agent-api tests