### PR TITLE
fix: use top-level await in backfill-thumbnails.js

### DIFF
--- a/services/agent-api/src/scripts/backfill-thumbnails.js
+++ b/services/agent-api/src/scripts/backfill-thumbnails.js
@@ -79,4 +79,9 @@ async function main() {
   console.log(`\n📊 Summary: ${success} success, ${failed} failed`);
 }
 
-main().catch(console.error);
+try {
+  await main();
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
Fixes SonarCloud issue S7785: Prefer top-level await over promise chain.

Changed `main().catch(console.error)` → `try { await main(); } catch (err) { ... }`