### PR TITLE
fix(KB-285): move pipeline_run operations to server-side API route

### DIFF
--- a/admin-next/src/app/api/enrich-step/route.ts
+++ b/admin-next/src/app/api/enrich-step/route.ts
@@ -1,9 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { createServiceRoleClient } from '@/lib/supabase/server';
 
 const AGENT_API_URL = process.env.AGENT_API_URL || 'http://localhost:3001';
 const AGENT_API_KEY = process.env.AGENT_API_KEY || '';
 
+// KB-202: Load status codes from status_lookup table (single source of truth)
+async function getStatusCode(
+  supabase: ReturnType<typeof createServiceRoleClient>,
+  name: string,
+): Promise<number> {
+  const { data } = await supabase.from('status_lookup').select('code').eq('name', name).single();
+  if (!data) throw new Error(`Status code not found: ${name}`);
+  return data.code;
+}
+
 // KB-285: Trigger a single enrichment step for immediate processing
+// This route handles pipeline_run management with service role (RLS bypass)
 export async function POST(request: NextRequest) {
   try {
     const { step, id } = await request.json();
@@ -12,19 +24,76 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'step and id are required' }, { status: 400 });
     }
 
-    // Map step to agent API endpoint
-    const stepToEndpoint: Record<string, string> = {
-      summarize: '/api/agents/run/summarize',
-      tag: '/api/agents/run/tag',
-      thumbnail: '/api/agents/run/thumbnail',
+    const supabase = createServiceRoleClient();
+
+    // Map step to status name and agent API endpoint
+    const stepConfig: Record<string, { statusName: string; endpoint: string }> = {
+      summarize: { statusName: 'to_summarize', endpoint: '/api/agents/run/summarize' },
+      tag: { statusName: 'to_tag', endpoint: '/api/agents/run/tag' },
+      thumbnail: { statusName: 'to_thumbnail', endpoint: '/api/agents/run/thumbnail' },
     };
 
-    const endpoint = stepToEndpoint[step];
-    if (!endpoint) {
+    const config = stepConfig[step];
+    if (!config) {
       return NextResponse.json({ error: `Unknown step: ${step}` }, { status: 400 });
     }
 
-    const res = await fetch(`${AGENT_API_URL}${endpoint}`, {
+    // KB-202: Load status codes from status_lookup
+    const statusCode = await getStatusCode(supabase, config.statusName);
+    const publishedCode = await getStatusCode(supabase, 'published');
+    const pendingReviewCode = await getStatusCode(supabase, 'pending_review');
+    const enrichedCode = await getStatusCode(supabase, 'enriched');
+
+    // Fetch current item
+    const { data: currentItem } = await supabase
+      .from('ingestion_queue')
+      .select('payload, status_code')
+      .eq('id', id)
+      .single();
+
+    if (!currentItem) {
+      return NextResponse.json({ error: 'Item not found' }, { status: 404 });
+    }
+
+    // Determine return status
+    const isPublished = currentItem.status_code === publishedCode;
+    const returnStatus = isPublished ? pendingReviewCode : enrichedCode;
+
+    // Cancel any running pipeline
+    await supabase
+      .from('pipeline_run')
+      .update({ status: 'cancelled', completed_at: new Date().toISOString() })
+      .eq('queue_id', id)
+      .eq('status', 'running');
+
+    // Create new pipeline run
+    const { data: newRun } = await supabase
+      .from('pipeline_run')
+      .insert({
+        queue_id: id,
+        trigger: `re-${step}`,
+        status: 'running',
+        created_by: 'system',
+      })
+      .select('id')
+      .single();
+
+    // Update status and set return_status in payload
+    await supabase
+      .from('ingestion_queue')
+      .update({
+        status_code: statusCode,
+        current_run_id: newRun?.id || null,
+        payload: {
+          ...currentItem.payload,
+          _return_status: returnStatus,
+          _single_step: step,
+        },
+      })
+      .eq('id', id);
+
+    // Call agent API
+    const res = await fetch(`${AGENT_API_URL}${config.endpoint}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
Fix the 400 Bad Request error when clicking Re-run in the Enrichment panel.

## Root Cause
- `pipeline_run` table RLS only allows `service_role` access
- Client-side Supabase calls use `authenticated` role → 400 error
- This prevented the enrichment from actually running

## Changes
- Move all `pipeline_run` operations from client (`enrichment-panel.tsx`) to server (`/api/enrich-step`)
- Server route uses `createServiceRoleClient` which bypasses RLS
- KB-202: Load status codes from `status_lookup` table instead of hardcoding
- Simplified `triggerStep` function in enrichment-panel

## Testing
1. Go to Items → select an item
2. Click Re-run on Summarize
3. Should see 'summarize complete' without 400 errors
4. Check that `enrichment_meta` is written to payload

Closes https://linear.app/knowledge-base/issue/KB-285