### PR TITLE
fix(KB-252): fix JSDoc return type for scoreRelevance

### DIFF
--- a/services/agent-api/src/agents/scorer.js
+++ b/services/agent-api/src/agents/scorer.js
@@ -302,7 +302,7 @@ export async function checkRejectionPatterns(title, description = '', source = '
 /**
  * Score a candidate for executive relevance
  * @param {Object} candidate - { title, description, source }
- * @returns {Object} - { relevance_score, executive_summary, skip_reason, usage }
+ * @returns {Promise<Object>} - { relevance_score, executive_summary, skip_reason, usage }
  */
 export async function scoreRelevance(candidate) {
   const { title, description = '', source = '', publishedDate = null, url = '' } = candidate;


### PR DESCRIPTION
## Problem
SonarCloud flagged 'Unexpected await of a non-Promise' on line 124 of discovery-scoring.js.

## Root Cause
The JSDoc for `scoreRelevance` said `@returns {Object}` but the function is async and returns a Promise. SonarCloud uses JSDoc types for analysis.

## Solution
Changed `@returns {Object}` to `@returns {Promise<Object>}` in scorer.js.

## Files Changed
- `services/agent-api/src/agents/scorer.js` - fix JSDoc return type

Closes https://linear.app/knowledge-base/issue/KB-252