### PR TITLE
fix(KB-255): advance thumbnailer to PENDING_REVIEW instead of ENRICHED

### DIFF
--- a/services/agent-api/src/routes/agent-jobs.js
+++ b/services/agent-api/src/routes/agent-jobs.js
@@ -63,7 +63,7 @@ const AGENTS = {
     runner: runThumbnailer,
     statusCode: () => STATUS.TO_THUMBNAIL,
     workingStatusCode: () => STATUS.THUMBNAILING,
-    nextStatusCode: () => STATUS.ENRICHED,
+    nextStatusCode: () => STATUS.PENDING_REVIEW,
     updatePayload: (item, result) => ({
       ...item.payload,
       thumbnail_url: result.publicUrl,

--- a/supabase/migrations/20251216105400_fix_enriched_to_pending_review.sql
+++ b/supabase/migrations/20251216105400_fix_enriched_to_pending_review.sql
@@ -1,0 +1,8 @@
+-- ============================================================================
+-- KB-255: Fix items stuck at enriched (240) - move to pending_review (300)
+-- These items were thumbnailed but not advanced to review queue due to bug
+-- ============================================================================
+
+UPDATE ingestion_queue
+SET status_code = 300
+WHERE status_code = 240;


### PR DESCRIPTION
## Problem
402 items stuck at 'enriched' (status 240) instead of advancing to 'pending review' (300).

## Root Cause
Thumbnailer in agent-jobs.js had `nextStatusCode: () => STATUS.ENRICHED` (240) instead of `STATUS.PENDING_REVIEW` (300).

## Solution
- Changed thumbnailer `nextStatusCode` to `STATUS.PENDING_REVIEW`
- Added migration to move existing 402 stuck items from 240 to 300

## Files Changed
- `services/agent-api/src/routes/agent-jobs.js` - fix nextStatusCode
- `supabase/migrations/20251216105400_fix_enriched_to_pending_review.sql` - fix stuck items

## Migration Required
Run the SQL migration in Supabase SQL Editor before or after deploying.

Closes https://linear.app/knowledge-base/issue/KB-255