### PR TITLE
fix(KB-277): backfill missed_discovery rows without queue_id

### DIFF
--- a/supabase/migrations/20251217133000_backfill_missed_discovery_queue_id.sql
+++ b/supabase/migrations/20251217133000_backfill_missed_discovery_queue_id.sql
@@ -1,0 +1,40 @@
+-- KB-277: Backfill missed_discovery rows that don't have a queue_id
+-- These were added before KB-277 introduced the auto-queue feature
+
+-- For each missed_discovery without a queue_id, create an ingestion_queue entry
+-- and link them together
+
+DO $$
+DECLARE
+  rec RECORD;
+  new_queue_id UUID;
+BEGIN
+  FOR rec IN 
+    SELECT id, url, source_domain, submitter_name, why_valuable
+    FROM missed_discovery 
+    WHERE queue_id IS NULL 
+      AND resolution_status = 'pending'
+  LOOP
+    -- Insert into ingestion_queue
+    INSERT INTO ingestion_queue (url, status_code, entry_type, payload)
+    VALUES (
+      rec.url,
+      200, -- pending_enrichment
+      'manual',
+      jsonb_build_object(
+        'manual_add', true,
+        'submitter', rec.submitter_name,
+        'why_valuable', rec.why_valuable,
+        'backfilled', true
+      )
+    )
+    RETURNING id INTO new_queue_id;
+
+    -- Update missed_discovery with the queue_id
+    UPDATE missed_discovery
+    SET queue_id = new_queue_id
+    WHERE id = rec.id;
+
+    RAISE NOTICE 'Backfilled missed_discovery % -> queue %', rec.id, new_queue_id;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Problem
Articles added to missed_discovery before KB-277 don't have a `queue_id`, so they show "Not in queue" in the History tab and never get processed.

## Solution
Migration that:
1. Finds all `missed_discovery` rows where `queue_id IS NULL` and `resolution_status = 'pending'`
2. Creates corresponding `ingestion_queue` entries with `status_code = 200` (pending_enrichment)
3. Links them via `queue_id` FK

## After Merge
Run `supabase db push` or apply migration manually to backfill existing data.

Closes https://linear.app/knowledge-base/issue/KB-277