### PR TITLE
fix(KB-218): Process Queue skips stuck items

### DIFF
--- a/services/agent-api/src/agents/enricher.js
+++ b/services/agent-api/src/agents/enricher.js
@@ -228,12 +228,13 @@ export async function processQueue(options = {}) {
 
   console.log('🔄 Processing queue...\n');
 
-  // Process items with status_code = PENDING_ENRICHMENT (200)
-  // This includes both discovery items and manual submissions
+  // Process items that need enrichment:
+  // 1. status_code = PENDING_ENRICHMENT (200) - normal queue items
+  // 2. status = 'pending' - stuck items that never got processed (data fix)
   const { data: items, error } = await supabase
     .from('ingestion_queue')
     .select('*')
-    .eq('status_code', STATUS.PENDING_ENRICHMENT)
+    .or(`status_code.eq.${STATUS.PENDING_ENRICHMENT},status.eq.pending`)
     .order('discovered_at', { ascending: true })
     .limit(limit);
 


### PR DESCRIPTION
## Problem
Clicking Process Queue shows '20 items processed' but 5 stuck items remain in Pending Review with status='pending' and no summary.

## Root Cause
Process Queue only processes items with `status_code=200`. The stuck items have `status_code=300` (PENDING_REVIEW) but were never actually enriched - they're old data with inconsistent status.

## Solution
Modified `processQueue` to also pick up items with `status='pending'` regardless of status_code. This fixes stuck items without requiring manual data migration.

## Files Changed
- `services/agent-api/src/agents/enricher.js` - query now uses OR condition

Closes https://linear.app/knowledge-base/issue/KB-218