### PR TITLE
refactor(KB-229): connect scoring taxonomy_config to source table

### DIFF
--- a/admin-next/src/app/(dashboard)/review/carousel/page.tsx
+++ b/admin-next/src/app/(dashboard)/review/carousel/page.tsx
@@ -40,9 +40,10 @@ async function getReviewData() {
     .limit(100);
 
   // Dynamically fetch taxonomy data for categories with source tables
+  // KB-229: Include scoring types (audience) to get labels from source table
   const taxonomyData: TaxonomyData = {};
   const sourceTables = taxonomyConfig
-    .filter((c) => c.source_table && c.behavior_type !== 'scoring')
+    .filter((c) => c.source_table)
     .map((c) => ({ slug: c.slug, table: c.source_table! }));
 
   // Fetch all source tables in parallel

--- a/supabase/migrations/20251214220600_connect_scoring_taxonomy_config_to_source_table.sql
+++ b/supabase/migrations/20251214220600_connect_scoring_taxonomy_config_to_source_table.sql
@@ -1,0 +1,19 @@
+-- ============================================================================
+-- KB-229: Connect scoring taxonomy_config entries to their source tables
+-- ============================================================================
+-- This enables UI components to dynamically fetch display labels from the
+-- single source of truth (kb_audience) instead of using duplicated display_name values.
+-- ============================================================================
+
+-- Update audience scoring rows to reference kb_audience table
+-- After KB-228, kb_audience uses 'code' and 'name' columns (standard pattern)
+UPDATE taxonomy_config 
+SET 
+  source_table = 'kb_audience',
+  source_code_column = 'code',
+  source_name_column = 'name'
+WHERE slug LIKE 'audience_%' 
+  AND behavior_type = 'scoring';
+
+-- Add comment explaining the relationship
+COMMENT ON COLUMN taxonomy_config.source_table IS 'Source table for taxonomy data. For scoring types like audience_*, this points to the table containing display labels.';


### PR DESCRIPTION
## Problem
Audience scoring rows in `taxonomy_config` have `source_table = null`, requiring UI components to use the duplicated `display_name` instead of fetching labels from the single source of truth (`kb_audience`).

## Root Cause
The original design didn't connect scoring-type taxonomy configs to their source tables, so the UI couldn't dynamically look up display labels.

## Solution
1. Created migration to set `source_table = 'kb_audience'` for all `audience_*` scoring entries
2. Updated `carousel/page.tsx` to include scoring types when loading taxonomyData
3. Added `getAudienceLabel()` helper in `TagDisplay.tsx` that:
   - Extracts audience code from `payload_field` (e.g., `audience_scores.executive` → `executive`)
   - Looks up label from `taxonomyData` (sourced from `kb_audience`)
   - Falls back to `display_name` if lookup fails

## Files Changed
- `supabase/migrations/20251214220600_connect_scoring_taxonomy_config_to_source_table.sql` - migration to set source_table
- `admin-next/src/app/(dashboard)/review/carousel/page.tsx` - include scoring types in taxonomyData loading
- `admin-next/src/components/tags/TagDisplay.tsx` - add getAudienceLabel helper

Closes https://linear.app/knowledge-base/issue/KB-229