### PR TITLE
fix(KB-255): fix Supabase database linter issues

### DIFF
--- a/supabase/migrations/20251216000000_fix_supabase_linter_issues.sql
+++ b/supabase/migrations/20251216000000_fix_supabase_linter_issues.sql
@@ -43,8 +43,7 @@ ALTER FUNCTION public.get_entity_audit_history SET search_path = public;
 -- Fix audit_trigger_func
 ALTER FUNCTION public.audit_trigger_func SET search_path = public;
 
--- Fix approve_from_queue
-ALTER FUNCTION public.approve_from_queue SET search_path = public;
+-- Note: approve_from_queue already has search_path set in 20251211104231
 
 -- =============================================================================
 -- 3. WARNINGS: Revoke anon/authenticated access from materialized view


### PR DESCRIPTION
## Problem
Supabase database linter reporting multiple security and performance issues.

## Solution
Migration that fixes:

### Errors (2)
- Enable RLS on `seen_urls` and `ingestion_queue_archive`

### Warnings (8)
- Set `search_path = public` on 6 functions
- Revoke anon/authenticated access from `rejection_summary` materialized view
- Drop duplicate index on `prompt_version`

### Info - Performance (reduced from 58 to ~25)
- Added 2 indexes for unindexed foreign keys (`status_history.from_status`, `thumbnail_jobs.current_item_id`)
- Dropped 33 unused indexes

## Files Changed
- `supabase/migrations/20251216000000_fix_supabase_linter_issues.sql`

## Manual Action Required
Run migration in Supabase SQL Editor (Dashboard → SQL Editor → paste and execute)

Closes https://linear.app/knowledge-base/issue/KB-255