### PR TITLE
fix(KB-252): remove duplicate thumbnail route mount

### DIFF
--- a/services/agent-api/src/index.js
+++ b/services/agent-api/src/index.js
@@ -87,7 +87,6 @@ app.post('/api/trigger-build', async (req, res) => {
 // Note: More specific routes must come first
 app.use('/api/agents/thumbnail', requireApiKey, thumbnailRoutes);
 app.use('/api/agents', requireApiKey, agentRoutes);
-app.use('/api/agents/thumbnail', requireApiKey, thumbnailRoutes);
 
 app.listen(port, () => {
   console.log(`🤖 Agent API running on port ${port}`);


### PR DESCRIPTION
## Problem
Thumbnail batch failing with 'Failed to start thumbnail batch' error.

## Root Cause
The thumbnail route was mounted twice in index.js (lines 88 and 90), causing routing issues.

## Solution
Removed the duplicate route mount.

## Files Changed
- `services/agent-api/src/index.js` - removed duplicate line

Closes https://linear.app/knowledge-base/issue/KB-252