### PR TITLE
fix(KB-219): No thumbnails, wrong source, no tags on publications

### DIFF
--- a/services/agent-api/src/agents/enricher.js
+++ b/services/agent-api/src/agents/enricher.js
@@ -157,7 +157,12 @@ async function stepThumbnail(queueId, payload) {
   console.log('   📸 Generating thumbnail...');
   try {
     const result = await runThumbnailer({ id: queueId, payload });
-    return { ...payload, thumbnail_bucket: result.bucket, thumbnail_path: result.path };
+    return {
+      ...payload,
+      thumbnail_bucket: result.bucket,
+      thumbnail_path: result.path,
+      thumbnail_url: result.publicUrl,
+    };
   } catch (error) {
     console.log(`   ⚠️ Thumbnail failed: ${error.message} (continuing without)`);
     return payload;


### PR DESCRIPTION
## Problem
Major regression in enrichment quality:
- No thumbnails on published articles
- Source shows 'manual' instead of domain for manually added articles
- No industry/topic tags being stored

## Root Cause
1. **Thumbnails**: `stepThumbnail` stored `thumbnail_bucket` and `thumbnail_path` but NOT `thumbnail_url` (publicUrl)
2. **Source**: Approve action used `source_slug || 'manual'` instead of extracting domain from URL
3. **Tags**: Approve action didn't insert industry/topic codes into junction tables

## Solution
1. Store `thumbnail_url` in enricher's stepThumbnail
2. Extract domain from URL for `source_name` and `source_domain`
3. Insert tags into `kb_publication_bfsi_industry` and `kb_publication_bfsi_topic` tables

## Files Changed
- `services/agent-api/src/agents/enricher.js` - store thumbnail_url
- `admin-next/src/app/(dashboard)/review/actions.ts` - fix source_name, insert tags
- `admin-next/src/app/(dashboard)/review/carousel/carousel-review.tsx` - same fixes
- `admin-next/src/app/(dashboard)/review/[id]/actions.tsx` - same fixes

## Note
Summary quality and preview modal UX improvements are separate items to address.

Closes https://linear.app/knowledge-base/issue/KB-219