### PR TITLE
fix(KB-285): render markdown only on client to avoid hydration mismatch

### DIFF
--- a/admin-next/src/components/ui/markdown-renderer.tsx
+++ b/admin-next/src/components/ui/markdown-renderer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import Markdown from 'react-markdown';
 
 interface MarkdownRendererProps {
@@ -8,6 +9,17 @@ interface MarkdownRendererProps {
 }
 
 export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Render plain text on server, markdown on client to avoid hydration mismatch
+  if (!mounted) {
+    return <div className={className}>{content}</div>;
+  }
+
   return (
     <div className={className}>
       <Markdown>{content}</Markdown>


### PR DESCRIPTION
## Summary
Fix React error #418 (hydration mismatch) that persists after PR #321.

## Approach
Use `useState`/`useEffect` to detect client mount:
- Server: render plain text
- Client: render markdown

This completely avoids the hydration mismatch since server and client initial renders match.

## Testing
1. Go to review page with long summary
2. No React error #418 in console
3. Markdown renders correctly (headings, bullets)