### PR TITLE
refactor(KB-236): update code to use status_code instead of text status field (Phase 1)

### DIFF
--- a/scripts/publishing/publish-approved.mjs
+++ b/scripts/publishing/publish-approved.mjs
@@ -17,6 +17,9 @@ dotenv.config();
 
 const supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
 
+// KB-236: Status codes for ingestion_queue (from status_lookup table)
+const STATUS_APPROVED = 330;
+
 // -------------------------------------------------------------
 // Utility helpers
 // -------------------------------------------------------------
@@ -246,10 +249,11 @@ async function main() {
 
   console.log(`🚀 Publishing approved items (${dryRun ? 'DRY RUN' : 'LIVE'})\n`);
 
+  // KB-236: Use status_code instead of text status field
   const { data: items, error } = await supabase
     .from('ingestion_queue')
     .select('*')
-    .eq('status', 'approved')
+    .eq('status_code', STATUS_APPROVED)
     .order('reviewed_at', { ascending: true })
     .limit(limit);
 

--- a/services/agent-api/src/cli.js
+++ b/services/agent-api/src/cli.js
@@ -536,10 +536,11 @@ async function runQueueHealthCmd() {
   }
 
   // Pending items by age
+  // KB-236: Use status_code - items in discovery/enrichment phase (< 300)
   const { data: pending } = await supabase
     .from('ingestion_queue')
     .select('discovered_at, payload')
-    .eq('status', 'pending')
+    .lt('status_code', 300)
     .order('discovered_at', { ascending: true });
 
   if (pending?.length) {
@@ -674,10 +675,11 @@ async function runEvalCmd(options) {
     await runGoldenEval(agentName, agentFn, { limit: options.limit || 100 });
   } else if (evalType === 'judge') {
     // For judge eval, we need sample inputs
+    // KB-236: Use status_code instead of text status field
     const { data: samples } = await supabase
       .from('ingestion_queue')
       .select('payload')
-      .eq('status', 'enriched')
+      .eq('status_code', STATUS.ENRICHED)
       .limit(options.limit || 10);
 
     const inputs = samples?.map((s) => s.payload) || [];


### PR DESCRIPTION
## Problem
The `ingestion_queue` table has both `status` (text) and `status_code` (integer) columns. Code uses both inconsistently, causing confusion. Per KB-202, we should use `status_code` exclusively.

## Solution (Phase 1 of 2)
Updated all code that filters by text `status` to use `status_code` instead:

### Changes Made
- **discoverer.js**: `.eq('status', 'rejected')` → `.eq('status_code', STATUS.REJECTED)`
- **cli.js**: 
  - `.eq('status', 'pending')` → `.lt('status_code', 300)` (items in discovery/enrichment phase)
  - `.eq('status', 'enriched')` → `.eq('status_code', STATUS.ENRICHED)`
- **publish-approved.mjs**: `.eq('status', 'approved')` → `.eq('status_code', STATUS_APPROVED)`

### Status Code Reference
- 330 = approved
- 240 = enriched  
- 540 = rejected
- < 300 = in discovery/enrichment phase

## Files Changed
- `services/agent-api/src/agents/discoverer.js` - use STATUS.REJECTED
- `services/agent-api/src/cli.js` - use status_code for filters
- `scripts/publishing/publish-approved.mjs` - use STATUS_APPROVED

## Phase 2 (separate PR after this merges)
- Drop the text `status` column from `ingestion_queue`
- Update any remaining display code

Closes https://linear.app/knowledge-base/issue/KB-236