### PR TITLE
fix(KB-276): articles added via admin UI not visible in dashboard

### DIFF
--- a/admin-next/src/app/(dashboard)/add/page.tsx
+++ b/admin-next/src/app/(dashboard)/add/page.tsx
@@ -233,7 +233,6 @@ export default function AddArticlePage() {
         const isPdf = inputMode === 'pdf';
         const { error: queueError } = await supabase.from('ingestion_queue').insert({
           url: finalUrl,
-          status: 'pending',
           status_code: isPdf ? 230 : 200, // PDFs skip to thumbnailing (230), URLs start at pending_enrichment (200)
           entry_type: 'manual',
           payload: {

--- a/supabase/migrations/20251217120000_drop_broken_manual_url_trigger.sql
+++ b/supabase/migrations/20251217120000_drop_broken_manual_url_trigger.sql
@@ -1,0 +1,9 @@
+-- ============================================================================
+-- KB-276: Drop broken trigger that references dropped status column
+-- ============================================================================
+-- The trigger_auto_process_url() function references NEW.status which no longer
+-- exists, causing all inserts to ingestion_queue to fail.
+-- ============================================================================
+
+DROP TRIGGER IF EXISTS on_manual_url_added ON ingestion_queue;
+DROP FUNCTION IF EXISTS trigger_auto_process_url() CASCADE;


### PR DESCRIPTION
## Problem
Articles added via the Add Article page were not appearing in the dashboard or review queue.

## Root Cause
1. **Code bug**: Insert statement included `status: 'pending'` but the `status` column was dropped (only `status_code` exists)
2. **DB trigger bug**: `on_manual_url_added` trigger called `trigger_auto_process_url()` which referenced `NEW.status`

Both caused silent failures on insert.

## Fix
1. **Code**: Removed `status` field from ingestion_queue insert
2. **Migration**: Added `20251217120000_drop_broken_manual_url_trigger.sql` to drop the broken trigger

## Data Recovery
Manually inserted 2 articles that were stuck in `missed_discovery` but never made it to `ingestion_queue`:
- https://arxiv.org/abs/2411.14251
- https://fintechnews.ae/29260/fintechdubai/mastercard-kee-platforms-embedded-financing/

Closes https://linear.app/knowledge-base/issue/KB-276