### PR TITLE
feat(KB-268): dead letter queue with failure metadata

### DIFF
--- a/admin-next/src/app/(dashboard)/review/actions.ts
+++ b/admin-next/src/app/(dashboard)/review/actions.ts
@@ -195,11 +195,14 @@ export async function bulkReenrichAction(ids: string[]) {
       .single();
 
     // Update ingestion_queue with new current_run_id and reset status
+    // Also reset failure tracking for DLQ items (KB-268)
     await supabase
       .from('ingestion_queue')
       .update({
         status_code: 200, // 200 = PENDING_ENRICHMENT
         current_run_id: newRun?.id || null,
+        failure_count: 0,
+        last_failed_step: null,
       })
       .eq('id', queueId);
   }

--- a/admin-next/src/app/(dashboard)/review/page.tsx
+++ b/admin-next/src/app/(dashboard)/review/page.tsx
@@ -232,6 +232,7 @@ export default async function ReviewPage({
     { value: 'queued', label: 'Queued' },
     { value: 'processing', label: 'Processing' },
     { value: 'failed', label: 'Failed' },
+    { value: 'dead_letter', label: '💀 Dead Letter' },
     { value: 'rejected', label: 'Rejected' },
     { value: 'approved', label: 'Approved' },
     { value: 'all', label: 'All' },

--- a/admin-next/src/app/(dashboard)/review/review-list.tsx
+++ b/admin-next/src/app/(dashboard)/review/review-list.tsx
@@ -142,7 +142,7 @@ export function ReviewList({
 
   const canBulkApprove = status === 'pending_review';
   const canBulkReject = ['pending_review', 'failed'].includes(status);
-  const canBulkReenrich = ['pending_review', 'failed', 'rejected'].includes(status);
+  const canBulkReenrich = ['pending_review', 'failed', 'rejected', 'dead_letter'].includes(status);
 
   return (
     <div className="space-y-4">

--- a/supabase/migrations/20251217030000_dead_letter_queue.sql
+++ b/supabase/migrations/20251217030000_dead_letter_queue.sql
@@ -1,0 +1,26 @@
+-- KB-268: Dead Letter Queue with failure metadata
+-- Items that fail 3+ times on the same step are quarantined
+
+-- Add dead_letter status to status_lookup
+INSERT INTO status_lookup (code, name, description, category, is_terminal, sort_order)
+VALUES (599, 'dead_letter', 'Item failed 3+ times on same step, quarantined for manual review', 'terminal', false, 599)
+ON CONFLICT (code) DO NOTHING;
+
+-- Add failure tracking columns to ingestion_queue
+ALTER TABLE ingestion_queue 
+ADD COLUMN IF NOT EXISTS failure_count INT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS last_failed_step TEXT,
+ADD COLUMN IF NOT EXISTS last_error_message TEXT,
+ADD COLUMN IF NOT EXISTS last_error_signature TEXT,
+ADD COLUMN IF NOT EXISTS last_error_at TIMESTAMPTZ;
+
+-- Index for finding DLQ items quickly
+CREATE INDEX IF NOT EXISTS idx_ingestion_queue_dead_letter 
+ON ingestion_queue(status_code) WHERE status_code = 599;
+
+-- Comment for documentation
+COMMENT ON COLUMN ingestion_queue.failure_count IS 'Number of consecutive failures on current step';
+COMMENT ON COLUMN ingestion_queue.last_failed_step IS 'Name of step that last failed (summarize, tag, thumbnail)';
+COMMENT ON COLUMN ingestion_queue.last_error_message IS 'Full error message from last failure';
+COMMENT ON COLUMN ingestion_queue.last_error_signature IS 'Normalized error (first 100 chars, UUIDs/numbers replaced) for grouping';
+COMMENT ON COLUMN ingestion_queue.last_error_at IS 'Timestamp of last failure';


### PR DESCRIPTION
## User Story
As a developer, I want items that fail 3+ times to be quarantined, so that poison pills don't block the pipeline forever.

## Changes

### Migration
- Add status **599 (dead_letter)** to `status_lookup`
- Add failure tracking columns to `ingestion_queue`:
  - `failure_count`: consecutive failures on current step
  - `last_failed_step`: step that last failed
  - `last_error_message`: full error text (max 1000 chars)
  - `last_error_signature`: normalized for grouping
  - `last_error_at`: timestamp

### Agent Jobs (DLQ Logic)
```js
// Increment failure count if same step, reset to 1 if different
const isSameStep = currentItem.last_failed_step === stepName;
const newFailureCount = isSameStep ? failureCount + 1 : 1;

// Move to dead_letter after 3 failures
if (newFailureCount >= 3) {
  newStatusCode = 599; // dead_letter
}
```

### UI
- Added **💀 Dead Letter** filter to review page
- DLQ items can use **Re-enrich** action to retry
- Re-enrich resets `failure_count` to 0

## Acceptance Criteria
- [x] After 3 failed attempts on same step, item moves to status 599
- [x] `failure_reason`, `error_signature`, `last_error_at` stored
- [x] Dead letter items visible in dashboard with filter
- [x] Manual "retry" action available for dead letter items

## Files Changed
- `supabase/migrations/20251217030000_dead_letter_queue.sql`
- `services/agent-api/src/routes/agent-jobs.js`
- `admin-next/src/app/(dashboard)/review/page.tsx`
- `admin-next/src/app/(dashboard)/review/review-list.tsx`
- `admin-next/src/app/(dashboard)/review/actions.ts`

Closes https://linear.app/knowledge-base/issue/KB-268