### PR TITLE
feat(KB-264): agents write to pipeline_step_run

### DIFF
--- a/services/agent-api/src/lib/pipeline-tracking.js
+++ b/services/agent-api/src/lib/pipeline-tracking.js
@@ -1,0 +1,147 @@
+/**
+ * Pipeline Tracking Helpers
+ * KB-264: Extracted from agent-jobs.js to reduce file size
+ * Provides helpers for tracking pipeline runs and step runs
+ */
+
+import process from 'node:process';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+
+/**
+ * Ensure pipeline_run exists for an item
+ * Creates a new run if current_run_id is null, or returns the existing run
+ */
+export async function ensurePipelineRun(item) {
+  // Check if item already has a current run
+  if (item.current_run_id) {
+    return item.current_run_id;
+  }
+
+  // Determine trigger based on entry_type
+  const triggerMap = {
+    manual: 'manual',
+    discovery: 'discovery',
+    rss: 'discovery',
+    sitemap: 'discovery',
+  };
+  const trigger = triggerMap[item.entry_type] || 'discovery';
+
+  // Create new pipeline_run
+  const { data: run, error } = await supabase
+    .from('pipeline_run')
+    .insert({
+      queue_id: item.id,
+      trigger,
+      status: 'running',
+      created_by: 'system',
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    console.error(`Failed to create pipeline_run for ${item.id}:`, error.message);
+    return null;
+  }
+
+  // Update ingestion_queue with current_run_id
+  await supabase.from('ingestion_queue').update({ current_run_id: run.id }).eq('id', item.id);
+
+  console.log(`   📋 Created pipeline_run ${run.id} for item ${item.id}`);
+  return run.id;
+}
+
+/**
+ * Start a step run (insert with status='running')
+ */
+export async function startStepRun(runId, stepName, inputSnapshot) {
+  if (!runId) return null;
+
+  // Check for existing attempt count
+  const { data: existing } = await supabase
+    .from('pipeline_step_run')
+    .select('attempt')
+    .eq('run_id', runId)
+    .eq('step_name', stepName)
+    .order('attempt', { ascending: false })
+    .limit(1);
+
+  const attempt = (existing?.[0]?.attempt || 0) + 1;
+
+  const { data: stepRun, error } = await supabase
+    .from('pipeline_step_run')
+    .insert({
+      run_id: runId,
+      step_name: stepName,
+      status: 'running',
+      attempt,
+      started_at: new Date().toISOString(),
+      input_snapshot: inputSnapshot,
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    console.error(`Failed to create step_run for ${stepName}:`, error.message);
+    return null;
+  }
+
+  return stepRun.id;
+}
+
+/**
+ * Complete a step run (update status='success')
+ */
+export async function completeStepRun(stepRunId, output) {
+  if (!stepRunId) return;
+
+  await supabase
+    .from('pipeline_step_run')
+    .update({
+      status: 'success',
+      output,
+      completed_at: new Date().toISOString(),
+    })
+    .eq('id', stepRunId);
+}
+
+/**
+ * Fail a step run (update status='failed')
+ */
+export async function failStepRun(stepRunId, error) {
+  if (!stepRunId) return;
+
+  // Create error signature (first 100 chars, normalized)
+  const errorMessage = error?.message || String(error);
+  const errorSignature = errorMessage
+    .substring(0, 100)
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, 'UUID')
+    .replace(/\d+/g, 'N');
+
+  await supabase
+    .from('pipeline_step_run')
+    .update({
+      status: 'failed',
+      error_message: errorMessage,
+      error_signature: errorSignature,
+      completed_at: new Date().toISOString(),
+    })
+    .eq('id', stepRunId);
+}
+
+/**
+ * Skip a step run (for rejected items)
+ */
+export async function skipStepRun(stepRunId, reason) {
+  if (!stepRunId) return;
+
+  await supabase
+    .from('pipeline_step_run')
+    .update({
+      status: 'skipped',
+      error_message: reason,
+      completed_at: new Date().toISOString(),
+    })
+    .eq('id', stepRunId);
+}

--- a/services/agent-api/src/routes/agent-jobs.js
+++ b/services/agent-api/src/routes/agent-jobs.js
@@ -10,139 +10,19 @@ import { runSummarizer } from '../agents/summarizer.js';
 import { runTagger } from '../agents/tagger.js';
 import { runThumbnailer } from '../agents/thumbnailer.js';
 import { STATUS, loadStatusCodes } from '../lib/status-codes.js';
+import {
+  ensurePipelineRun,
+  startStepRun,
+  completeStepRun,
+  failStepRun,
+  skipStepRun,
+} from '../lib/pipeline-tracking.js';
 
 const router = express.Router();
 const supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
 
 // Helper: Update job record
 const updateJob = (jobId, updates) => supabase.from('agent_jobs').update(updates).eq('id', jobId);
-
-// Helper: Ensure pipeline_run exists for an item
-// Creates a new run if current_run_id is null, or returns the existing run
-async function ensurePipelineRun(item) {
-  // Check if item already has a current run
-  if (item.current_run_id) {
-    return item.current_run_id;
-  }
-
-  // Determine trigger based on entry_type
-  const triggerMap = {
-    manual: 'manual',
-    discovery: 'discovery',
-    rss: 'discovery',
-    sitemap: 'discovery',
-  };
-  const trigger = triggerMap[item.entry_type] || 'discovery';
-
-  // Create new pipeline_run
-  const { data: run, error } = await supabase
-    .from('pipeline_run')
-    .insert({
-      queue_id: item.id,
-      trigger,
-      status: 'running',
-      created_by: 'system',
-    })
-    .select('id')
-    .single();
-
-  if (error) {
-    console.error(`Failed to create pipeline_run for ${item.id}:`, error.message);
-    return null;
-  }
-
-  // Update ingestion_queue with current_run_id
-  await supabase.from('ingestion_queue').update({ current_run_id: run.id }).eq('id', item.id);
-
-  console.log(`   📋 Created pipeline_run ${run.id} for item ${item.id}`);
-  return run.id;
-}
-
-// Helper: Start a step run (insert with status='running')
-async function startStepRun(runId, stepName, inputSnapshot) {
-  if (!runId) return null;
-
-  // Check for existing attempt count
-  const { data: existing } = await supabase
-    .from('pipeline_step_run')
-    .select('attempt')
-    .eq('run_id', runId)
-    .eq('step_name', stepName)
-    .order('attempt', { ascending: false })
-    .limit(1);
-
-  const attempt = (existing?.[0]?.attempt || 0) + 1;
-
-  const { data: stepRun, error } = await supabase
-    .from('pipeline_step_run')
-    .insert({
-      run_id: runId,
-      step_name: stepName,
-      status: 'running',
-      attempt,
-      started_at: new Date().toISOString(),
-      input_snapshot: inputSnapshot,
-    })
-    .select('id')
-    .single();
-
-  if (error) {
-    console.error(`Failed to create step_run for ${stepName}:`, error.message);
-    return null;
-  }
-
-  return stepRun.id;
-}
-
-// Helper: Complete a step run (update status='success')
-async function completeStepRun(stepRunId, output) {
-  if (!stepRunId) return;
-
-  await supabase
-    .from('pipeline_step_run')
-    .update({
-      status: 'success',
-      output,
-      completed_at: new Date().toISOString(),
-    })
-    .eq('id', stepRunId);
-}
-
-// Helper: Fail a step run (update status='failed')
-async function failStepRun(stepRunId, error) {
-  if (!stepRunId) return;
-
-  // Create error signature (first 100 chars, normalized)
-  const errorMessage = error?.message || String(error);
-  const errorSignature = errorMessage
-    .substring(0, 100)
-    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, 'UUID')
-    .replace(/\d+/g, 'N');
-
-  await supabase
-    .from('pipeline_step_run')
-    .update({
-      status: 'failed',
-      error_message: errorMessage,
-      error_signature: errorSignature,
-      completed_at: new Date().toISOString(),
-    })
-    .eq('id', stepRunId);
-}
-
-// Helper: Skip a step run (for rejected items)
-async function skipStepRun(stepRunId, reason) {
-  if (!stepRunId) return;
-
-  await supabase
-    .from('pipeline_step_run')
-    .update({
-      status: 'skipped',
-      error_message: reason,
-      completed_at: new Date().toISOString(),
-    })
-    .eq('id', stepRunId);
-}
 
 // Helper: Find running job for agent
 const findRunningJob = (agent, select = 'id') =>


### PR DESCRIPTION
## User Story
As a developer, I want each agent to write its outcome to `pipeline_step_run`, so that we have a complete record of every step attempt.

## Changes

### New Helper Functions
```js
startStepRun(runId, stepName, inputSnapshot)  // Insert with status='running'
completeStepRun(stepRunId, output)            // Update status='success'
failStepRun(stepRunId, error)                 // Update status='failed' + error_signature
skipStepRun(stepRunId, reason)                // Update status='skipped' (for rejections)
```

### Integration
- Called in `processAgentBatch` for summarizer, tagger, thumbnailer
- `stepRunId` declared outside try block for access in catch
- Error signature normalizes UUIDs and numbers for grouping

### Data Captured
- **input_snapshot**: url, title, payload_keys
- **output**: full agent result (summary, tags, thumbnail_url, etc.)
- **error_message**: full error message
- **error_signature**: normalized for grouping (e.g., `Timeout after Ns`)
- **attempt**: auto-incremented per step/run

## Acceptance Criteria
- [x] On step start: insert `pipeline_step_run` with status='running'
- [x] On step success: update status='success', output, completed_at
- [x] On step failure: update status='failed', error_message, error_signature
- [x] input_snapshot captures the payload the step received
- [x] Works for summarizer, tagger, thumbnailer

## Files Changed
- `services/agent-api/src/routes/agent-jobs.js` (+104 lines)

## Note
File now exceeds 500 lines (533). Consider refactoring helpers to separate module in future.

Closes https://linear.app/knowledge-base/issue/KB-264