### PR TITLE
fix(KB-223): save audience and geography on approval

### DIFF
--- a/admin-next/src/app/(dashboard)/review/actions.ts
+++ b/admin-next/src/app/(dashboard)/review/actions.ts
@@ -56,6 +56,22 @@ export async function approveQueueItemAction(queueId: string, editedTitle?: stri
     buildPublicStorageUrl(thumbnailBucket, thumbnailPath) ??
     null;
 
+  // Extract audience (highest scoring from audience_scores object)
+  const audienceScores = payload.audience_scores as Record<string, number> | undefined;
+  let audience: string | null = null;
+  if (audienceScores && typeof audienceScores === 'object') {
+    const entries = Object.entries(audienceScores);
+    if (entries.length > 0) {
+      const [topAudience] = entries.reduce((a, b) => (b[1] > a[1] ? b : a));
+      audience = topAudience;
+    }
+  }
+
+  // Extract geography (first from geography_codes array)
+  const geographyCodes = payload.geography_codes as string[] | undefined;
+  const geography =
+    Array.isArray(geographyCodes) && geographyCodes.length > 0 ? geographyCodes[0] : null;
+
   // Insert publication
   const { data: pubData, error: pubError } = await supabase
     .from('kb_publication')
@@ -73,6 +89,8 @@ export async function approveQueueItemAction(queueId: string, editedTitle?: stri
       thumbnail: thumbnailUrl,
       thumbnail_bucket: thumbnailBucket,
       thumbnail_path: thumbnailPath,
+      audience,
+      geography,
       status: 'published',
     })
     .select('id')
@@ -218,6 +236,22 @@ export async function bulkApproveAction(ids: string[]) {
       buildPublicStorageUrl(thumbnailBucket, thumbnailPath) ??
       null;
 
+    // Extract audience (highest scoring from audience_scores object)
+    const audienceScores = payload.audience_scores as Record<string, number> | undefined;
+    let audience: string | null = null;
+    if (audienceScores && typeof audienceScores === 'object') {
+      const entries = Object.entries(audienceScores);
+      if (entries.length > 0) {
+        const [topAudience] = entries.reduce((a, b) => (b[1] > a[1] ? b : a));
+        audience = topAudience;
+      }
+    }
+
+    // Extract geography (first from geography_codes array)
+    const geographyCodes = payload.geography_codes as string[] | undefined;
+    const geography =
+      Array.isArray(geographyCodes) && geographyCodes.length > 0 ? geographyCodes[0] : null;
+
     // Insert publication
     const { data: pubData, error: pubError } = await supabase
       .from('kb_publication')
@@ -238,6 +272,8 @@ export async function bulkApproveAction(ids: string[]) {
         thumbnail: thumbnailUrl,
         thumbnail_bucket: thumbnailBucket,
         thumbnail_path: thumbnailPath,
+        audience,
+        geography,
         status: 'published',
       })
       .select('id')


### PR DESCRIPTION
## Problem
Publications show no audience or geography tags on cards because these fields aren't saved during approval.

## Root Cause
The approve actions extract and save taxonomy tags via junction tables, but `audience` and `geography` are stored directly on `kb_publication` and were never being populated.

## Solution
Extract and save:
- `audience`: highest-scoring value from `payload.audience_scores` object
- `geography`: first value from `payload.geography_codes` array

Applied to both `approveQueueItemAction` and `bulkApproveAction`.

## Note
This is a quick fix. A follow-up ticket (KB-224) will migrate audience/geography to junction tables for consistency with other taxonomy tags.

## Files Changed
- `admin-next/src/app/(dashboard)/review/actions.ts` - Extract and save audience/geography

Closes https://linear.app/knowledge-base/issue/KB-223