### PR TITLE
feat(KB-248): add automated eval runs on prompt version changes

### DIFF
--- a/admin-next/src/app/(dashboard)/prompts/components/AgentTable.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/components/AgentTable.tsx
@@ -4,6 +4,26 @@ import type { PromptVersion } from '@/types/database';
 import type { PromptsByAgent } from '../types';
 import { estimateTokens, getStageBadge, getAgentIcon } from '../utils';
 
+// Eval status badge component
+function EvalStatusBadge({ status, score }: { status: string; score?: number }) {
+  const configs: Record<string, { icon: string; className: string; label: string }> = {
+    passed: { icon: '🟢', className: 'bg-emerald-500/20 text-emerald-300', label: 'Passed' },
+    warning: { icon: '🟡', className: 'bg-yellow-500/20 text-yellow-300', label: 'Warning' },
+    failed: { icon: '🔴', className: 'bg-red-500/20 text-red-300', label: 'Failed' },
+    running: { icon: '⏳', className: 'bg-blue-500/20 text-blue-300', label: 'Running' },
+    pending: { icon: '⏸️', className: 'bg-neutral-500/20 text-neutral-300', label: 'Pending' },
+  };
+  const config = configs[status] || configs.pending;
+  const scoreText = score !== undefined ? ` ${(score * 100).toFixed(0)}%` : '';
+
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-xs ${config.className}`}>
+      {config.icon} {config.label}
+      {scoreText}
+    </span>
+  );
+}
+
 interface AgentTableProps {
   agents: string[];
   promptsByAgent: PromptsByAgent;
@@ -31,6 +51,7 @@ export function AgentTable({
           <th className="px-4 py-3">Chars</th>
           <th className="px-4 py-3">~Tokens</th>
           <th className="px-4 py-3">Status</th>
+          <th className="px-4 py-3">Eval</th>
           <th className="px-4 py-3">Actions</th>
         </tr>
       </thead>
@@ -83,6 +104,19 @@ export function AgentTable({
                   <span className="rounded-full bg-red-500/20 text-red-300 px-2 py-0.5 text-xs">
                     ⚠️ Missing
                   </span>
+                )}
+              </td>
+              <td className="px-4 py-3">
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- KB-248: fields added in migration, types will sync after build */}
+                {(currentPrompt as any)?.last_eval_status ? (
+                  <EvalStatusBadge
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    status={(currentPrompt as any).last_eval_status}
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    score={(currentPrompt as any).last_eval_score}
+                  />
+                ) : (
+                  <span className="text-neutral-500 text-xs">—</span>
                 )}
               </td>
               <td className="px-4 py-3">

--- a/packages/types/src/prompt.ts
+++ b/packages/types/src/prompt.ts
@@ -13,7 +13,14 @@ export interface PromptVersion {
   is_current: boolean;
   created_at: string;
   notes?: string;
+  // Eval status (KB-248)
+  last_eval_run_id?: string;
+  last_eval_score?: number;
+  last_eval_status?: PromptEvalStatus;
+  last_eval_at?: string;
 }
+
+export type PromptEvalStatus = 'pending' | 'running' | 'passed' | 'warning' | 'failed';
 
 export type PromptStage = 'development' | 'staging' | 'production';
 

--- a/services/agent-api/src/lib/prompt-eval.js
+++ b/services/agent-api/src/lib/prompt-eval.js
@@ -1,0 +1,273 @@
+/**
+ * Prompt Evaluation Runner
+ *
+ * Runs eval against golden sets when prompt versions change.
+ * KB-248: Automated eval runs on prompt version changes
+ */
+
+import process from 'node:process';
+import { createClient } from '@supabase/supabase-js';
+// Note: runGoldenEval and getEvalHistory are available from ./evals.js for future use
+
+const supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+
+/**
+ * Run eval for a specific prompt version
+ * @param {object} options
+ * @param {string} options.agentName - Agent name
+ * @param {string} options.promptVersionId - UUID of prompt_version record
+ * @param {string} options.triggerType - 'manual' | 'auto_on_change' | 'scheduled'
+ */
+export async function runPromptEval(options) {
+  const { agentName, promptVersionId, triggerType = 'manual' } = options;
+
+  console.log(`\n🧪 Running prompt eval for ${agentName}`);
+  console.log(`   Prompt version: ${promptVersionId}`);
+  console.log(`   Trigger: ${triggerType}`);
+
+  // Get prompt version details
+  const { data: promptVersion, error: pvError } = await supabase
+    .from('prompt_version')
+    .select('*')
+    .eq('id', promptVersionId)
+    .single();
+
+  if (pvError || !promptVersion) {
+    throw new Error(`Prompt version not found: ${promptVersionId}`);
+  }
+
+  // Check if golden set exists for this agent
+  const { data: goldenExamples, error: gsError } = await supabase
+    .from('eval_golden_set')
+    .select('id')
+    .eq('agent_name', agentName)
+    .limit(1);
+
+  if (gsError) throw gsError;
+
+  if (!goldenExamples?.length) {
+    console.log(`⚠️ No golden set found for ${agentName}, skipping eval`);
+
+    // Update prompt version to indicate no eval available
+    await supabase
+      .from('prompt_version')
+      .update({
+        last_eval_status: 'pending',
+        last_eval_at: new Date().toISOString(),
+      })
+      .eq('id', promptVersionId);
+
+    return {
+      status: 'skipped',
+      reason: 'No golden set available',
+      agentName,
+      promptVersionId,
+    };
+  }
+
+  // Get baseline from previous version
+  const { data: previousEvals } = await supabase
+    .from('eval_run')
+    .select('score')
+    .eq('agent_name', agentName)
+    .eq('status', 'success')
+    .order('finished_at', { ascending: false })
+    .limit(1);
+
+  const baselineScore = previousEvals?.[0]?.score ?? null;
+
+  // Create eval run with prompt_version_id linked
+  const { data: evalRun, error: runError } = await supabase
+    .from('eval_run')
+    .insert({
+      agent_name: agentName,
+      prompt_version: promptVersion.version,
+      prompt_version_id: promptVersionId,
+      eval_type: 'golden',
+      trigger_type: triggerType,
+      baseline_score: baselineScore,
+      status: 'running',
+      started_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (runError) throw runError;
+
+  // Update prompt version to show eval is running
+  await supabase
+    .from('prompt_version')
+    .update({
+      last_eval_run_id: evalRun.id,
+      last_eval_status: 'running',
+    })
+    .eq('id', promptVersionId);
+
+  try {
+    // Import the agent function dynamically based on agent name
+    const agentFn = await getAgentFunction(agentName);
+
+    if (!agentFn) {
+      throw new Error(`No agent function found for: ${agentName}`);
+    }
+
+    // Fetch golden examples
+    const { data: examples } = await supabase
+      .from('eval_golden_set')
+      .select('*')
+      .eq('agent_name', agentName);
+
+    let passed = 0;
+    let failed = 0;
+
+    for (const example of examples) {
+      try {
+        const actual = await agentFn(example.input);
+        const match = compareResults(example.expected_output, actual);
+
+        if (match) passed++;
+        else failed++;
+
+        await supabase.from('eval_result').insert({
+          run_id: evalRun.id,
+          input: example.input,
+          expected_output: example.expected_output,
+          actual_output: actual,
+          passed: match,
+          score: match ? 1 : 0,
+        });
+      } catch (err) {
+        failed++;
+        console.error(`   ❌ Error on example: ${err.message}`);
+      }
+    }
+
+    const score = examples.length > 0 ? passed / examples.length : 0;
+    const scoreDelta = baselineScore !== null ? score - baselineScore : null;
+    const regressionDetected = baselineScore !== null && score < baselineScore - 0.1;
+
+    // Update eval run with results
+    await supabase
+      .from('eval_run')
+      .update({
+        status: 'success',
+        passed,
+        failed,
+        total_examples: examples.length,
+        score,
+        score_delta: scoreDelta,
+        regression_detected: regressionDetected,
+        finished_at: new Date().toISOString(),
+      })
+      .eq('id', evalRun.id);
+
+    // The trigger will update prompt_version automatically
+
+    console.log(
+      `\n📊 Eval complete: ${passed}/${examples.length} passed (${(score * 100).toFixed(1)}%)`,
+    );
+    if (scoreDelta !== null) {
+      console.log(
+        `   Delta from baseline: ${scoreDelta > 0 ? '+' : ''}${(scoreDelta * 100).toFixed(1)}%`,
+      );
+    }
+    if (regressionDetected) {
+      console.log(`   ⚠️ Regression detected!`);
+    }
+
+    return {
+      status: 'success',
+      evalRunId: evalRun.id,
+      agentName,
+      promptVersionId,
+      score,
+      passed,
+      failed,
+      total: examples.length,
+      baselineScore,
+      scoreDelta,
+      regressionDetected,
+    };
+  } catch (err) {
+    // Update eval run as failed
+    await supabase
+      .from('eval_run')
+      .update({
+        status: 'failed',
+        finished_at: new Date().toISOString(),
+      })
+      .eq('id', evalRun.id);
+
+    throw err;
+  }
+}
+
+/**
+ * Get agent function for running eval
+ */
+async function getAgentFunction(agentName) {
+  // Map agent names to their runner functions
+  const agentMap = {
+    screener: async (input) => {
+      const { runRelevanceFilter } = await import('../agents/screener.js');
+      return runRelevanceFilter(input);
+    },
+    summarizer: async (input) => {
+      const { runSummarizer } = await import('../agents/summarizer.js');
+      return runSummarizer(input);
+    },
+    tagger: async (input) => {
+      const { runTagger } = await import('../agents/tagger.js');
+      return runTagger(input);
+    },
+    scorer: async (input) => {
+      const { runScorer } = await import('../agents/scorer.js');
+      return runScorer(input);
+    },
+  };
+
+  return agentMap[agentName] || null;
+}
+
+/**
+ * Simple comparison of expected vs actual output
+ */
+function compareResults(expected, actual) {
+  if (!expected || !actual) return false;
+
+  // For boolean-like results (screener)
+  if (typeof expected.relevant === 'boolean') {
+    return expected.relevant === actual.relevant;
+  }
+
+  // For tagged results (tagger)
+  if (expected.tags && actual.tags) {
+    const expectedTags = new Set(expected.tags);
+    const actualTags = new Set(actual.tags);
+    const intersection = [...expectedTags].filter((t) => actualTags.has(t));
+    return intersection.length / expectedTags.size >= 0.8;
+  }
+
+  // For score-based results (scorer)
+  if (typeof expected.score === 'number' && typeof actual.score === 'number') {
+    return Math.abs(expected.score - actual.score) <= 1;
+  }
+
+  // Default: stringify and compare
+  return JSON.stringify(expected) === JSON.stringify(actual);
+}
+
+/**
+ * Get eval status for an agent
+ */
+export async function getPromptEvalStatus(agentName) {
+  const { data, error } = await supabase
+    .from('v_prompt_eval_status')
+    .select('*')
+    .eq('agent_name', agentName)
+    .eq('is_current', true)
+    .single();
+
+  if (error) return null;
+  return data;
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -54,6 +54,7 @@ sonar.coverage.exclusions=\
   **/lib/content-fetcher.js,\
   **/lib/runner.js,\
   **/lib/tracing.js,\
+  **/lib/prompt-eval.js,\
   **/lib/evals.js,\
   **/lib/scrapers.js,\
   **/lib/embeddings.js,\

--- a/supabase/migrations/20251215030000_add_prompt_eval_tracking.sql
+++ b/supabase/migrations/20251215030000_add_prompt_eval_tracking.sql
@@ -1,0 +1,120 @@
+-- ============================================================================
+-- KB-248: Add automated eval runs on prompt version changes
+-- ============================================================================
+-- Links eval_run to specific prompt_version and adds trigger status tracking
+-- ============================================================================
+
+-- Add prompt_version_id to eval_run for direct linking
+ALTER TABLE eval_run 
+ADD COLUMN IF NOT EXISTS prompt_version_id UUID REFERENCES prompt_version(id);
+
+-- Add trigger_type to indicate how the eval was triggered
+ALTER TABLE eval_run 
+ADD COLUMN IF NOT EXISTS trigger_type TEXT 
+CHECK (trigger_type IN ('manual', 'auto_on_change', 'scheduled'));
+
+-- Add baseline comparison columns
+ALTER TABLE eval_run 
+ADD COLUMN IF NOT EXISTS baseline_score NUMERIC(5,4);
+
+ALTER TABLE eval_run 
+ADD COLUMN IF NOT EXISTS score_delta NUMERIC(5,4);
+
+ALTER TABLE eval_run 
+ADD COLUMN IF NOT EXISTS regression_detected BOOLEAN DEFAULT false;
+
+-- Index for quick lookups by prompt version
+CREATE INDEX IF NOT EXISTS idx_eval_run_prompt_version 
+ON eval_run(prompt_version_id) 
+WHERE prompt_version_id IS NOT NULL;
+
+-- Add last_eval columns to prompt_version for quick status display
+ALTER TABLE prompt_version 
+ADD COLUMN IF NOT EXISTS last_eval_run_id UUID REFERENCES eval_run(id);
+
+ALTER TABLE prompt_version 
+ADD COLUMN IF NOT EXISTS last_eval_score NUMERIC(5,4);
+
+ALTER TABLE prompt_version 
+ADD COLUMN IF NOT EXISTS last_eval_status TEXT 
+CHECK (last_eval_status IN ('pending', 'running', 'passed', 'warning', 'failed'));
+
+ALTER TABLE prompt_version 
+ADD COLUMN IF NOT EXISTS last_eval_at TIMESTAMPTZ;
+
+-- Comments
+COMMENT ON COLUMN eval_run.prompt_version_id IS 'Links eval run to specific prompt version';
+COMMENT ON COLUMN eval_run.trigger_type IS 'How eval was triggered: manual, auto_on_change, scheduled';
+COMMENT ON COLUMN eval_run.baseline_score IS 'Score from previous version for comparison';
+COMMENT ON COLUMN eval_run.score_delta IS 'Difference from baseline (positive = improvement)';
+COMMENT ON COLUMN eval_run.regression_detected IS 'True if score dropped significantly from baseline';
+
+COMMENT ON COLUMN prompt_version.last_eval_run_id IS 'Most recent eval run for this version';
+COMMENT ON COLUMN prompt_version.last_eval_score IS 'Score from most recent eval (0-1)';
+COMMENT ON COLUMN prompt_version.last_eval_status IS 'Status: passed (>=baseline), warning (<baseline), failed (regression)';
+COMMENT ON COLUMN prompt_version.last_eval_at IS 'Timestamp of last eval run';
+
+-- =============================================================================
+-- Function to update prompt_version after eval completes
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION update_prompt_eval_status()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only update when eval finishes (status changes to success or failed)
+  IF NEW.status IN ('success', 'failed') AND OLD.status = 'running' THEN
+    -- Update the prompt_version with eval results
+    IF NEW.prompt_version_id IS NOT NULL THEN
+      UPDATE prompt_version SET
+        last_eval_run_id = NEW.id,
+        last_eval_score = NEW.score,
+        last_eval_status = CASE
+          WHEN NEW.status = 'failed' THEN 'failed'
+          WHEN NEW.regression_detected THEN 'warning'
+          WHEN NEW.score >= 0.8 THEN 'passed'
+          WHEN NEW.score >= 0.6 THEN 'warning'
+          ELSE 'failed'
+        END,
+        last_eval_at = NEW.finished_at
+      WHERE id = NEW.prompt_version_id;
+    END IF;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger to auto-update prompt_version when eval completes
+DROP TRIGGER IF EXISTS update_prompt_eval_status_trigger ON eval_run;
+CREATE TRIGGER update_prompt_eval_status_trigger
+  AFTER UPDATE ON eval_run
+  FOR EACH ROW
+  EXECUTE FUNCTION update_prompt_eval_status();
+
+COMMENT ON FUNCTION update_prompt_eval_status IS 'Updates prompt_version eval status when eval_run completes';
+
+-- =============================================================================
+-- View for prompt eval status (for admin UI)
+-- =============================================================================
+
+CREATE OR REPLACE VIEW v_prompt_eval_status
+WITH (security_invoker = true) AS
+SELECT 
+  pv.id,
+  pv.agent_name,
+  pv.version,
+  pv.is_current,
+  pv.last_eval_status,
+  pv.last_eval_score,
+  pv.last_eval_at,
+  er.eval_type,
+  er.passed,
+  er.failed,
+  er.total_examples,
+  er.baseline_score,
+  er.score_delta,
+  er.regression_detected
+FROM prompt_version pv
+LEFT JOIN eval_run er ON er.id = pv.last_eval_run_id;
+
+COMMENT ON VIEW v_prompt_eval_status IS 'Prompt versions with their latest eval status';


### PR DESCRIPTION
## Summary
Adds infrastructure for running automated evals when prompt versions change.

## Changes
- Migration: Add eval tracking columns to eval_run and prompt_version tables
- API: POST /api/agents/eval/run and GET /api/agents/eval/status/:agentName
- UI: Eval status column in prompts page AgentTable
- Types: PromptEvalStatus and eval fields on PromptVersion

## Files Changed
- supabase/migrations/20251215030000_add_prompt_eval_tracking.sql
- services/agent-api/src/lib/prompt-eval.js
- services/agent-api/src/routes/agents.js
- packages/types/src/prompt.ts
- admin-next/src/app/(dashboard)/prompts/components/AgentTable.tsx
- sonar-project.properties

Closes https://linear.app/knowledge-base/issue/KB-248