### PR TITLE
fix(KB-280): fix FK join syntax for history tab

### DIFF
--- a/admin-next/src/app/(dashboard)/add/page.tsx
+++ b/admin-next/src/app/(dashboard)/add/page.tsx
@@ -36,18 +36,21 @@ export default function AddArticlePage() {
   const loadMissedItems = useCallback(async () => {
     setLoadingList(true);
     // KB-277: Join with ingestion_queue to show pipeline status
-    // KB-280: Use explicit FK hint for join (queue_id -> ingestion_queue.id)
+    // KB-280: Use inner join syntax for FK relationship
     const { data, error } = await supabase
       .from('missed_discovery')
       .select(
         `id, url, source_domain, submitter_name, submitter_audience, submitter_channel, 
          why_valuable, submitter_urgency, resolution_status, submitted_at, existing_source_slug,
-         queue_id, ingestion_queue!queue_id(status_code, payload)`,
+         queue_id, ingestion_queue:queue_id(status_code, payload)`,
       )
       .order('submitted_at', { ascending: false })
       .limit(100);
 
-    if (!error && data) {
+    if (error) {
+      console.error('Failed to load missed items:', error);
+    }
+    if (data) {
       setMissedItems(data);
     }
     setLoadingList(false);


### PR DESCRIPTION
## Problem
History tab still showing 'Not in queue' even after PR #299.

## Fix
Changed FK join syntax from `ingestion_queue!queue_id(...)` to `ingestion_queue:queue_id(...)`.

The colon syntax is the correct Supabase/PostgREST syntax for specifying which FK to use when there are multiple possible relationships.

Also added error logging to help debug if this still fails.

Closes https://linear.app/knowledge-base/issue/KB-280