### PR TITLE
fix(KB-219): update status_code to ENRICHED after thumbnail generation

### DIFF
--- a/services/agent-api/src/cli.js
+++ b/services/agent-api/src/cli.js
@@ -388,6 +388,7 @@ async function runThumbnailCmd(options) {
       await supabase
         .from('ingestion_queue')
         .update({
+          status_code: STATUS.ENRICHED,
           payload: {
             ...item.payload,
             thumbnail_url: result.publicUrl,


### PR DESCRIPTION
## Problem
1. Thumbnail CLI didn't update status_code after processing, leaving items stuck at 230 (TO_THUMBNAIL)
2. Failed items kept cycling forever without a retry limit
3. LLM generates 'dpa' regulator code but it's not in database

## Solution
1. Update status_code to 240 (ENRICHED) after successful thumbnail generation
2. Add retry limit (MAX_FETCH_ATTEMPTS=3) - mark as FAILED permanently after max attempts
3. Add DPA (Data Protection Authorities) to regulator table
4. Migration to clean up stuck items:
   - Move items at 230 with thumbnails → 300 (PENDING_REVIEW)
   - Mark items with fetch_attempts >= 3 as FAILED

## Files Changed
- `services/agent-api/src/cli.js` - add status_code update in thumbnail command
- `services/agent-api/src/agents/enricher.js` - add retry tracking with MAX_FETCH_ATTEMPTS=3
- `supabase/migrations/20251213022500_add_dpa_regulator_and_cleanup_stuck.sql` - DPA + cleanup

Closes https://linear.app/knowledge-base/issue/KB-219