### PR TITLE
fix(KB-275): update success/failed counts during job run

### DIFF
--- a/services/agent-api/src/routes/agent-jobs.js
+++ b/services/agent-api/src/routes/agent-jobs.js
@@ -275,6 +275,13 @@ async function processAgentBatch(agent, jobId, items, config) {
       // Track failure for DLQ
       await handleItemFailure(item, agent, stepName, err, config);
     }
+
+    // Update counts after each item (KB-275: live progress)
+    await updateJob(jobId, {
+      processed_items: i + 1,
+      success_count: successCount,
+      failed_count: failedCount,
+    });
   }
 
   // Mark job complete

--- a/services/agent-api/src/routes/thumbnail-routes.js
+++ b/services/agent-api/src/routes/thumbnail-routes.js
@@ -140,6 +140,16 @@ async function processThumbnailBatch(jobId, items) {
       console.error(`Thumbnail failed for ${item.id}:`, err.message);
       failedCount++;
     }
+
+    // Update counts after each item (KB-275: live progress)
+    await supabase
+      .from('thumbnail_jobs')
+      .update({
+        processed_items: i + 1,
+        success_count: successCount,
+        failed_count: failedCount,
+      })
+      .eq('id', jobId);
   }
 
   // Mark job complete


### PR DESCRIPTION
## Problem
Status bar shows `9/25 processed` but `0 success, 0 failed` during job run.

The `success_count` and `failed_count` were only being updated at job completion, not incrementally.

## Fix
Update counts after each item is processed in:
- `agent-jobs.js` - summarizer, tagger, thumbnailer (via generic agent routes)
- `thumbnail-routes.js` - legacy thumbnail job route

## Before
```
9 / 25    →    0 success, 0 failed
```

## After
```
9 / 25    →    8 success, 1 failed
```

Closes https://linear.app/knowledge-base/issue/KB-275