### PR TITLE
improve(KB-274): add admin-next patterns to large file check

### DIFF
--- a/scripts/check-large-files.cjs
+++ b/scripts/check-large-files.cjs
@@ -12,20 +12,28 @@ const MAX_LINES = 500;
 // TODO(KB-151): Gradually refactor and remove entries from allowList.
 // These files are known to exceed the limit and are tracked for refactoring.
 const ALLOW_LIST = new Set([
+  // Astro main site
   'src/pages/publications.astro',
   'src/features/publications/publication-filters.ts',
   'src/features/publications/multi-select-filters.ts',
-  'src/pages/admin/review.astro',
-  'src/pages/admin/sources.astro',
+  // Agent API
+  'services/agent-api/src/cli.js',
+  // Admin-next pages (KB-274: tracked for refactoring)
+  'admin-next/src/app/(dashboard)/sources/page.tsx',
+  'admin-next/src/app/(dashboard)/ab-tests/page.tsx',
+  'admin-next/src/app/(dashboard)/missed/page.tsx',
+  'admin-next/src/app/(dashboard)/page.tsx',
 ]);
 
 // Use git ls-files to only scan tracked files
 const patterns = [
   'src/**/*.ts',
-  'src/**/*.js', 
+  'src/**/*.js',
   'src/**/*.astro',
   'services/agent-api/src/**/*.ts',
   'services/agent-api/src/**/*.js',
+  'admin-next/src/**/*.ts',
+  'admin-next/src/**/*.tsx',
 ];
 
 try {


### PR DESCRIPTION
## Problem
`check-large-files.cjs` wasn't scanning `admin-next/` files, and the allowlist had stale entries for deleted files.

## Changes
1. **Added patterns** for `admin-next/src/**/*.ts` and `admin-next/src/**/*.tsx`
2. **Removed stale entries**: `src/pages/admin/review.astro`, `src/pages/admin/sources.astro` (deleted)
3. **Added missing entry**: `services/agent-api/src/cli.js` (711 LoC)

## Allowlist (8 files)
| Category | File |
|----------|------|
| Astro | `src/pages/publications.astro` |
| Astro | `src/features/publications/publication-filters.ts` |
| Astro | `src/features/publications/multi-select-filters.ts` |
| Agent API | `services/agent-api/src/cli.js` |
| Admin-next | `admin-next/src/app/(dashboard)/sources/page.tsx` |
| Admin-next | `admin-next/src/app/(dashboard)/ab-tests/page.tsx` |
| Admin-next | `admin-next/src/app/(dashboard)/missed/page.tsx` |
| Admin-next | `admin-next/src/app/(dashboard)/page.tsx` |

Closes https://linear.app/knowledge-base/issue/KB-274