### PR TITLE
fix(KB-256): add stale job cleanup and reset stuck items

### DIFF
--- a/supabase/migrations/20251216110600_fix_stuck_jobs.sql
+++ b/supabase/migrations/20251216110600_fix_stuck_jobs.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- KB-256: Fix stuck jobs and items in working status
+-- Thumbnailing job stuck at 8/50 for 565+ minutes
+-- Tagging items stuck in working status (221)
+-- ============================================================================
+
+-- Mark stale running jobs as failed
+UPDATE agent_jobs
+SET status = 'failed',
+    error_message = 'Job timed out (stale) - manual cleanup',
+    completed_at = now(),
+    current_item_id = NULL,
+    current_item_title = NULL
+WHERE status = 'running'
+  AND started_at < now() - interval '30 minutes';
+
+-- Reset tagging items (221) back to to_tag (220)
+UPDATE ingestion_queue
+SET status_code = 220
+WHERE status_code = 221;
+
+-- Reset thumbnailing items (231) back to to_thumbnail (230)
+UPDATE ingestion_queue
+SET status_code = 230
+WHERE status_code = 231;


### PR DESCRIPTION
## Problem
- Thumbnailing job stuck at 8/50, running for 565+ minutes
- Tagging shows 67 pending but no progress bar visible
- Items stuck in 'working' status (221/231) block new jobs

## Root Cause
When a job crashes (e.g., Render timeout), it stays in 'running' status forever in the database, blocking new jobs from starting. Items being processed when the crash occurs remain stuck in 'working' status.

## Solution
1. **Stale job detection**: Jobs running > 30 minutes without completion are automatically cleaned up
2. **Auto-cleanup on start**: `cleanupStaleJob()` runs before checking for running jobs
3. **Reset stuck items**: Items in 'working' status (221/231) are reset to 'ready' (220/230)
4. **Migration**: Fixes currently stuck jobs and items

## Files Changed
- `services/agent-api/src/routes/agent-jobs.js` - add stale job cleanup logic
- `supabase/migrations/20251216110600_fix_stuck_jobs.sql` - fix current stuck data

## Migration Required
Run the SQL migration in Supabase SQL Editor before or after deploying.

Closes https://linear.app/knowledge-base/issue/KB-256