### PR TITLE
feat(KB-266): review queue filters by run completion

### DIFF
--- a/admin-next/src/app/(dashboard)/review/carousel/page.tsx
+++ b/admin-next/src/app/(dashboard)/review/carousel/page.tsx
@@ -31,11 +31,11 @@ async function getReviewData() {
 
   const taxonomyConfig = (configData || []) as TaxonomyConfig[];
 
-  // Fetch queue items using status_code for consistency with dashboard
+  // Fetch queue items using review_queue_ready view (KB-266)
+  // This ensures items only appear when all enrichment steps succeeded
   const queueResult = await supabase
-    .from('ingestion_queue')
+    .from('review_queue_ready')
     .select('*')
-    .eq('status_code', STATUS_CODE.PENDING_REVIEW)
     .order('fetched_at', { ascending: false })
     .limit(100);
 

--- a/supabase/migrations/20251217020000_review_queue_enrichment_filter.sql
+++ b/supabase/migrations/20251217020000_review_queue_enrichment_filter.sql
@@ -1,0 +1,34 @@
+-- KB-266: Review queue filters by run completion
+-- Only show items where all enrichment steps succeeded
+
+-- Create a view for the review queue that checks enrichment completion
+CREATE OR REPLACE VIEW review_queue_ready AS
+SELECT iq.*
+FROM ingestion_queue iq
+WHERE iq.status_code = 300  -- PENDING_REVIEW
+  AND (
+    -- Either no current_run_id (legacy items, show them)
+    iq.current_run_id IS NULL
+    OR
+    -- Or all required steps have succeeded
+    EXISTS (
+      SELECT 1 
+      FROM pipeline_step_run psr
+      WHERE psr.run_id = iq.current_run_id
+        AND psr.step_name IN ('summarize', 'tag', 'thumbnail')
+      GROUP BY psr.run_id
+      HAVING COUNT(DISTINCT psr.step_name) = 3
+         AND bool_and(psr.status = 'success')
+    )
+  );
+
+-- Grant access to the view
+GRANT SELECT ON review_queue_ready TO authenticated;
+GRANT SELECT ON review_queue_ready TO service_role;
+
+-- Comment for documentation
+COMMENT ON VIEW review_queue_ready IS 'KB-266: Review queue filtered to only show items with all enrichment steps (summarize, tag, thumbnail) completed successfully. Legacy items without current_run_id are included.';
+
+-- Create index to speed up the EXISTS subquery
+CREATE INDEX IF NOT EXISTS idx_pipeline_step_run_run_step_status 
+ON pipeline_step_run(run_id, step_name, status);


### PR DESCRIPTION
## User Story
As a content curator, I want items to appear in review only when all enrichment steps succeeded, so that I never see items with missing summaries or thumbnails.

## Changes

### New Database View
```sql
CREATE VIEW review_queue_ready AS
SELECT iq.*
FROM ingestion_queue iq
WHERE iq.status_code = 300
  AND (
    iq.current_run_id IS NULL  -- Legacy items
    OR EXISTS (
      SELECT 1 FROM pipeline_step_run psr
      WHERE psr.run_id = iq.current_run_id
        AND psr.step_name IN ('summarize', 'tag', 'thumbnail')
      GROUP BY psr.run_id
      HAVING COUNT(DISTINCT psr.step_name) = 3
         AND bool_and(psr.status = 'success')
    )
  );
```

### UI Changes
- `review/page.tsx`: Use `review_queue_ready` view for pending_review status
- `review/carousel/page.tsx`: Use `review_queue_ready` view

### Performance
- Added index `idx_pipeline_step_run_run_step_status` for fast EXISTS check

## Acceptance Criteria
- [x] Review queue query joins on current_run_id
- [x] Only shows items where summarize, tag, thumbnail all succeeded
- [x] Items with failed/pending steps don't appear in review
- [x] Legacy items (NULL current_run_id) still visible
- [x] Query performant with index

## Files Changed
- `supabase/migrations/20251217020000_review_queue_enrichment_filter.sql`
- `admin-next/src/app/(dashboard)/review/page.tsx`
- `admin-next/src/app/(dashboard)/review/carousel/page.tsx`

Closes https://linear.app/knowledge-base/issue/KB-266