### PR TITLE
improve(KB-245): add user_id attribution to review actions

### DIFF
--- a/supabase/migrations/20251215011500_add_reviewed_by_column.sql
+++ b/supabase/migrations/20251215011500_add_reviewed_by_column.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- KB-245: Add reviewed_by column to ingestion_queue
+-- ============================================================================
+-- Adds user attribution to review actions for accountability.
+-- ============================================================================
+
+-- Add reviewed_by column to track who approved/rejected items
+ALTER TABLE ingestion_queue 
+ADD COLUMN IF NOT EXISTS reviewed_by UUID REFERENCES auth.users(id);
+
+-- Add index for querying by reviewer
+CREATE INDEX IF NOT EXISTS idx_ingestion_queue_reviewed_by 
+ON ingestion_queue(reviewed_by) 
+WHERE reviewed_by IS NOT NULL;
+
+-- Add comment
+COMMENT ON COLUMN ingestion_queue.reviewed_by IS 'User ID who approved/rejected this item (from auth.users)';
+
+-- =============================================================================
+-- Add created_by column to prompt_version
+-- =============================================================================
+
+ALTER TABLE prompt_version 
+ADD COLUMN IF NOT EXISTS created_by UUID REFERENCES auth.users(id);
+
+COMMENT ON COLUMN prompt_version.created_by IS 'User ID who created this prompt version';


### PR DESCRIPTION
## Problem
IT Auditor identified lack of user attribution - no record of who approved/rejected items. Required for SOC 2 compliance and accountability.

## Solution

### Database Changes
- Add `reviewed_by` column to `ingestion_queue` (UUID FK to auth.users)
- Add `created_by` column to `prompt_version` (UUID FK to auth.users)

### Code Changes
- Add `getCurrentUserId()` helper function to get authenticated user
- Update `approveQueueItemAction` to set `reviewed_by` and `reviewed_at`
- Update `bulkApproveAction` to set `reviewed_by` and `reviewed_at`
- Update `bulkRejectAction` to set `reviewed_by` and `reviewed_at`

## Files Changed
- `supabase/migrations/20251215011500_add_reviewed_by_column.sql` - add columns
- `admin-next/src/app/(dashboard)/review/actions.ts` - pass user_id to updates

## Post-Merge
Run migration: `supabase db push`

## Testing
1. Log in to admin UI
2. Approve or reject an item
3. Query: `SELECT id, reviewed_by, reviewed_at FROM ingestion_queue WHERE reviewed_by IS NOT NULL;`
4. Verify user_id is populated

Closes https://linear.app/knowledge-base/issue/KB-245