### PR TITLE
refactor(KB-233): simplify taxonomy_config schema by removing redundant columns

### DIFF
--- a/services/agent-api/tests/agents/tagger.spec.js
+++ b/services/agent-api/tests/agents/tagger.spec.js
@@ -12,13 +12,11 @@ vi.mock('@supabase/supabase-js', () => ({
       select: vi.fn(() => {
         // Return different data based on table
         const mockData = {
-          // KB-231: taxonomy_config for dynamic loading
+          // KB-233: taxonomy_config - simplified without source_code_column/source_name_column
           taxonomy_config: [
             {
               slug: 'industry',
               source_table: 'bfsi_industry',
-              source_code_column: 'code',
-              source_name_column: 'name',
               is_hierarchical: true,
               parent_code_column: 'parent_code',
               behavior_type: 'guardrail',
@@ -26,8 +24,6 @@ vi.mock('@supabase/supabase-js', () => ({
             {
               slug: 'topic',
               source_table: 'bfsi_topic',
-              source_code_column: 'code',
-              source_name_column: 'name',
               is_hierarchical: true,
               parent_code_column: 'parent_code',
               behavior_type: 'guardrail',
@@ -35,8 +31,6 @@ vi.mock('@supabase/supabase-js', () => ({
             {
               slug: 'geography',
               source_table: 'kb_geography',
-              source_code_column: 'code',
-              source_name_column: 'name',
               is_hierarchical: false,
               parent_code_column: 'parent_code',
               behavior_type: 'guardrail',

--- a/supabase/migrations/20251214223200_simplify_taxonomy_config_schema.sql
+++ b/supabase/migrations/20251214223200_simplify_taxonomy_config_schema.sql
@@ -1,0 +1,13 @@
+-- ============================================================================
+-- KB-233: Simplify taxonomy_config schema
+-- ============================================================================
+-- Now that all taxonomy tables use standardized 'code' and 'name' columns
+-- (thanks to KB-228), we no longer need source_code_column and source_name_column.
+-- ============================================================================
+
+-- Drop the redundant columns
+ALTER TABLE taxonomy_config DROP COLUMN IF EXISTS source_code_column;
+ALTER TABLE taxonomy_config DROP COLUMN IF EXISTS source_name_column;
+
+-- Add comment explaining the standardization
+COMMENT ON TABLE taxonomy_config IS 'Central registry for all tag categories. All source tables must use ''code'' and ''name'' columns (standardized in KB-228).';


### PR DESCRIPTION
## Problem
`taxonomy_config` has `source_code_column` and `source_name_column` columns that are now redundant since KB-228 standardized all taxonomy tables to use `code` and `name`.

## Root Cause
Before KB-228, `kb_audience` used `name`/`label` instead of `code`/`name`, requiring these config columns to handle the difference. Now that all tables are standardized, these columns just add complexity.

## Solution
1. Updated `tagger.js` to hardcode `'code'` and `'name'` instead of reading from config
2. Simplified formatting functions to not require column name parameters
3. Created migration to drop `source_code_column` and `source_name_column` from `taxonomy_config`
4. Updated test mocks

## Files Changed
- `services/agent-api/src/agents/tagger.js` - simplified to use hardcoded column names
- `services/agent-api/tests/agents/tagger.spec.js` - updated mock data
- `supabase/migrations/20251214223200_simplify_taxonomy_config_schema.sql` - drop columns

## Result
Simpler schema and code. Adding new taxonomy types no longer requires thinking about column names - just use `code` and `name`.

Closes https://linear.app/knowledge-base/issue/KB-233