### PR TITLE
feat(KB-247): add LangSmith for prompt tracing

### DIFF
--- a/services/agent-api/.env.example
+++ b/services/agent-api/.env.example
@@ -11,3 +11,9 @@ AGENT_API_KEY=your-secret-api-key
 # Server
 PORT=3000
 NODE_ENV=development
+
+# LangSmith Tracing (optional - for prompt debugging)
+# Get API key from: https://smith.langchain.com/
+LANGSMITH_API_KEY=
+LANGSMITH_TRACING=false
+LANGSMITH_PROJECT=bfsi-insights

--- a/services/agent-api/package-lock.json
+++ b/services/agent-api/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
         "fast-xml-parser": "^5.3.2",
+        "langsmith": "^0.2.15",
         "openai": "^4.73.1",
         "playwright": "^1.57.0",
         "zod": "^3.23.8"
@@ -1015,6 +1016,18 @@
       "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -1428,6 +1441,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1705,6 +1727,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
@@ -2203,6 +2231,28 @@
         "node": ">=16"
       }
     },
+    "node_modules/langsmith": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.2.15.tgz",
+      "integrity": "sha512-homtJU41iitqIZVuuLW7iarCzD4f39KcfP9RTBWav9jifhrsDa1Ez89Ejr+4qi72iuBu8Y5xykchsGVgiEZ93w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "commander": "^10.0.1",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "openai": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2493,6 +2543,56 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -2677,6 +2777,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.53.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
@@ -2749,7 +2858,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3216,6 +3324,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/services/agent-api/package.json
+++ b/services/agent-api/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "fast-xml-parser": "^5.3.2",
+    "langsmith": "^0.2.15",
     "openai": "^4.73.1",
     "playwright": "^1.57.0",
     "zod": "^3.23.8"

--- a/services/agent-api/src/lib/tracing.js
+++ b/services/agent-api/src/lib/tracing.js
@@ -1,0 +1,207 @@
+/**
+ * LangSmith Tracing Integration
+ *
+ * Provides optional tracing for LLM calls via LangSmith.
+ * Enable by setting LANGSMITH_API_KEY and LANGSMITH_TRACING=true
+ *
+ * KB-247: Add LangSmith for prompt tracing
+ *
+ * FREE TIER LIMITS (as of Dec 2024):
+ * - 5,000 traces/month
+ * - 14-day retention
+ *
+ * Recommended: Enable only for debugging specific issues, not always-on in production.
+ */
+
+import process from 'node:process';
+
+// Lazy-loaded LangSmith client
+let _langsmithClient = null;
+let _tracingEnabled = null;
+
+/**
+ * Check if tracing is enabled
+ */
+export function isTracingEnabled() {
+  if (_tracingEnabled === null) {
+    _tracingEnabled = !!(process.env.LANGSMITH_API_KEY && process.env.LANGSMITH_TRACING === 'true');
+    if (_tracingEnabled) {
+      console.log('📊 LangSmith tracing enabled');
+    }
+  }
+  return _tracingEnabled;
+}
+
+/**
+ * Get or create LangSmith client
+ */
+async function getLangSmithClient() {
+  if (!isTracingEnabled()) return null;
+
+  if (!_langsmithClient) {
+    try {
+      const { Client } = await import('langsmith');
+      _langsmithClient = new Client({
+        apiKey: process.env.LANGSMITH_API_KEY,
+        apiUrl: process.env.LANGSMITH_ENDPOINT || 'https://api.smith.langchain.com',
+      });
+    } catch (error) {
+      console.warn('⚠️ Failed to initialize LangSmith client:', error.message);
+      _tracingEnabled = false;
+      return null;
+    }
+  }
+  return _langsmithClient;
+}
+
+/**
+ * Create a new trace run for an agent execution
+ * @param {object} options - Trace options
+ * @param {string} options.name - Run name (agent name)
+ * @param {string} options.runType - Type of run ('chain', 'llm', 'tool')
+ * @param {object} options.inputs - Input data
+ * @param {string} options.queueId - Queue item ID for correlation
+ * @param {string} options.parentRunId - Parent run ID for nesting
+ * @returns {Promise<object|null>} Run object with id and methods
+ */
+export async function createTrace(options) {
+  const client = await getLangSmithClient();
+  if (!client) return null;
+
+  const { name, runType = 'chain', inputs, queueId, parentRunId } = options;
+
+  try {
+    const runId = crypto.randomUUID();
+
+    await client.createRun({
+      id: runId,
+      name,
+      run_type: runType,
+      inputs,
+      start_time: new Date().toISOString(),
+      parent_run_id: parentRunId,
+      extra: {
+        metadata: {
+          queue_id: queueId,
+          project: 'bfsi-insights',
+        },
+      },
+      project_name: process.env.LANGSMITH_PROJECT || 'bfsi-insights',
+    });
+
+    return {
+      id: runId,
+
+      /**
+       * End the trace with outputs
+       */
+      async end(outputs, error = null) {
+        try {
+          await client.updateRun(runId, {
+            outputs,
+            error: error?.message,
+            end_time: new Date().toISOString(),
+          });
+        } catch (e) {
+          console.warn('⚠️ Failed to end trace:', e.message);
+        }
+      },
+
+      /**
+       * Create a child trace (for nested LLM calls)
+       */
+      async createChild(childOptions) {
+        return createTrace({
+          ...childOptions,
+          parentRunId: runId,
+          queueId,
+        });
+      },
+    };
+  } catch (error) {
+    console.warn('⚠️ Failed to create trace:', error.message);
+    return null;
+  }
+}
+
+/**
+ * Trace an LLM call
+ * @param {object} options - LLM call options
+ * @param {string} options.name - Call name
+ * @param {string} options.model - Model name
+ * @param {Array} options.messages - Chat messages
+ * @param {object} options.response - LLM response
+ * @param {object} options.usage - Token usage
+ * @param {number} options.durationMs - Call duration
+ * @param {string} options.queueId - Queue item ID
+ * @param {string} options.parentRunId - Parent trace ID
+ */
+export async function traceLLMCall(options) {
+  const client = await getLangSmithClient();
+  if (!client) return;
+
+  const { name, model, messages, response, usage, durationMs, queueId, parentRunId, error } =
+    options;
+
+  try {
+    const runId = crypto.randomUUID();
+    const startTime = new Date(Date.now() - durationMs);
+
+    await client.createRun({
+      id: runId,
+      name: name || `llm_call_${model}`,
+      run_type: 'llm',
+      inputs: { messages },
+      outputs: error ? undefined : { response },
+      error: error?.message,
+      start_time: startTime.toISOString(),
+      end_time: new Date().toISOString(),
+      parent_run_id: parentRunId,
+      extra: {
+        metadata: {
+          queue_id: queueId,
+          model,
+          tokens_prompt: usage?.prompt_tokens,
+          tokens_completion: usage?.completion_tokens,
+          tokens_total: usage?.total_tokens,
+        },
+      },
+      project_name: process.env.LANGSMITH_PROJECT || 'bfsi-insights',
+    });
+  } catch (e) {
+    console.warn('⚠️ Failed to trace LLM call:', e.message);
+  }
+}
+
+/**
+ * Wrapper to trace an async function
+ * @param {string} name - Trace name
+ * @param {function} fn - Function to trace
+ * @param {object} context - Context with queueId, parentRunId
+ */
+export async function withTrace(name, fn, context = {}) {
+  if (!isTracingEnabled()) {
+    return fn();
+  }
+
+  const trace = await createTrace({
+    name,
+    runType: 'chain',
+    inputs: context.inputs || {},
+    queueId: context.queueId,
+    parentRunId: context.parentRunId,
+  });
+
+  if (!trace) {
+    return fn();
+  }
+
+  try {
+    const result = await fn(trace);
+    await trace.end({ result });
+    return result;
+  } catch (error) {
+    await trace.end(null, error);
+    throw error;
+  }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -53,6 +53,7 @@ sonar.coverage.exclusions=\
   **/agents/discover-classics.js,\
   **/lib/content-fetcher.js,\
   **/lib/runner.js,\
+  **/lib/tracing.js,\
   **/lib/evals.js,\
   **/lib/scrapers.js,\
   **/lib/embeddings.js,\


### PR DESCRIPTION
## Problem
Agentic AI Programmer identified lack of trace/observability - hard to debug why specific items scored poorly or were misclassified.

## Solution
Integrated LangSmith for optional prompt tracing.

### Features
- **Opt-in tracing** via `LANGSMITH_TRACING=true`
- **Agent-level traces** - each agent run creates a parent trace
- **LLM call traces** - individual LLM calls can be traced via `traceLLM()` helper
- **Correlation** - traces include `queue_id` for linking to ingestion queue items
- **Zero overhead when disabled** - tracing module checks env vars early

### Files Changed
- `services/agent-api/src/lib/tracing.js` - new tracing module
- `services/agent-api/src/lib/runner.js` - integrate tracing into AgentRunner
- `services/agent-api/package.json` - add langsmith dependency
- `services/agent-api/.env.example` - document LANGSMITH_* variables

### Usage
```bash
# Enable tracing
LANGSMITH_API_KEY=lsv2_...
LANGSMITH_TRACING=true
LANGSMITH_PROJECT=bfsi-insights
```

Then view traces at: https://smith.langchain.com/

### Testing
1. Set env vars above
2. Run an agent (e.g., process a queue item)
3. Check LangSmith dashboard for traces

Closes https://linear.app/knowledge-base/issue/KB-247