### PR TITLE
improve(KB-224): migrate audience and geography to junction tables

### DIFF
--- a/src/features/publications/PublicationCard.astro
+++ b/src/features/publications/PublicationCard.astro
@@ -53,16 +53,22 @@ const expandItemThumb = (t?: string) => {
 const topic = asArr(item.topic);
 const content_type = asArr(item.content_type);
 const audience = item.audience || (item as any).role || '';
+const audiences = item.audiences || [];
 const industry = item.industry || '';
+const industries = item.industries || [];
 const geography = item.geography || '';
+const geographies = item.geographies || [];
 const regulators = item.regulators || [];
 const regulations = item.regulations || [];
 const obligations = item.obligations || [];
 const processes = item.processes || [];
 
-// Count extra tags (everything except audience and geography shown on card)
+// Count extra tags (everything except first audience and first geography shown on card)
+// Extra audiences (beyond first), extra geographies (beyond first), plus all other tags
 const extraTagCount =
-  (industry ? 1 : 0) +
+  Math.max(0, audiences.length - 1) +
+  Math.max(0, geographies.length - 1) +
+  industries.length +
   topic.length +
   content_type.length +
   regulators.length +
@@ -105,10 +111,14 @@ const candidates = [...itemThumbs];
   class="group rounded-2xl border border-neutral-800 bg-neutral-900/60 p-5 shadow-sm ring-1 ring-neutral-800/40 transition-all hover:border-neutral-700 hover:ring-neutral-700 hover:bg-neutral-900 relative"
   aria-labelledby={`t-${item.slug}`}
   data-audience={audience}
+  data-audiences={audiences.join(',') || ''}
   data-industry={industry}
+  data-industries={industries.join(',') || ''}
   data-topic={topic[0] || ''}
+  data-topics={(item.topics || []).join(',') || ''}
   data-content_type={content_type[0] || ''}
   data-geography={geography}
+  data-geographies={geographies.join(',') || ''}
   data-regulator={regulators.join(',') || ''}
   data-regulation={regulations.join(',') || ''}
   data-obligation={obligations.join(',') || ''}

--- a/src/features/publications/publication-modal.ts
+++ b/src/features/publications/publication-modal.ts
@@ -14,14 +14,14 @@ function extractCardData(li: HTMLElement) {
     link: (li.querySelector('a') as HTMLAnchorElement)?.href || '#',
     slug: li.dataset.slug || '',
     tags: [
-      // Audience/role
-      li.dataset.audience || li.dataset.role || '',
-      // Geography
-      li.dataset.geography || '',
-      // Industry
-      li.dataset.industry || '',
-      // Topic
-      li.dataset.topic || '',
+      // All audiences (comma-separated)
+      ...(li.dataset.audiences?.split(',') || [li.dataset.audience || li.dataset.role || '']),
+      // All geographies (comma-separated)
+      ...(li.dataset.geographies?.split(',') || [li.dataset.geography || '']),
+      // All industries (comma-separated)
+      ...(li.dataset.industries?.split(',') || [li.dataset.industry || '']),
+      // All topics (comma-separated)
+      ...(li.dataset.topics?.split(',') || [li.dataset.topic || '']),
       // Content type
       li.dataset.content_type || '',
       // Regulators (comma-separated)

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -32,8 +32,10 @@ export interface Publication {
   summary_long: string | null;
 
   audience: string | null;
+  audiences?: string[];
   content_type: string | null;
   geography: string | null;
+  geographies?: string[];
 
   industry: string | null;
   topic: string | null;

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -139,11 +139,22 @@ const ogImage = thumbCandidates[0];
 
     <div class="mt-4 flex flex-wrap gap-2 text-xs">
       {
-        item.audience && (
-          <span class="rounded-md border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-neutral-300">
-            {item.audience}
-          </span>
-        )
+        (item.audiences || [item.audience])
+          .filter((c): c is string => Boolean(c))
+          .map((code) => (
+            <span class="rounded-md border border-amber-800/50 bg-amber-900/20 px-2 py-0.5 text-amber-300">
+              {code}
+            </span>
+          ))
+      }
+      {
+        (item.geographies || [item.geography])
+          .filter((c): c is string => Boolean(c))
+          .map((code) => (
+            <span class="rounded-md border border-teal-800/50 bg-teal-900/20 px-2 py-0.5 text-teal-300">
+              {code}
+            </span>
+          ))
       }
       {
         item.content_type && (
@@ -154,24 +165,17 @@ const ogImage = thumbCandidates[0];
       }
       {
         (item.industries || []).map((code: string) => (
-          <span class="rounded-md border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-neutral-300">
+          <span class="rounded-md border border-cyan-800/50 bg-cyan-900/20 px-2 py-0.5 text-cyan-300">
             {code}
           </span>
         ))
       }
       {
         (item.topics || []).map((code: string) => (
-          <span class="rounded-md border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-neutral-300">
+          <span class="rounded-md border border-purple-800/50 bg-purple-900/20 px-2 py-0.5 text-purple-300">
             {code}
           </span>
         ))
-      }
-      {
-        item.geography && (
-          <span class="rounded-md border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-neutral-300">
-            {item.geography}
-          </span>
-        )
       }
       {
         (item.regulators || []).map((code: string) => (

--- a/supabase/migrations/20251214200000_migrate_audience_geography_to_junction_tables.sql
+++ b/supabase/migrations/20251214200000_migrate_audience_geography_to_junction_tables.sql
@@ -1,0 +1,155 @@
+-- KB-224: Migrate audience and geography to junction tables
+-- This creates junction tables for audience and geography to match the pattern
+-- used by other taxonomy tags (industry, topic, etc.)
+
+-- ============================================================================
+-- 1. Create kb_audience reference table (if not exists)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS kb_audience (
+  code TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  sort_order INTEGER DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Insert audience types
+INSERT INTO kb_audience (code, name, description, sort_order) VALUES
+  ('executive', 'Executive', 'C-suite and senior leadership', 1),
+  ('functional_specialist', 'Functional Specialist', 'Domain experts and practitioners', 2),
+  ('researcher', 'Researcher', 'Academics and research professionals', 3),
+  ('engineer', 'Engineer', 'Technical and engineering roles', 4)
+ON CONFLICT (code) DO NOTHING;
+
+-- ============================================================================
+-- 2. Create kb_publication_audience junction table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS kb_publication_audience (
+  publication_id UUID NOT NULL REFERENCES kb_publication(id) ON DELETE CASCADE,
+  audience_code TEXT NOT NULL REFERENCES kb_audience(code) ON DELETE CASCADE,
+  score NUMERIC(3,2) DEFAULT 0.0,
+  PRIMARY KEY (publication_id, audience_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pub_audience_code ON kb_publication_audience(audience_code);
+CREATE INDEX IF NOT EXISTS idx_pub_audience_score ON kb_publication_audience(score DESC);
+
+-- ============================================================================
+-- 3. Create kb_publication_geography junction table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS kb_publication_geography (
+  publication_id UUID NOT NULL REFERENCES kb_publication(id) ON DELETE CASCADE,
+  geography_code TEXT NOT NULL REFERENCES kb_geography(code) ON DELETE CASCADE,
+  PRIMARY KEY (publication_id, geography_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pub_geography_code ON kb_publication_geography(geography_code);
+
+-- ============================================================================
+-- 4. Update taxonomy_config for audience and geography
+-- ============================================================================
+
+-- Add audience to taxonomy_config
+INSERT INTO taxonomy_config (
+  slug, display_name, display_name_plural, display_order, behavior_type,
+  source_table, source_code_column, source_name_column,
+  is_hierarchical, junction_table, junction_code_column, payload_field,
+  include_list_in_prompt, prompt_section_title, prompt_instruction,
+  color, is_active
+) VALUES (
+  'audience', 'Audience', 'Audiences', 0, 'scoring',
+  'kb_audience', 'code', 'name',
+  false, 'kb_publication_audience', 'audience_code', 'audience_scores',
+  true, 'AUDIENCE SCORING', 'Score relevance 0.0-1.0 for each audience type.',
+  'amber', true
+) ON CONFLICT (slug) DO UPDATE SET
+  junction_table = 'kb_publication_audience',
+  junction_code_column = 'audience_code',
+  is_active = true;
+
+-- Update geography in taxonomy_config to use junction table
+UPDATE taxonomy_config SET
+  junction_table = 'kb_publication_geography',
+  junction_code_column = 'geography_code'
+WHERE slug = 'geography';
+
+-- ============================================================================
+-- 5. Migrate existing data from kb_publication columns to junction tables
+-- ============================================================================
+
+-- Migrate audience data (single value -> junction with score 1.0)
+INSERT INTO kb_publication_audience (publication_id, audience_code, score)
+SELECT id, audience, 1.0
+FROM kb_publication
+WHERE audience IS NOT NULL
+ON CONFLICT (publication_id, audience_code) DO NOTHING;
+
+-- Migrate geography data (single value -> junction)
+INSERT INTO kb_publication_geography (publication_id, geography_code)
+SELECT id, geography
+FROM kb_publication
+WHERE geography IS NOT NULL
+ON CONFLICT (publication_id, geography_code) DO NOTHING;
+
+-- ============================================================================
+-- 6. Recreate kb_publication_pretty view with audiences[] and geographies[]
+-- ============================================================================
+DROP VIEW IF EXISTS kb_publication_pretty;
+
+CREATE VIEW kb_publication_pretty AS
+SELECT
+  p.id,
+  p.slug,
+  p.title,
+  p.authors,
+  p.source_url AS url,
+  p.source_name,
+  p.source_domain,
+  p.date_published,
+  p.created_at AS date_added,
+  p.updated_at AS last_edited,
+  p.thumbnail,
+  p.thumbnail_bucket,
+  p.thumbnail_path,
+  p.summary_short,
+  p.summary_medium,
+  p.summary_long,
+  p.status,
+  -- Audience: top scoring audience (for backwards compat) + all audiences array
+  (SELECT audience_code FROM kb_publication_audience WHERE publication_id = p.id ORDER BY score DESC LIMIT 1) AS audience,
+  COALESCE((SELECT array_agg(audience_code ORDER BY score DESC) FROM kb_publication_audience WHERE publication_id = p.id), '{}') AS audiences,
+  -- Geography: first geography (for backwards compat) + all geographies array
+  (SELECT geography_code FROM kb_publication_geography WHERE publication_id = p.id LIMIT 1) AS geography,
+  COALESCE((SELECT array_agg(geography_code) FROM kb_publication_geography WHERE publication_id = p.id), '{}') AS geographies,
+  -- Content type (still single value)
+  p.content_type,
+  -- Industry: first + all
+  (SELECT industry_code FROM kb_publication_bfsi_industry WHERE publication_id = p.id ORDER BY rank LIMIT 1) AS industry,
+  COALESCE((SELECT array_agg(industry_code ORDER BY rank) FROM kb_publication_bfsi_industry WHERE publication_id = p.id), '{}') AS industries,
+  -- Topic: first + all
+  (SELECT topic_code FROM kb_publication_bfsi_topic WHERE publication_id = p.id ORDER BY rank LIMIT 1) AS topic,
+  COALESCE((SELECT array_agg(topic_code ORDER BY rank) FROM kb_publication_bfsi_topic WHERE publication_id = p.id), '{}') AS topics,
+  -- Process: all
+  COALESCE((SELECT array_agg(process_code ORDER BY rank) FROM kb_publication_bfsi_process WHERE publication_id = p.id), '{}') AS processes,
+  -- Regulatory
+  COALESCE((SELECT array_agg(regulator_code) FROM kb_publication_regulator WHERE publication_id = p.id), '{}') AS regulators,
+  COALESCE((SELECT array_agg(regulation_code) FROM kb_publication_regulation WHERE publication_id = p.id), '{}') AS regulations,
+  COALESCE((SELECT array_agg(obligation_code) FROM kb_publication_obligation WHERE publication_id = p.id), '{}') AS obligations,
+  -- Legacy fields
+  p.use_cases,
+  p.agentic_capabilities
+FROM kb_publication p
+WHERE p.status = 'published';
+
+-- Grant access
+GRANT SELECT ON kb_publication_pretty TO anon, authenticated;
+GRANT ALL ON kb_publication_audience TO anon, authenticated, service_role;
+GRANT ALL ON kb_publication_geography TO anon, authenticated, service_role;
+GRANT SELECT ON kb_audience TO anon, authenticated;
+
+-- ============================================================================
+-- 7. Add comments for documentation
+-- ============================================================================
+COMMENT ON TABLE kb_publication_audience IS 'Junction table linking publications to audience types with relevance scores';
+COMMENT ON TABLE kb_publication_geography IS 'Junction table linking publications to geographic regions';
+COMMENT ON COLUMN kb_publication_audience.score IS 'Relevance score 0.0-1.0 indicating how relevant the publication is for this audience';


### PR DESCRIPTION
## Problem
Audience and geography are stored as single columns on kb_publication, losing data since the tagger produces multiple audiences with scores and multiple geography codes.

## Solution
Migrate audience and geography to junction tables for consistency with other taxonomy tags.

### Changes
1. **Migration**: Create `kb_audience` reference table, `kb_publication_audience` (with scores), and `kb_publication_geography` junction tables
2. **taxonomy_config**: Add audience and update geography to use junction tables
3. **Approve actions**: Use taxonomy_config pattern for audience/geography (special handling for audience_scores object)
4. **kb_publication_pretty view**: Return `audiences[]` and `geographies[]` arrays
5. **Frontend**: Display all audiences/geographies in modal and detail page

### Data preserved
- Audience scores (0.0-1.0) stored in junction table
- All geography codes stored, not just first
- Backwards compat: `audience` and `geography` columns still populated via view

## Files Changed
- `supabase/migrations/20251214200000_migrate_audience_geography_to_junction_tables.sql`
- `admin-next/src/app/(dashboard)/review/actions.ts`
- `src/lib/supabase.ts`
- `src/features/publications/PublicationCard.astro`
- `src/features/publications/publication-modal.ts`
- `src/pages/[slug].astro`

Closes https://linear.app/knowledge-base/issue/KB-224