### PR TITLE
fix(KB-277): manual articles skip relevance rejection

### DIFF
--- a/admin-next/src/app/(dashboard)/add/components/MissedItemsList.tsx
+++ b/admin-next/src/app/(dashboard)/add/components/MissedItemsList.tsx
@@ -23,6 +23,7 @@ const STATUS_MAP: Record<number, { label: string; color: string }> = {
   330: { label: 'Approved', color: 'bg-emerald-500/20 text-emerald-300' },
   400: { label: 'Published', color: 'bg-emerald-500/30 text-emerald-200' },
   500: { label: 'Failed', color: 'bg-red-500/20 text-red-300' },
+  530: { label: 'Irrelevant', color: 'bg-neutral-500/20 text-neutral-400' },
   540: { label: 'Rejected', color: 'bg-red-500/20 text-red-300' },
   599: { label: 'Dead Letter', color: 'bg-red-500/30 text-red-200' },
 };

--- a/services/agent-api/src/agents/enricher.js
+++ b/services/agent-api/src/agents/enricher.js
@@ -272,7 +272,9 @@ export async function processQueue(options = {}) {
   let failed = 0;
 
   for (const item of items) {
-    const result = await enrichItem(item, { includeThumbnail });
+    // KB-277: Manual articles skip relevance rejection (human already deemed relevant)
+    const isManual = item.entry_type === 'manual' || item.payload?.manual_add === true;
+    const result = await enrichItem(item, { includeThumbnail, skipRejection: isManual });
     if (result.success) {
       success++;
     } else {

--- a/supabase/migrations/20251217143000_reset_manual_articles_wrongly_rejected.sql
+++ b/supabase/migrations/20251217143000_reset_manual_articles_wrongly_rejected.sql
@@ -1,0 +1,13 @@
+-- KB-277: Reset manual articles that were wrongly rejected by relevance filter
+-- Manual articles should never be rejected for relevance - humans already deemed them relevant
+
+UPDATE ingestion_queue
+SET 
+  status_code = 200, -- PENDING_ENRICHMENT
+  payload = payload - 'rejection_reason' -- Remove rejection reason
+WHERE 
+  status_code = 530 -- IRRELEVANT
+  AND (
+    entry_type = 'manual' 
+    OR payload->>'manual_add' = 'true'
+  );


### PR DESCRIPTION
## Problem
Manual articles were being rejected by the relevance filter even though humans already deemed them relevant by submitting them.

Example: arxiv.org article about reinforcement learning was marked as IRRELEVANT (530) when it should have gone to review.

## Root Cause
The normal batch processing (`processQueue`) didn't check for `entry_type='manual'` - only the priority endpoint did.

## Fix
1. **enricher.js**: Normal batch processing now passes `skipRejection: true` for manual articles
2. **Migration**: Resets wrongly-rejected manual articles (status 530 → 200) so they can be re-processed
3. **MissedItemsList**: Added status 530 to display map

## After Merge
Run `supabase db push` then `Process Queue` to re-enrich the reset articles.

Closes https://linear.app/knowledge-base/issue/KB-277