### PR TITLE
fix(KB-249): add URL fallback for View Source when origin_queue_id is null

### DIFF
--- a/admin-next/src/app/(dashboard)/published/page.tsx
+++ b/admin-next/src/app/(dashboard)/published/page.tsx
@@ -97,6 +97,7 @@ export default async function PublishedPage({
                   publicationId={pub.id}
                   title={pub.title}
                   queueItemId={pub.origin_queue_id}
+                  sourceUrl={pub.source_url}
                 />
               </div>
             </div>

--- a/admin-next/src/app/(dashboard)/published/publication-actions.tsx
+++ b/admin-next/src/app/(dashboard)/published/publication-actions.tsx
@@ -7,9 +7,15 @@ interface PublicationActionsProps {
   publicationId: string;
   title: string;
   queueItemId: string | null;
+  sourceUrl: string;
 }
 
-export function PublicationActions({ publicationId, title, queueItemId }: PublicationActionsProps) {
+export function PublicationActions({
+  publicationId,
+  title,
+  queueItemId,
+  sourceUrl,
+}: PublicationActionsProps) {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
 
@@ -40,18 +46,16 @@ export function PublicationActions({ publicationId, title, queueItemId }: Public
 
   return (
     <div className="flex items-center gap-2">
-      {queueItemId ? (
-        <a
-          href={`/review?id=${queueItemId}`}
-          className="px-3 py-1.5 rounded-lg border border-neutral-700 text-neutral-300 text-sm hover:bg-neutral-800"
-        >
-          View Source
-        </a>
-      ) : (
-        <span className="px-3 py-1.5 rounded-lg border border-neutral-700 text-neutral-500 text-sm cursor-not-allowed">
-          No Source
-        </span>
-      )}
+      <a
+        href={
+          queueItemId
+            ? `/review?id=${queueItemId}`
+            : `/review?url=${encodeURIComponent(sourceUrl)}&status=all`
+        }
+        className="px-3 py-1.5 rounded-lg border border-neutral-700 text-neutral-300 text-sm hover:bg-neutral-800"
+      >
+        View Source
+      </a>
       <button
         onClick={handleDelete}
         disabled={loading}


### PR DESCRIPTION
## Problem
View Source shows 'No Source' for published articles where origin_queue_id is null.

## Solution
Fall back to URL-based search when origin_queue_id is missing:
- Add sourceUrl prop to PublicationActions
- Add ?url= parameter support to review page
- Always show 'View Source' button

## Files Changed
- `admin-next/.../published/publication-actions.tsx` - Add sourceUrl prop, use URL fallback
- `admin-next/.../published/page.tsx` - Pass sourceUrl
- `admin-next/.../review/page.tsx` - Support ?url= parameter

Closes https://linear.app/knowledge-base/issue/KB-249