### PR TITLE
fix(KB-218): Filter rejected items from Pending Review

### DIFF
--- a/admin-next/src/app/(dashboard)/review/page.tsx
+++ b/admin-next/src/app/(dashboard)/review/page.tsx
@@ -50,6 +50,10 @@ async function getQueueItems(status?: string, source?: string, timeWindow?: stri
     const code = statusCodeMap[status];
     if (code) {
       query = query.eq('status_code', code);
+      // For "enriched" filter, also exclude items with wrong status text (data inconsistency)
+      if (status === 'enriched') {
+        query = query.eq('status', 'enriched');
+      }
     } else {
       // Fallback to text status for queued/processing (not yet migrated)
       query = query.eq('status', status);


### PR DESCRIPTION
## Problem
Rejected item showing in Pending Review tab (has status_code=300 but status='rejected').

## Root Cause
Data inconsistency: item has status_code=300 (PENDING_REVIEW) but status='rejected'. Query only filtered by status_code.

## Solution
For 'enriched' (Pending Review) filter, also require status='enriched' to exclude items with inconsistent data.

## Files Changed
- `admin-next/src/app/(dashboard)/review/page.tsx` - added status filter

Closes https://linear.app/knowledge-base/issue/KB-218