### PR TITLE
fix(KB-285): fix dashboard API using wrong RPC function name

### DIFF
--- a/admin-next/src/app/api/dashboard/stats/route.ts
+++ b/admin-next/src/app/api/dashboard/stats/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
     const supabase = createServiceRoleClient();
 
     // Get all status counts via RPC
-    const { data: statusData, error } = await supabase.rpc('get_pipeline_status_counts');
+    const { data: statusData, error } = await supabase.rpc('get_status_code_counts');
 
     if (error) {
       console.error('Failed to get pipeline status counts:', error);


### PR DESCRIPTION
## URGENT FIX

Dashboard was broken because it called a non-existent Supabase function.

## Root Cause
- API called `get_pipeline_status_counts` (doesn't exist)
- Should call `get_status_code_counts` (the actual function)

## Impact
- Dashboard showing 0 items
- 'fetch failed' errors

Closes https://linear.app/knowledge-base/issue/KB-285