### PR TITLE
fix: clarify version count label to '+ X older' in Prompts table

### DIFF
--- a/admin-next/src/app/(dashboard)/prompts/components/AgentTable.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/components/AgentTable.tsx
@@ -135,9 +135,7 @@ export function AgentTable({ agents, promptsByAgent, onEdit, onTest }: AgentTabl
                       <span className="text-neutral-600">•</span>
                     </>
                   )}
-                  <span className="text-neutral-500 text-xs">
-                    {historyCount} version{historyCount !== 1 ? 's' : ''}
-                  </span>
+                  <span className="text-neutral-500 text-xs">+ {historyCount} older</span>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
## Problem
The version count column in the Prompts table showed 'X versions' which was confusing - it actually showed the count of historical (non-current) versions, not total versions.

## Solution
Changed label from 'X versions' to '+ X older' to make it clear that:
- The current version is shown separately in the table
- This count represents older/historical versions available for comparison

## Files Changed
- `admin-next/src/app/(dashboard)/prompts/components/AgentTable.tsx` - Updated label text