### PR TITLE
fix(KB-271): WIP limits to 50, single source of truth

### DIFF
--- a/admin-next/src/app/api/jobs/wip-limits/route.ts
+++ b/admin-next/src/app/api/jobs/wip-limits/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+const AGENT_API_URL = process.env.AGENT_API_URL || 'https://bfsi-insights.onrender.com';
+
+export async function GET() {
+  try {
+    const res = await fetch(`${AGENT_API_URL}/api/jobs/wip-limits`);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch WIP limits: ${res.status}`);
+    }
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('WIP limits fetch error:', error);
+    // Fallback to defaults if agent-api is unavailable
+    return NextResponse.json({
+      summarizer: 50,
+      tagger: 50,
+      thumbnailer: 50,
+    });
+  }
+}

--- a/admin-next/src/components/tags/types.ts
+++ b/admin-next/src/components/tags/types.ts
@@ -1,30 +1,12 @@
 /**
  * Shared types for dynamic taxonomy display
+ * Re-exported from @bfsi/types for convenience
  */
 
-export interface TaxonomyItem {
-  code: string;
-  name: string;
-}
-
-export interface TaxonomyConfig {
-  slug: string;
-  display_name: string;
-  display_order: number;
-  behavior_type: 'guardrail' | 'expandable' | 'scoring';
-  source_table: string | null;
-  payload_field: string;
-  color: string;
-  score_parent_slug: string | null;
-  score_threshold: number | null;
-}
-
-// Dynamic taxonomy data keyed by slug
-export type TaxonomyData = Record<string, TaxonomyItem[]>;
-
-// Payload with dynamic tag fields
-export type TagPayload = Record<string, unknown>;
-
-// Validation lookups for expandable entities (keyed by slug)
-// Values should be lowercase for case-insensitive matching
-export type ValidationLookups = Record<string, Set<string>>;
+export type {
+  TaxonomyItem,
+  TaxonomyConfig,
+  TaxonomyData,
+  TagPayload,
+  ValidationLookups,
+} from '@bfsi/types';

--- a/admin-next/src/types/database.ts
+++ b/admin-next/src/types/database.ts
@@ -35,6 +35,12 @@ export type {
   StatusLookup,
   StatusPhase,
   StatusCode,
+  // Taxonomy
+  TaxonomyItem,
+  TaxonomyConfig,
+  TaxonomyData,
+  TagPayload,
+  ValidationLookups,
 } from '@bfsi/types';
 
 export { STATUS_CODES } from '@bfsi/types';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,3 +13,4 @@ export * from './source';
 export * from './prompt';
 export * from './eval';
 export * from './status';
+export * from './taxonomy';

--- a/packages/types/src/taxonomy.ts
+++ b/packages/types/src/taxonomy.ts
@@ -1,0 +1,31 @@
+/**
+ * Taxonomy types for dynamic tag display
+ * Based on taxonomy_config and related tables
+ */
+
+export interface TaxonomyItem {
+  code: string;
+  name: string;
+}
+
+export interface TaxonomyConfig {
+  slug: string;
+  display_name: string;
+  display_order: number;
+  behavior_type: 'guardrail' | 'expandable' | 'scoring';
+  source_table: string | null;
+  payload_field: string;
+  color: string;
+  score_parent_slug: string | null;
+  score_threshold: number | null;
+}
+
+// Dynamic taxonomy data keyed by slug
+export type TaxonomyData = Record<string, TaxonomyItem[]>;
+
+// Payload with dynamic tag fields
+export type TagPayload = Record<string, unknown>;
+
+// Validation lookups for expandable entities (keyed by slug)
+// Values should be lowercase for case-insensitive matching
+export type ValidationLookups = Record<string, Set<string>>;

--- a/services/agent-api/src/lib/wip-limits.js
+++ b/services/agent-api/src/lib/wip-limits.js
@@ -9,9 +9,10 @@ import { createClient } from '@supabase/supabase-js';
 const supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
 
 // WIP limits per agent - controls max concurrent items in "working" status
+// Must match UI dropdown options in admin-next pipeline health dashboard
 export const WIP_LIMITS = {
-  summarizer: 10,
-  tagger: 20,
+  summarizer: 50,
+  tagger: 50,
   thumbnailer: 50,
 };
 

--- a/services/agent-api/src/routes/agent-jobs.js
+++ b/services/agent-api/src/routes/agent-jobs.js
@@ -488,4 +488,9 @@ router.get('/wip', async (req, res) => {
   }
 });
 
+// GET /api/jobs/wip-limits - Get WIP limits (single source of truth)
+router.get('/wip-limits', (_req, res) => {
+  res.json(WIP_LIMITS);
+});
+
 export default router;


### PR DESCRIPTION
## Problem
When selecting 10 items for thumbnailing, only 5 were processed due to WIP limit.

## Root Cause
1. WIP limit for thumbnailer was hardcoded to 5
2. WIP limits were duplicated between backend and UI (could drift out of sync)
3. Taxonomy types were defined locally instead of in shared package

## Solution
- Set all WIP limits to 50 (summarizer, tagger, thumbnailer)
- Created `/api/jobs/wip-limits` endpoint as single source of truth
- UI now fetches limits from backend instead of hardcoding
- Moved taxonomy types to `@bfsi/types` package

## Files Changed
- `services/agent-api/src/lib/wip-limits.js` - All limits set to 50
- `services/agent-api/src/routes/agent-jobs.js` - Added GET endpoint
- `admin-next/src/app/api/jobs/wip-limits/route.ts` - Proxy to backend
- `admin-next/src/app/(dashboard)/pipeline/pipeline-metrics.tsx` - Fetch limits dynamically
- `packages/types/src/taxonomy.ts` - New shared taxonomy types
- `admin-next/src/types/database.ts` - Re-export taxonomy types
- `admin-next/src/components/tags/types.ts` - Import from @bfsi/types

Closes https://linear.app/knowledge-base/issue/KB-271