### PR TITLE
feat(KB-269): WIP limits enforced by orchestrator

### DIFF
--- a/services/agent-api/src/lib/wip-limits.js
+++ b/services/agent-api/src/lib/wip-limits.js
@@ -1,0 +1,48 @@
+/**
+ * WIP Limits Configuration
+ * KB-269: Backpressure to prevent pipeline choking
+ */
+
+import process from 'node:process';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+
+// WIP limits per agent - controls max concurrent items in "working" status
+export const WIP_LIMITS = {
+  summarizer: 10,
+  tagger: 20,
+  thumbnailer: 5,
+};
+
+/**
+ * Get current WIP count for an agent
+ * @param {Object} config - Agent config with workingStatusCode()
+ * @returns {Promise<number>} Current count of items in working status
+ */
+export async function getCurrentWIP(config) {
+  const { count, error } = await supabase
+    .from('ingestion_queue')
+    .select('*', { count: 'exact', head: true })
+    .eq('status_code', config.workingStatusCode());
+
+  if (error) {
+    console.error('Error getting WIP count:', error.message);
+    return 0;
+  }
+  return count || 0;
+}
+
+/**
+ * Check available capacity for an agent
+ * @param {string} agent - Agent name
+ * @param {Object} config - Agent config
+ * @returns {Promise<{limit: number, current: number, available: number}>}
+ */
+export async function checkWIPCapacity(agent, config) {
+  const limit = WIP_LIMITS[agent] || 10;
+  const current = await getCurrentWIP(config);
+  const available = Math.max(0, limit - current);
+
+  return { limit, current, available };
+}


### PR DESCRIPTION
## User Story
As a developer, I want the orchestrator to limit work-in-progress per stage, so that the pipeline doesn't choke with too many concurrent items.

## Changes

### New Module: `lib/wip-limits.js`
```js
export const WIP_LIMITS = {
  summarizer: 10,
  tagger: 20,
  thumbnailer: 5,
};

export async function getCurrentWIP(config) {
  // Count items in "working" status
}
```

### Job Start Endpoint
Before enqueueing batch:
1. Check current WIP count
2. Calculate available capacity: `wipLimit - currentWIP`
3. If capacity = 0, return early with WIP status
4. Limit batch to `min(requested, available)`

### New Endpoint: `GET /api/jobs/wip`
Returns WIP status for all agents:
```json
{
  "wip": {
    "summarizer": { "current": 3, "limit": 10, "available": 7, "utilizationPct": 30 },
    "tagger": { "current": 15, "limit": 20, "available": 5, "utilizationPct": 75 },
    "thumbnailer": { "current": 5, "limit": 5, "available": 0, "utilizationPct": 100 }
  }
}
```

## Acceptance Criteria
- [x] Config: WIP_LIMITS = { summarizer: 10, tagger: 20, thumbnailer: 5 }
- [x] Before enqueueing batch, orchestrator checks current WIP
- [x] Only enqueues min(requested, available_capacity) items
- [x] Dashboard endpoint shows current WIP vs limit per stage

## Files Changed
- `services/agent-api/src/lib/wip-limits.js` (new)
- `services/agent-api/src/routes/agent-jobs.js`

Closes https://linear.app/knowledge-base/issue/KB-269