### PR TITLE
fix(KB-216): Review page approve button fails

### DIFF
--- a/admin-next/src/app/(dashboard)/review/[id]/actions.tsx
+++ b/admin-next/src/app/(dashboard)/review/[id]/actions.tsx
@@ -41,12 +41,13 @@ export function ReviewActions({ item }: { item: QueueItem }) {
         slug: `${slug}-${Date.now()}`,
         title,
         source_url: item.url,
-        source_slug: (item.payload?.source_slug as string) || 'manual',
-        published_at: (item.payload?.published_at as string) || new Date().toISOString(),
+        source_name: (item.payload?.source_slug as string) || 'manual',
+        date_published: (item.payload?.published_at as string) || new Date().toISOString(),
         summary_short: summary?.short || '',
         summary_medium: summary?.medium || '',
         summary_long: summary?.long || '',
-        thumbnail_url: item.payload?.thumbnail_url as string,
+        thumbnail: item.payload?.thumbnail_url as string,
+        status: 'published',
       });
 
       if (pubError) throw pubError;
@@ -54,7 +55,7 @@ export function ReviewActions({ item }: { item: QueueItem }) {
       // Update queue status
       const { error: updateError } = await supabase
         .from('ingestion_queue')
-        .update({ status: 'approved' })
+        .update({ status: 'approved', status_code: 330 })
         .eq('id', item.id);
 
       if (updateError) throw updateError;

--- a/admin-next/src/app/(dashboard)/review/actions.ts
+++ b/admin-next/src/app/(dashboard)/review/actions.ts
@@ -99,11 +99,13 @@ export async function bulkApproveAction(ids: string[]) {
       slug: `${slug}-${Date.now()}`,
       title,
       source_url: item.url,
-      source_slug: payload.source_slug || 'manual',
-      published_at: new Date().toISOString(),
+      source_name: payload.source_slug || 'manual',
+      date_published: payload.published_at || new Date().toISOString(),
       summary_short: summary.short || '',
       summary_medium: summary.medium || '',
       summary_long: summary.long || '',
+      thumbnail: payload.thumbnail_url || null,
+      status: 'published',
     });
 
     if (pubError) {
@@ -111,7 +113,10 @@ export async function bulkApproveAction(ids: string[]) {
       return { success: false, error: `Failed to publish: ${pubError.message}` };
     }
 
-    await supabase.from('ingestion_queue').update({ status: 'approved' }).eq('id', item.id);
+    await supabase
+      .from('ingestion_queue')
+      .update({ status: 'approved', status_code: 330 })
+      .eq('id', item.id);
   }
 
   revalidatePath('/review');

--- a/admin-next/src/app/(dashboard)/review/carousel/carousel-review.tsx
+++ b/admin-next/src/app/(dashboard)/review/carousel/carousel-review.tsx
@@ -85,17 +85,19 @@ export function CarouselReview({
         slug: `${slug}-${Date.now()}`,
         title,
         source_url: currentItem.url,
-        source_slug: payload.source_slug || 'manual',
-        published_at: new Date().toISOString(),
+        source_name: payload.source_slug || 'manual',
+        date_published: payload.published_at || new Date().toISOString(),
         summary_short: summary.short || '',
         summary_medium: summary.medium || '',
         summary_long: summary.long || '',
+        thumbnail: payload.thumbnail_url || null,
+        status: 'published',
       });
 
       // Update queue status
       await supabase
         .from('ingestion_queue')
-        .update({ status: 'approved' })
+        .update({ status: 'approved', status_code: 330 })
         .eq('id', currentItem.id);
 
       // Remove from list


### PR DESCRIPTION
## Problem
Approve button on review page was stuck on 'Approving...' and failed silently.

## Root Cause
Wrong column names used when inserting into `kb_publication`:
- `source_slug` → should be `source_name`
- `published_at` → should be `date_published`
- `thumbnail_url` → should be `thumbnail`
- Missing `status: 'published'`

Also missing `status_code: 330` when updating ingestion_queue to approved.

## Solution
Fixed all 3 approve handlers to use correct column names.

## Files Changed
- `admin-next/src/app/(dashboard)/review/actions.ts` - bulkApproveAction
- `admin-next/src/app/(dashboard)/review/carousel/carousel-review.tsx` - handleApprove
- `admin-next/src/app/(dashboard)/review/[id]/actions.tsx` - handleApprove

Closes https://linear.app/knowledge-base/issue/KB-216