### PR TITLE
improve(KB-253): make prompt panel more readable

### DIFF
--- a/admin-next/src/app/(dashboard)/prompts/components/AgentDetail.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/components/AgentDetail.tsx
@@ -66,9 +66,11 @@ export function AgentDetail({
         </div>
       )}
 
-      <div className="flex-shrink-0">
-        <h3 className="text-sm font-medium text-neutral-400 mb-3">Version History</h3>
-        <div className="space-y-2">
+      <div className="flex-shrink-0 max-h-[200px] flex flex-col">
+        <h3 className="text-sm font-medium text-neutral-400 mb-3 flex-shrink-0">
+          Version History ({prompts.length})
+        </h3>
+        <div className="space-y-2 overflow-y-auto flex-1 pr-2">
           {prompts.map((p) => (
             <div
               key={p.version}


### PR DESCRIPTION
## Problem
The prompt panel in the Prompts page has poor readability - only ~4 lines visible, and the version history takes up excessive space that will become unmanageable with many versions.

## Solution
- Added max-height (200px) to version history section with vertical scrolling
- Show version count in header for better context
- More vertical space now available for prompt content area

## Files Changed
- `admin-next/src/app/(dashboard)/prompts/components/AgentDetail.tsx` - scrollable version history

Closes https://linear.app/knowledge-base/issue/KB-253