### PR TITLE
fix(KB-285): wrap Markdown in client component to fix hydration error

### DIFF
--- a/admin-next/src/app/(dashboard)/review/[id]/page.tsx
+++ b/admin-next/src/app/(dashboard)/review/[id]/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import Markdown from 'react-markdown';
+import { MarkdownRenderer } from '@/components/ui/markdown-renderer';
 import { createServiceRoleClient } from '@/lib/supabase/server';
 import { formatDateTime, getStatusColorByCode, getStatusName } from '@/lib/utils';
 import { notFound } from 'next/navigation';
@@ -300,7 +300,11 @@ export default async function ReviewDetailPage({
                   </span>
                 </div>
                 <div className="text-neutral-200 bg-neutral-800/50 rounded-lg p-3 prose prose-invert prose-sm max-w-none prose-headings:text-neutral-200 prose-headings:font-semibold prose-headings:text-sm prose-p:my-1 prose-ul:my-1 prose-li:my-0">
-                  {summary.long ? <Markdown>{summary.long}</Markdown> : <p>No long summary</p>}
+                  {summary.long ? (
+                    <MarkdownRenderer content={summary.long} />
+                  ) : (
+                    <p>No long summary</p>
+                  )}
                 </div>
               </div>
             </div>

--- a/admin-next/src/components/ui/markdown-renderer.tsx
+++ b/admin-next/src/components/ui/markdown-renderer.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import Markdown from 'react-markdown';
+
+interface MarkdownRendererProps {
+  content: string;
+  className?: string;
+}
+
+export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
+  return (
+    <div className={className}>
+      <Markdown>{content}</Markdown>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Fix React error #418 (hydration mismatch) when rendering markdown in long summary.

## Root Cause
`react-markdown` produces different output on server vs client in Next.js, causing hydration mismatch.

## Fix
- Create `MarkdownRenderer` client component wrapper with `'use client'` directive
- Use wrapper instead of direct `<Markdown>` usage in server component

## Testing
Long summary should now render with proper markdown formatting (headings, bullets).