### PR TITLE
refactor(KB-237): drop text status column from ingestion_queue (Phase 2)

### DIFF
--- a/services/agent-api/src/agents/improver.js
+++ b/services/agent-api/src/agents/improver.js
@@ -78,9 +78,10 @@ async function isSourceTracked(domain) {
  * Check if URL was ever in ingestion_queue
  */
 async function checkIngestionHistory(urlNorm) {
+  // KB-237: Removed text status field, use status_code only
   const { data } = await getSupabase()
     .from('ingestion_queue')
-    .select('id, status, status_code, payload, discovered_at, created_at')
+    .select('id, status_code, payload, discovered_at, created_at')
     .eq('url_norm', urlNorm)
     .limit(1);
 

--- a/supabase/migrations/20251215233700_drop_text_status_column.sql
+++ b/supabase/migrations/20251215233700_drop_text_status_column.sql
@@ -1,0 +1,36 @@
+-- ============================================================================
+-- KB-237: Drop deprecated text status column from ingestion_queue
+-- ============================================================================
+-- Phase 2 of status field deprecation.
+-- Phase 1 (KB-236) updated all code to use status_code instead of text status.
+-- This migration removes the now-unused text status column.
+-- ============================================================================
+
+-- Drop the check constraint first
+ALTER TABLE ingestion_queue DROP CONSTRAINT IF EXISTS ingestion_queue_status_check;
+
+-- Drop the deprecated text status column
+ALTER TABLE ingestion_queue DROP COLUMN IF EXISTS status;
+
+-- Drop the old index on text status (replaced by idx_queue_status_code)
+DROP INDEX IF EXISTS idx_queue_status;
+
+-- Update table comment to reflect the change
+COMMENT ON TABLE ingestion_queue IS 'Lightweight queue for discovery, enrichment, and review.
+
+STATUS (KB-237):
+- Use status_code (integer) exclusively - text status column has been removed
+- See status_lookup table for code definitions
+- Use get_status_code_counts() RPC for aggregated status counts
+
+RETENTION POLICY (KB-235):
+- Items with terminal status older than 90 days are archived
+- Run: SELECT * FROM archive_old_queue_items(90);
+- Approved/published items are added to seen_urls (prevents re-discovery)
+- Rejected items can be re-discovered if prompts change
+
+INDEX STRATEGY (KB-234):
+- idx_queue_status_discovered: Composite for dashboard (status_code + discovered_at DESC)
+- idx_queue_payload_gin: GIN index for JSONB payload queries
+- idx_queue_url_norm: UNIQUE for deduplication
+- idx_queue_content_hash: UNIQUE for content deduplication';


### PR DESCRIPTION
## Problem
The `ingestion_queue` table still has the deprecated text `status` column even though all code now uses `status_code` (KB-236).

## Solution (Phase 2 of 2)
1. Updated remaining code that selected text `status`:
   - `cli.js`: Queue health report now uses `get_status_code_counts()` RPC
   - `improver.js`: Removed `status` from select statement

2. Created migration to drop the column:
   - Drop `ingestion_queue_status_check` constraint
   - Drop `status` column
   - Drop `idx_queue_status` index

## Files Changed
- `services/agent-api/src/cli.js` - use RPC for status counts, select status_code
- `services/agent-api/src/agents/improver.js` - remove status from select
- `supabase/migrations/20251215233700_drop_text_status_column.sql` - drop column

## Result
`ingestion_queue` now has only `status_code` (integer) - no more confusion about which field to use. Complies with KB-202 rule.

Closes https://linear.app/knowledge-base/issue/KB-237