### PR TITLE
feat(KB-259): add Enrichment and Tagging agent controls to dashboard

### DIFF
--- a/admin-next/src/app/(dashboard)/page.tsx
+++ b/admin-next/src/app/(dashboard)/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import { createServiceRoleClient } from '@/lib/supabase/server';
 import { PipelineStatusGrid } from '@/components/dashboard/PipelineStatusGrid';
+import { EnrichmentCard } from '@/components/dashboard/EnrichmentCard';
+import { TaggingCard } from '@/components/dashboard/TaggingCard';
 import { ThumbnailJobsCard } from '@/components/dashboard/ThumbnailJobsCard';
 
 // Force dynamic rendering to always get fresh data
@@ -293,8 +295,32 @@ export default async function DashboardPage() {
         <PipelineStatusGrid statusData={allStatusData} />
       </div>
 
+      {/* Agent Controls */}
+      <div className="space-y-3">
+        <h2 className="text-xs md:text-sm font-medium text-neutral-400 uppercase tracking-wide">
+          Agent Controls
+        </h2>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 md:gap-4">
+          <EnrichmentCard
+            pendingCount={
+              (allStatusData?.find((s: { code: number }) => s.code === 210)?.count as number) || 0
+            }
+          />
+          <TaggingCard
+            pendingCount={
+              (allStatusData?.find((s: { code: number }) => s.code === 220)?.count as number) || 0
+            }
+          />
+          <ThumbnailJobsCard
+            pendingCount={
+              (allStatusData?.find((s: { code: number }) => s.code === 230)?.count as number) || 0
+            }
+          />
+        </div>
+      </div>
+
       {/* Other Metrics */}
-      <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4">
+      <div className="grid grid-cols-2 gap-3 md:gap-4">
         <div className="rounded-xl border border-purple-500/20 bg-purple-500/5 p-3 md:p-4">
           <p className="text-xs md:text-sm text-neutral-400">Active A/B Tests</p>
           <p className="mt-1 text-xl md:text-2xl font-bold text-purple-400">{activeTests}</p>
@@ -309,11 +335,6 @@ export default async function DashboardPage() {
             Review proposals →
           </Link>
         </div>
-        <ThumbnailJobsCard
-          pendingCount={
-            (allStatusData?.find((s: { code: number }) => s.code === 230)?.count as number) || 0
-          }
-        />
       </div>
 
       {/* Quick Actions */}

--- a/admin-next/src/app/api/enrich/route.ts
+++ b/admin-next/src/app/api/enrich/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const AGENT_API_URL = process.env.AGENT_API_URL || 'http://localhost:3001';
+const AGENT_API_KEY = process.env.AGENT_API_KEY || '';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const res = await fetch(`${AGENT_API_URL}/api/agents/run/summarize`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': AGENT_API_KEY,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error('Enrich error:', error);
+    return NextResponse.json({ error: 'Failed to run enrichment' }, { status: 500 });
+  }
+}

--- a/admin-next/src/app/api/tag/route.ts
+++ b/admin-next/src/app/api/tag/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const AGENT_API_URL = process.env.AGENT_API_URL || 'http://localhost:3001';
+const AGENT_API_KEY = process.env.AGENT_API_KEY || '';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const res = await fetch(`${AGENT_API_URL}/api/agents/run/tag`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': AGENT_API_KEY,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch (error) {
+    console.error('Tag error:', error);
+    return NextResponse.json({ error: 'Failed to run tagging' }, { status: 500 });
+  }
+}

--- a/admin-next/src/components/dashboard/EnrichmentCard.tsx
+++ b/admin-next/src/components/dashboard/EnrichmentCard.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+
+interface EnrichmentCardProps {
+  pendingCount: number;
+}
+
+export function EnrichmentCard({ pendingCount }: EnrichmentCardProps) {
+  const [processing, setProcessing] = useState(false);
+  const [batchSize, setBatchSize] = useState(10);
+  const [result, setResult] = useState<{ processed: number; message?: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const runEnrichment = async () => {
+    setProcessing(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch('/api/enrich', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ limit: batchSize }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Failed to run enrichment');
+        return;
+      }
+      setResult({ processed: data.processed || 0, message: data.message });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-4">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-white">Summarizing</h3>
+        <span className="text-sm text-emerald-400">{pendingCount} pending</span>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <select
+            value={batchSize}
+            onChange={(e) => setBatchSize(Number(e.target.value))}
+            className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-sm text-white"
+          >
+            <option value={5}>5 items</option>
+            <option value={10}>10 items</option>
+            <option value={25}>25 items</option>
+            <option value={50}>50 items</option>
+          </select>
+
+          <button
+            onClick={runEnrichment}
+            disabled={processing || pendingCount === 0}
+            className="flex-1 px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 disabled:bg-neutral-700 disabled:text-neutral-500 text-white text-sm rounded transition-colors"
+          >
+            {processing ? 'Running...' : 'Run Batch'}
+          </button>
+        </div>
+
+        {error && <p className="text-xs text-red-400">{error}</p>}
+        {result && (
+          <p className="text-xs text-emerald-400">
+            {result.message || `Processed ${result.processed} items`}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin-next/src/components/dashboard/TaggingCard.tsx
+++ b/admin-next/src/components/dashboard/TaggingCard.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+
+interface TaggingCardProps {
+  pendingCount: number;
+}
+
+export function TaggingCard({ pendingCount }: TaggingCardProps) {
+  const [processing, setProcessing] = useState(false);
+  const [batchSize, setBatchSize] = useState(10);
+  const [result, setResult] = useState<{ processed: number; message?: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const runTagging = async () => {
+    setProcessing(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch('/api/tag', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ limit: batchSize }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Failed to run tagging');
+        return;
+      }
+      setResult({ processed: data.processed || 0, message: data.message });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-4">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-white">Tagging</h3>
+        <span className="text-sm text-violet-400">{pendingCount} pending</span>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <select
+            value={batchSize}
+            onChange={(e) => setBatchSize(Number(e.target.value))}
+            className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-sm text-white"
+          >
+            <option value={5}>5 items</option>
+            <option value={10}>10 items</option>
+            <option value={25}>25 items</option>
+            <option value={50}>50 items</option>
+          </select>
+
+          <button
+            onClick={runTagging}
+            disabled={processing || pendingCount === 0}
+            className="flex-1 px-3 py-1.5 bg-violet-600 hover:bg-violet-700 disabled:bg-neutral-700 disabled:text-neutral-500 text-white text-sm rounded transition-colors"
+          >
+            {processing ? 'Running...' : 'Run Batch'}
+          </button>
+        </div>
+
+        {error && <p className="text-xs text-red-400">{error}</p>}
+        {result && (
+          <p className="text-xs text-violet-400">
+            {result.message || `Processed ${result.processed} items`}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem
Dashboard only had Thumbnailing control card, missing controls for Summarizing and Tagging agents.

## Solution
- Add **EnrichmentCard** component for running summarizer agent (to_summarize → to_tag)
- Add **TaggingCard** component for running tagger agent (to_tag → to_thumbnail)
- Add API routes `/api/enrich` and `/api/tag` to proxy to agent-api
- Create new 'Agent Controls' section on dashboard with all 3 cards
- Move A/B Tests and Proposals boxes to separate section below

## Files Changed
- `admin-next/src/app/(dashboard)/page.tsx` - add imports and Agent Controls section
- `admin-next/src/components/dashboard/EnrichmentCard.tsx` - new component
- `admin-next/src/components/dashboard/TaggingCard.tsx` - new component
- `admin-next/src/app/api/enrich/route.ts` - new API route
- `admin-next/src/app/api/tag/route.ts` - new API route

Closes https://linear.app/knowledge-base/issue/KB-259