### PR TITLE
fix: use llm.parseStructured for tagger (fixes openai.beta.chat undefined)

### DIFF
--- a/services/agent-api/src/agents/tagger.js
+++ b/services/agent-api/src/agents/tagger.js
@@ -336,7 +336,7 @@ export async function runTagger(queueItem) {
     },
     async (context, promptTemplate, tools) => {
       const { payload } = context;
-      const { openai } = tools;
+      const { llm } = tools;
 
       // Extract domain TLD for geography hints
       const url = payload.url || '';
@@ -427,18 +427,18 @@ ${taxonomies.processes}
       // Use model and max_tokens from prompt_version instead of hardcoding
       const modelId = tools.model || 'gpt-4o-mini';
       const maxTokens = tools.promptConfig?.max_tokens;
-      const completion = await openai.beta.chat.completions.parse({
+      const completion = await llm.parseStructured({
         model: modelId,
-        max_tokens: maxTokens,
+        maxTokens,
         messages: [
           { role: 'system', content: promptTemplate },
           { role: 'user', content: content },
         ],
-        response_format: zodResponseFormat(TaggingSchema, 'classification'),
+        responseFormat: zodResponseFormat(TaggingSchema, 'classification'),
         temperature: 0.1,
       });
 
-      const result = completion.choices[0].message.parsed;
+      const result = completion.parsed;
       const usage = completion.usage;
       const { validCodes, parentMaps } = taxonomies;
 

--- a/services/agent-api/src/lib/runner.js
+++ b/services/agent-api/src/lib/runner.js
@@ -160,16 +160,8 @@ export class AgentRunner {
       }
 
       // 3. Execute Logic with step helpers available via tools
-      // DEBUG: Check if openai client is available
-      const openaiClient = this.openai;
-      console.log(`🔍 [${this.agentName}] OpenAI client available:`, !!openaiClient);
-      if (!openaiClient) {
-        console.error(
-          `❌ [${this.agentName}] OpenAI client is undefined! Check OPENAI_API_KEY env var.`,
-        );
-      }
       const result = await logicFn(context, promptConfig.prompt_text, {
-        openai: openaiClient,
+        openai: this.openai,
         supabase: this.supabase,
         // LLM abstraction layer - model from prompt_version
         llm,


### PR DESCRIPTION
The OpenAI SDK v6 has an issue where openai.beta.chat is undefined. This fix switches the tagger to use the llm abstraction layer's parseStructured function instead of directly calling openai.beta.chat.completions.parse.