### PR TITLE
fix(KB-256): filter null codes before split() in review list

### DIFF
--- a/admin-next/src/app/(dashboard)/review/master-detail.tsx
+++ b/admin-next/src/app/(dashboard)/review/master-detail.tsx
@@ -181,22 +181,28 @@ export function MasterDetailView({
                     {((item.payload?.industry_codes || []).length > 0 ||
                       (item.payload?.geography_codes || []).length > 0) && (
                       <div className="flex flex-wrap gap-1 mt-1.5">
-                        {(item.payload?.industry_codes || []).slice(0, 2).map((code) => (
-                          <span
-                            key={code}
-                            className="px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-300 text-[10px]"
-                          >
-                            {code.split('-').pop()}
-                          </span>
-                        ))}
-                        {(item.payload?.geography_codes || []).slice(0, 2).map((code) => (
-                          <span
-                            key={code}
-                            className="px-1.5 py-0.5 rounded bg-green-500/20 text-green-300 text-[10px]"
-                          >
-                            {code}
-                          </span>
-                        ))}
+                        {(item.payload?.industry_codes || [])
+                          .filter(Boolean)
+                          .slice(0, 2)
+                          .map((code) => (
+                            <span
+                              key={code}
+                              className="px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-300 text-[10px]"
+                            >
+                              {code.split('-').pop()}
+                            </span>
+                          ))}
+                        {(item.payload?.geography_codes || [])
+                          .filter(Boolean)
+                          .slice(0, 2)
+                          .map((code) => (
+                            <span
+                              key={code}
+                              className="px-1.5 py-0.5 rounded bg-green-500/20 text-green-300 text-[10px]"
+                            >
+                              {code}
+                            </span>
+                          ))}
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Problem
Review page crashes with `Cannot read properties of null (reading 'split')` error.

## Root Cause
Some items have null values in `industry_codes` and `geography_codes` arrays. The code was calling `code.split('-').pop()` without checking for null.

## Solution
Added `.filter(Boolean)` before `.slice()` to remove null/undefined values from arrays before mapping.

## Files Changed
- `admin-next/src/app/(dashboard)/review/master-detail.tsx` - filter nulls before split

Closes https://linear.app/knowledge-base/issue/KB-256