### PR TITLE
fix(KB-253): fix prompt panel layout overflow

### DIFF
--- a/admin-next/src/app/(dashboard)/prompts/page.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/page.tsx
@@ -78,8 +78,8 @@ export default function PromptsPage() {
 
       <div
         ref={containerRef}
-        className="flex flex-col"
-        style={{ height: selectedAgent ? 'calc(100vh - 350px)' : 'auto' }}
+        className="flex flex-col overflow-hidden"
+        style={{ height: selectedAgent ? 'calc(100vh - 280px)' : 'auto' }}
       >
         <div
           className="rounded-xl border border-neutral-800 overflow-hidden"
@@ -107,7 +107,7 @@ export default function PromptsPage() {
         )}
 
         {selectedAgent && promptsByAgent[selectedAgent] && (
-          <div className="flex-1 min-h-0">
+          <div className="flex-1 min-h-0 overflow-hidden">
             <AgentDetail
               agentName={selectedAgent}
               prompts={promptsByAgent[selectedAgent]}


### PR DESCRIPTION
## Problem
The prompt panel still had overlap issues at the bottom - version history was overlapping with page content.

## Solution
- Added `overflow-hidden` to container and AgentDetail wrapper
- Increased available height (reduced offset from 350px to 280px)
- Prevents content from overflowing its boundaries

## Files Changed
- `admin-next/src/app/(dashboard)/prompts/page.tsx` - layout fixes
- `admin-next/src/app/(dashboard)/prompts/components/AgentDetail.tsx` - scrollable version history

Closes https://linear.app/knowledge-base/issue/KB-253