### PR TITLE
refactor(KB-230): remove hardcoded audience types from Zod/TypeScript

### DIFF
--- a/admin-next/src/app/(dashboard)/review/master-detail.tsx
+++ b/admin-next/src/app/(dashboard)/review/master-detail.tsx
@@ -19,12 +19,8 @@ interface QueueItem {
     published_at?: string;
     industry_codes?: string[];
     geography_codes?: string[];
-    audience_scores?: {
-      executive?: number;
-      functional_specialist?: number;
-      engineer?: number;
-      researcher?: number;
-    };
+    // KB-230: Dynamic audience scores - keys come from kb_audience table
+    audience_scores?: Record<string, number>;
   };
   discovered_at: string;
 }

--- a/services/agent-api/src/agents/scorer.js
+++ b/services/agent-api/src/agents/scorer.js
@@ -141,12 +141,9 @@ ${audienceSections}
 Respond with JSON:
 {
   "relevance_scores": {
-    "executive": <1-10>,
-    "functional_specialist": <1-10>,
-    "engineer": <1-10>,
-    "researcher": <1-10>
+${audiences.map((a) => `    "${a.code}": <1-10>`).join(',\n')}
   },
-  "primary_audience": "<audience with highest score>",
+  "primary_audience": "<audience code with highest score>",
   "executive_summary": "<1 sentence: what this content is about>",
   "skip_reason": "<null if any score >= 4, otherwise brief reason why rejected>"
 }`;

--- a/services/agent-api/src/agents/tagger.js
+++ b/services/agent-api/src/agents/tagger.js
@@ -72,37 +72,13 @@ const TaggingSchema = z.object({
     .describe('BFSI organizations mentioned (banks, insurers, asset managers)'),
   vendor_names: z.array(z.string()).describe('AI/tech vendors mentioned'),
 
-  // Audience relevance scores (0-1 for each audience type)
+  // KB-230: Audience relevance scores - dynamic record instead of hardcoded keys
+  // Audience types are loaded from kb_audience table at runtime
   audience_scores: z
-    .object({
-      executive: z
-        .number()
-        .min(0)
-        .max(1)
-        .describe('Relevance for C-suite/executives (strategy, business impact, market trends)'),
-      functional_specialist: z
-        .number()
-        .min(0)
-        .max(1)
-        .describe(
-          'Relevance for product managers, risk/compliance/legal specialists, auditors, business analysts',
-        ),
-      engineer: z
-        .number()
-        .min(0)
-        .max(1)
-        .describe(
-          'Relevance for developers, architects, DevOps, security engineers (implementation, APIs, technical details)',
-        ),
-      researcher: z
-        .number()
-        .min(0)
-        .max(1)
-        .describe(
-          'Relevance for academics, PhD researchers, analysts (methodology, data, peer-reviewed findings)',
-        ),
-    })
-    .describe('Relevance scores per audience type'),
+    .record(z.string(), z.number().min(0).max(1))
+    .describe(
+      'Relevance scores (0-1) per audience type. Keys are audience codes from kb_audience table.',
+    ),
 
   // Overall metadata
   overall_confidence: z.number().min(0).max(1).describe('Overall confidence in classification 0-1'),


### PR DESCRIPTION
## Problem
Audience types are hardcoded in 3 places, requiring code changes to add a 5th audience type:
- `tagger.js` Zod schema (explicit object with fixed keys)
- `scorer.js` response format template
- `master-detail.tsx` TypeScript interface

## Root Cause
Original implementation hardcoded audience types before the `kb_audience` table was established as single source of truth.

## Solution
1. **tagger.js**: Changed `audience_scores` from explicit `z.object({...})` to `z.record(z.string(), z.number())`
2. **scorer.js**: Response format now generates audience keys dynamically from `audiences` array (loaded from `kb_audience`)
3. **master-detail.tsx**: Changed interface from explicit keys to `Record<string, number>`

## Files Changed
- `services/agent-api/src/agents/tagger.js` - dynamic Zod schema
- `services/agent-api/src/agents/scorer.js` - dynamic response format
- `admin-next/src/app/(dashboard)/review/master-detail.tsx` - flexible TypeScript interface

## Result
Adding a new audience type now requires only a DB row in `kb_audience` - no code changes needed.

Closes https://linear.app/knowledge-base/issue/KB-230