### PR TITLE
fix(KB-223): fix source name, thumbnail, and tags not saving on approval

### DIFF
--- a/admin-next/src/app/(dashboard)/review/actions.ts
+++ b/admin-next/src/app/(dashboard)/review/actions.ts
@@ -44,7 +44,10 @@ export async function approveQueueItemAction(queueId: string, editedTitle?: stri
     .slice(0, 80);
 
   const sourceDomain = extractDomain(item.url);
-  const sourceSlug = payload.source_slug as string | undefined;
+  // Check multiple payload fields for source name (discoverer uses 'source', premium uses 'source_name'/'source_slug')
+  const sourceFromPayload = (payload.source_name || payload.source || payload.source_slug) as
+    | string
+    | undefined;
 
   const thumbnailBucket = (payload.thumbnail_bucket as string | null | undefined) ?? null;
   const thumbnailPath = (payload.thumbnail_path as string | null | undefined) ?? null;
@@ -60,7 +63,8 @@ export async function approveQueueItemAction(queueId: string, editedTitle?: stri
       slug: `${slug}-${Date.now()}`,
       title,
       source_url: item.url,
-      source_name: sourceSlug && sourceSlug !== 'manual' ? sourceSlug : sourceDomain,
+      source_name:
+        sourceFromPayload && sourceFromPayload !== 'manual' ? sourceFromPayload : sourceDomain,
       source_domain: sourceDomain,
       date_published: (payload.published_at as string) || new Date().toISOString(),
       summary_short: (summary.short as string) || '',
@@ -222,8 +226,9 @@ export async function bulkApproveAction(ids: string[]) {
         title,
         source_url: item.url,
         source_name:
-          payload.source_slug && payload.source_slug !== 'manual'
-            ? payload.source_slug
+          (payload.source_name || payload.source || payload.source_slug) &&
+          (payload.source_name || payload.source || payload.source_slug) !== 'manual'
+            ? payload.source_name || payload.source || payload.source_slug
             : sourceDomain,
         source_domain: sourceDomain,
         date_published: payload.published_at || new Date().toISOString(),

--- a/services/agent-api/src/agents/enricher.js
+++ b/services/agent-api/src/agents/enricher.js
@@ -203,11 +203,12 @@ export async function enrichItem(queueItem, options = {}) {
     const tagged = await stepTag(queueItem.id, summarized);
 
     // Step 5: Thumbnail (optional)
+    let finalPayload = tagged;
     if (includeThumbnail) {
-      await stepThumbnail(queueItem.id, tagged);
+      finalPayload = await stepThumbnail(queueItem.id, tagged);
     }
 
-    await updateStatus(queueItem.id, STATUS.PENDING_REVIEW);
+    await updateStatus(queueItem.id, STATUS.PENDING_REVIEW, { payload: finalPayload });
     return { success: true };
   } catch (error) {
     console.error(`❌ Enrichment failed: ${error.message}`);


### PR DESCRIPTION
## Problem
Publications show 'manual' as source, missing thumbnails, and limited tags after approval.

## Root Cause
1. **Source name**: Discoverer sets `payload.source`, but approve action only checked `payload.source_slug`
2. **Thumbnail**: Enricher's `stepThumbnail` returned updated payload, but result was discarded - never saved to database
3. **Tags**: Fixed indirectly - the final payload with all tag data wasn't being saved before approval

## Solution
- Check `payload.source`, `payload.source_name`, and `payload.source_slug` for source name
- Capture `stepThumbnail` result and save `finalPayload` to database
- `updateStatus` now includes full payload before setting PENDING_REVIEW

## Files Changed
- `services/agent-api/src/agents/enricher.js` - Save thumbnail payload to database
- `admin-next/src/app/(dashboard)/review/actions.ts` - Check correct payload fields for source name

## Testing
- Re-enrich an item and verify thumbnail_url is in payload before approval
- Approve and verify source_name, thumbnail, and tags appear on publications page

Closes https://linear.app/knowledge-base/issue/KB-223