### PR TITLE
fix(KB-252): fix SonarCloud code smell issues

### DIFF
--- a/services/agent-api/src/lib/discovery-config.js
+++ b/services/agent-api/src/lib/discovery-config.js
@@ -116,6 +116,6 @@ export function isPoorTitle(title) {
   if (!title) return true;
   if (title.length < 10) return true;
   if (!title.includes(' ')) return true;
-  if (/^(fil|nr|bulletin)\d+/i.test(title.replace(/\s+/g, ''))) return true;
+  if (/^(fil|nr|bulletin)\d+/i.test(title.replaceAll(/\s+/g, ''))) return true;
   return false;
 }

--- a/src/features/publications/multi-select-filters.ts
+++ b/src/features/publications/multi-select-filters.ts
@@ -9,11 +9,6 @@ import {
   matchesFilters,
   matchesSearch,
   sortIndices,
-  createChip,
-  countActiveFilters,
-  serializeFilterState,
-  deserializeFilterState,
-  createDebouncer,
 } from './filter-utils';
 
 export default function initMultiSelectFilters() {


### PR DESCRIPTION
## Problem
SonarCloud flagged 7 code smell issues in the codebase.

## Solution
- **discovery-config.js**: Use `replaceAll()` instead of `replace(/g)` per ES2021 best practice
- **multi-select-filters.ts**: Remove 5 unused imports (createChip, countActiveFilters, serializeFilterState, deserializeFilterState, createDebouncer)

## Note
The `discovery-scoring.js` await issue appears to be a false positive - `scoreRelevance` is defined as `async function` in scorer.js.

## Files Changed
- `services/agent-api/src/lib/discovery-config.js`
- `src/features/publications/multi-select-filters.ts`

Closes https://linear.app/knowledge-base/issue/KB-252