### PR TITLE
fix(KB-249): View Source uses URL fallback when origin_queue_id is null

### DIFF
--- a/admin-next/src/app/(dashboard)/published/page.tsx
+++ b/admin-next/src/app/(dashboard)/published/page.tsx
@@ -12,6 +12,7 @@ interface Publication {
   source_url: string;
   date_published: string;
   date_added: string;
+  origin_queue_id: string | null;
 }
 
 async function getPublications(search?: string) {
@@ -19,7 +20,7 @@ async function getPublications(search?: string) {
 
   let query = supabase
     .from('kb_publication')
-    .select('id, slug, title, source_url, date_published, date_added')
+    .select('id, slug, title, source_url, date_published, date_added, origin_queue_id')
     .eq('status', 'published')
     .order('date_added', { ascending: false })
     .limit(200);
@@ -92,7 +93,12 @@ export default async function PublishedPage({
                     <span>Added: {formatDateTime(pub.date_added)}</span>
                   </div>
                 </div>
-                <PublicationActions publicationId={pub.id} title={pub.title} />
+                <PublicationActions
+                  publicationId={pub.id}
+                  title={pub.title}
+                  queueItemId={pub.origin_queue_id}
+                  sourceUrl={pub.source_url}
+                />
               </div>
             </div>
           ))

--- a/admin-next/src/app/(dashboard)/published/publication-actions.tsx
+++ b/admin-next/src/app/(dashboard)/published/publication-actions.tsx
@@ -6,9 +6,16 @@ import { useRouter } from 'next/navigation';
 interface PublicationActionsProps {
   publicationId: string;
   title: string;
+  queueItemId: string | null;
+  sourceUrl: string;
 }
 
-export function PublicationActions({ publicationId, title }: PublicationActionsProps) {
+export function PublicationActions({
+  publicationId,
+  title,
+  queueItemId,
+  sourceUrl,
+}: PublicationActionsProps) {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
 
@@ -40,7 +47,11 @@ export function PublicationActions({ publicationId, title }: PublicationActionsP
   return (
     <div className="flex items-center gap-2">
       <a
-        href={`/review?search=${encodeURIComponent(title)}`}
+        href={
+          queueItemId
+            ? `/review?id=${queueItemId}`
+            : `/review?url=${encodeURIComponent(sourceUrl)}&status=all`
+        }
         className="px-3 py-1.5 rounded-lg border border-neutral-700 text-neutral-300 text-sm hover:bg-neutral-800"
       >
         View Source

--- a/admin-next/src/app/(dashboard)/review/page.tsx
+++ b/admin-next/src/app/(dashboard)/review/page.tsx
@@ -51,8 +51,38 @@ async function getQueueItems(
   source?: string,
   timeWindow?: string,
   statusCodes?: Record<string, number>,
+  itemId?: string,
+  urlSearch?: string,
 ) {
   const supabase = createServiceRoleClient();
+
+  // If specific item ID provided, fetch just that item (for View Source from Published)
+  if (itemId) {
+    const { data, error } = await supabase
+      .from('ingestion_queue')
+      .select('id, url, status_code, payload, discovered_at')
+      .eq('id', itemId);
+
+    if (error || !data?.length) {
+      console.error('Error fetching queue item by ID:', error?.message);
+      return { items: [], sources: [] };
+    }
+    return { items: data as QueueItem[], sources: [] };
+  }
+
+  // If URL search provided, find item by URL (fallback when origin_queue_id is missing)
+  if (urlSearch) {
+    const { data, error } = await supabase
+      .from('ingestion_queue')
+      .select('id, url, status_code, payload, discovered_at')
+      .eq('url', urlSearch);
+
+    if (error || !data?.length) {
+      console.error('Error fetching queue item by URL:', error?.message);
+      return { items: [], sources: [] };
+    }
+    return { items: data as QueueItem[], sources: [] };
+  }
 
   let query = supabase
     .from('ingestion_queue')
@@ -161,10 +191,22 @@ async function getTaxonomyData() {
 export default async function ReviewPage({
   searchParams,
 }: {
-  searchParams: Promise<{ status?: string; source?: string; time?: string; view?: string }>;
+  searchParams: Promise<{
+    status?: string;
+    source?: string;
+    time?: string;
+    view?: string;
+    id?: string;
+    search?: string;
+    url?: string;
+  }>;
 }) {
   const params = await searchParams;
-  const status = params.status || 'pending_review';
+  const itemId = params.id || '';
+  const urlSearch = params.url || '';
+  const _searchQuery = params.search || ''; // Reserved for future search functionality
+  // When viewing specific item or URL search, show all statuses
+  const status = itemId || urlSearch ? 'all' : params.status || 'pending_review';
   const source = params.source || '';
   const timeWindow = params.time || '';
   const viewMode = params.view || 'split'; // 'list' or 'split'
@@ -174,7 +216,7 @@ export default async function ReviewPage({
 
   const [{ items, sources: _sources }, allSources, { taxonomyConfig, taxonomyData }] =
     await Promise.all([
-      getQueueItems(status, source, timeWindow, statusCodes),
+      getQueueItems(status, source, timeWindow, statusCodes, itemId, urlSearch),
       getAllSources(),
       getTaxonomyData(),
     ]);


### PR DESCRIPTION
## Problem
View Source shows 'No Source' for published articles where origin_queue_id is null.

## Solution
Fall back to URL-based search when origin_queue_id is missing:
- Pass sourceUrl to PublicationActions component
- Add ?url= parameter support to review page
- Always show 'View Source' button (never 'No Source')

## Files Changed
- `admin-next/.../published/page.tsx` - Pass sourceUrl prop
- `admin-next/.../published/publication-actions.tsx` - Use URL fallback
- `admin-next/.../review/page.tsx` - Support ?url= parameter

Closes https://linear.app/knowledge-base/issue/KB-249