### PR TITLE
fix(KB-220): dashboard shows zero published items

### DIFF
--- a/supabase/migrations/20251214170000_fix_published_count_in_status_rpc.sql
+++ b/supabase/migrations/20251214170000_fix_published_count_in_status_rpc.sql
@@ -1,0 +1,43 @@
+-- Fix get_status_code_counts to include kb_publication count for "published" category
+-- KB-220: Dashboard shows zero published items
+--
+-- The issue: published items are in kb_publication table, not ingestion_queue
+-- The RPC only counted ingestion_queue, so "published" always showed 0
+
+CREATE OR REPLACE FUNCTION public.get_status_code_counts()
+RETURNS TABLE (
+  code smallint,
+  name text,
+  category text,
+  count bigint
+) AS $$
+DECLARE
+  v_publication_count bigint;
+BEGIN
+  -- Get count of published items from kb_publication
+  SELECT COUNT(*) INTO v_publication_count FROM public.kb_publication;
+
+  RETURN QUERY
+  SELECT 
+    sl.code,
+    sl.name,
+    sl.category,
+    CASE 
+      -- For "published" status (code 400), use kb_publication count
+      WHEN sl.code = 400 THEN v_publication_count
+      -- For all other statuses, count from ingestion_queue
+      ELSE COALESCE(counts.cnt, 0)
+    END AS count
+  FROM public.status_lookup sl
+  LEFT JOIN (
+    SELECT 
+      iq.status_code,
+      COUNT(*) AS cnt
+    FROM public.ingestion_queue iq
+    WHERE iq.status_code IS NOT NULL
+    GROUP BY iq.status_code
+  ) counts ON sl.code = counts.status_code
+  ORDER BY sl.sort_order;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = '';


### PR DESCRIPTION
## Problem
Dashboard 'Published' category shows 0, even though there are 138 published items in `kb_publication`.

## Root Cause
The `get_status_code_counts()` RPC only queries `ingestion_queue` table. But published items are moved to `kb_publication` table - they don't stay in the queue with status 400.

## Solution
Modified the RPC to count from `kb_publication` table when returning the count for status code 400 (PUBLISHED).

## Files Changed
- `supabase/migrations/20251214170000_fix_published_count_in_status_rpc.sql` - Updated RPC function

## Deployment
Apply migration via Supabase dashboard or `supabase db push` after merge.

Closes https://linear.app/knowledge-base/issue/KB-220