### PR TITLE
fix(KB-223): make update-schema-docs CI job non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,12 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         run: npm run build --if-present
 
-  # Update schema docs after merge to main
+  # Update schema docs after merge to main (non-blocking)
   update-schema-docs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    continue-on-error: true  # Don't fail the build if schema update fails
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Add `continue-on-error: true` to the update-schema-docs job so failures don't fail the overall build.

This is a docs-only job that shouldn't block deployments.

Closes https://linear.app/knowledge-base/issue/KB-223