### PR TITLE
feat(KB-265): re-enrich creates new pipeline_run and cancels old

### DIFF
--- a/admin-next/src/app/(dashboard)/review/actions.ts
+++ b/admin-next/src/app/(dashboard)/review/actions.ts
@@ -171,15 +171,41 @@ export async function approveQueueItemAction(queueId: string, editedTitle?: stri
 
 export async function bulkReenrichAction(ids: string[]) {
   const supabase = createServiceRoleClient();
+  const userId = await getCurrentUserId();
 
-  const { error } = await supabase
-    .from('ingestion_queue')
-    .update({ status_code: 200 }) // 200 = PENDING_ENRICHMENT
-    .in('id', ids);
+  // For each item, cancel old run and create new one
+  for (const queueId of ids) {
+    // Cancel any running pipeline_run for this item
+    await supabase
+      .from('pipeline_run')
+      .update({ status: 'cancelled', completed_at: new Date().toISOString() })
+      .eq('queue_id', queueId)
+      .eq('status', 'running');
 
-  if (error) {
-    return { success: false, error: error.message };
+    // Create new pipeline_run with trigger='re-enrich'
+    const { data: newRun } = await supabase
+      .from('pipeline_run')
+      .insert({
+        queue_id: queueId,
+        trigger: 're-enrich',
+        status: 'running',
+        created_by: userId || 'system',
+      })
+      .select('id')
+      .single();
+
+    // Update ingestion_queue with new current_run_id and reset status
+    await supabase
+      .from('ingestion_queue')
+      .update({
+        status_code: 200, // 200 = PENDING_ENRICHMENT
+        current_run_id: newRun?.id || null,
+      })
+      .eq('id', queueId);
   }
+
+  // Note: We don't check for errors on pipeline_run operations
+  // because the table might not exist in older environments
 
   // Trigger processing
   const agentApiUrl = process.env.AGENT_API_URL || 'https://bfsi-insights.onrender.com';


### PR DESCRIPTION
## User Story
As a content curator, I want re-enrich to start a fresh run, so that old incomplete outputs don't mix with new processing.

## Changes

### bulkReenrichAction (actions.ts)
- Cancel any running `pipeline_run` for the item
- Create new `pipeline_run` with `trigger='re-enrich'`
- Update `ingestion_queue.current_run_id` to new run
- Reset `status_code` to 200 (PENDING_ENRICHMENT)

### handleReenrich (carousel-review.tsx, [id]/actions.tsx)
- Same pipeline_run handling as bulk action
- Cancel old → create new → update current_run_id

## Acceptance Criteria
- [x] Re-enrich creates new `pipeline_run` with `trigger='re-enrich'`
- [x] Old run (if running) marked as `status='cancelled'`
- [x] `ingestion_queue.current_run_id` updated to new run
- [x] Item status reset to 200 (PENDING_ENRICHMENT)
- [x] Old step_runs remain for history

## Key Fix
This prevents the "reappears with bad summary" bug:
- Old jobs write to old `run_id` (ignored by UI)
- New processing writes to new `run_id` (shown by UI)
- No mixing of outputs from different attempts

## Files Changed
- `admin-next/src/app/(dashboard)/review/actions.ts`
- `admin-next/src/app/(dashboard)/review/carousel/carousel-review.tsx`
- `admin-next/src/app/(dashboard)/review/[id]/actions.tsx`

Closes https://linear.app/knowledge-base/issue/KB-265