### PR TITLE
fix(KB-237): complete migration with view drops and recreates

### DIFF
--- a/supabase/migrations/20251215233700_drop_text_status_column.sql
+++ b/supabase/migrations/20251215233700_drop_text_status_column.sql
@@ -6,16 +6,80 @@
 -- This migration removes the now-unused text status column.
 -- ============================================================================
 
--- Drop the check constraint first
+-- =============================================================================
+-- STEP 1: Drop dependent views first
+-- =============================================================================
+
+DROP VIEW IF EXISTS ingestion_review_queue;
+DROP VIEW IF EXISTS v_queue_health;
+DROP VIEW IF EXISTS v_queue_pending_by_source;
+DROP VIEW IF EXISTS v_queue_daily_stats;
+DROP VIEW IF EXISTS ingestion_queue_with_status;
+
+-- =============================================================================
+-- STEP 2: Drop constraint, column, and index
+-- =============================================================================
+
 ALTER TABLE ingestion_queue DROP CONSTRAINT IF EXISTS ingestion_queue_status_check;
-
--- Drop the deprecated text status column
 ALTER TABLE ingestion_queue DROP COLUMN IF EXISTS status;
-
--- Drop the old index on text status (replaced by idx_queue_status_code)
 DROP INDEX IF EXISTS idx_queue_status;
 
--- Update table comment to reflect the change
+-- =============================================================================
+-- STEP 3: Recreate views using status_code (via status_lookup join)
+-- =============================================================================
+
+CREATE VIEW v_queue_health 
+WITH (security_invoker = true) AS
+SELECT 
+  sl.name as status,
+  CASE 
+    WHEN discovered_at > NOW() - INTERVAL '1 day' THEN '0_last_24h'
+    WHEN discovered_at > NOW() - INTERVAL '7 days' THEN '1_last_week'
+    WHEN discovered_at > NOW() - INTERVAL '30 days' THEN '2_last_month'
+    ELSE '3_older'
+  END as age_bucket,
+  COUNT(*) as count,
+  MIN(discovered_at) as oldest,
+  MAX(discovered_at) as newest
+FROM ingestion_queue q
+LEFT JOIN status_lookup sl ON sl.code = q.status_code
+GROUP BY sl.name, age_bucket
+ORDER BY sl.name, age_bucket;
+
+COMMENT ON VIEW v_queue_health IS 'Queue health summary: items by status and age bucket';
+
+CREATE VIEW v_queue_pending_by_source
+WITH (security_invoker = true) AS
+SELECT 
+  payload->>'source' as source,
+  COUNT(*) as pending_count,
+  MIN(discovered_at) as oldest_pending,
+  AVG(EXTRACT(EPOCH FROM (NOW() - discovered_at))/86400)::numeric(10,1) as avg_age_days
+FROM ingestion_queue
+WHERE status_code < 300
+GROUP BY payload->>'source'
+ORDER BY pending_count DESC;
+
+COMMENT ON VIEW v_queue_pending_by_source IS 'Pending items grouped by source to identify backlog';
+
+CREATE VIEW v_queue_daily_stats
+WITH (security_invoker = true) AS
+SELECT 
+  DATE(reviewed_at) as review_date,
+  sl.name as status,
+  COUNT(*) as count
+FROM ingestion_queue q
+LEFT JOIN status_lookup sl ON sl.code = q.status_code
+WHERE reviewed_at > NOW() - INTERVAL '7 days'
+GROUP BY DATE(reviewed_at), sl.name
+ORDER BY review_date DESC, sl.name;
+
+COMMENT ON VIEW v_queue_daily_stats IS 'Daily processing statistics for last 7 days';
+
+-- =============================================================================
+-- STEP 4: Update table comment
+-- =============================================================================
+
 COMMENT ON TABLE ingestion_queue IS 'Lightweight queue for discovery, enrichment, and review.
 
 STATUS (KB-237):


### PR DESCRIPTION
## Problem
The KB-237 migration was merged without the view drops/recreates. The original migration would fail on a fresh DB because views depend on the `status` column.

## Solution
Updated migration to:
1. Drop dependent views first (`ingestion_review_queue`, `v_queue_health`, etc.)
2. Drop constraint, column, and index
3. Recreate views using `status_code` (via `status_lookup` join)

## Note
Database is already correct (SQL was run manually). This fix ensures the migration file matches what was actually executed.

## Files Changed
- `supabase/migrations/20251215233700_drop_text_status_column.sql` - complete migration

Closes https://linear.app/knowledge-base/issue/KB-237