### PR TITLE
improve: Dashboard cleanup and UX improvements

### DIFF
--- a/admin-next/src/app/(dashboard)/page.tsx
+++ b/admin-next/src/app/(dashboard)/page.tsx
@@ -219,18 +219,18 @@ async function getStats() {
 
 export default async function DashboardPage() {
   const {
-    statusCounts,
+    statusCounts: _statusCounts,
     recentFailures,
     publishedCount: _publishedCount,
-    successRate,
-    recentItemsCount,
-    activeTests,
+    successRate: _successRate,
+    recentItemsCount: _recentItemsCount,
+    activeTests: _activeTests,
     pendingProposals,
     failedLast24h,
     oldestPendingAge: _oldestPendingAge,
     oldestQueuedAge: _oldestQueuedAge,
-    discoveredToday,
-    enrichedToday,
+    discoveredToday: _discoveredToday,
+    enrichedToday: _enrichedToday,
     allStatusData,
   } = await getStats();
 
@@ -250,41 +250,6 @@ export default async function DashboardPage() {
         <h1 className="text-xl md:text-2xl font-bold">Dashboard</h1>
         <p className="mt-1 text-sm text-neutral-400">Overview of the ingestion pipeline</p>
       </header>
-
-      {/* Activity Today */}
-      <div className="space-y-3">
-        <h2 className="text-xs md:text-sm font-medium text-neutral-400 uppercase tracking-wide">
-          Activity Today
-        </h2>
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 md:gap-4">
-          <div className="rounded-xl border border-violet-500/20 bg-violet-500/5 p-3 md:p-4">
-            <p className="text-xs md:text-sm text-neutral-400">Discovered Today</p>
-            <p className="mt-1 text-xl md:text-2xl font-bold text-violet-400">{discoveredToday}</p>
-            <p className="text-[10px] md:text-xs text-neutral-500">New items found</p>
-          </div>
-          <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-3 md:p-4">
-            <p className="text-xs md:text-sm text-neutral-400">Processed Today</p>
-            <p className="mt-1 text-xl md:text-2xl font-bold text-emerald-400">{enrichedToday}</p>
-            <p className="text-[10px] md:text-xs text-neutral-500">Enriched + reviewed</p>
-          </div>
-          <div className="rounded-xl border border-sky-500/20 bg-sky-500/5 p-3 md:p-4">
-            <p className="text-xs md:text-sm text-neutral-400">Total in Pipeline</p>
-            <p className="mt-1 text-xl md:text-2xl font-bold text-sky-400">
-              {(statusCounts.pending || 0) +
-                (statusCounts.processing || 0) +
-                (statusCounts.enriched || 0)}
-            </p>
-            <p className="text-[10px] md:text-xs text-neutral-500">Awaiting action</p>
-          </div>
-          <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-3 md:p-4">
-            <p className="text-xs md:text-sm text-neutral-400">Success Rate (7d)</p>
-            <p className="mt-1 text-xl md:text-2xl font-bold text-amber-400">
-              {successRate.toFixed(1)}%
-            </p>
-            <p className="text-[10px] md:text-xs text-neutral-500">{recentItemsCount} items</p>
-          </div>
-        </div>
-      </div>
 
       {/* Detailed Pipeline Status */}
       <div className="space-y-3">
@@ -337,95 +302,6 @@ export default async function DashboardPage() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 md:gap-4 mt-3">
           <DiscoveryControlCard />
         </div>
-      </div>
-
-      {/* Other Metrics */}
-      <div className="grid grid-cols-2 gap-3 md:gap-4">
-        <div className="rounded-xl border border-purple-500/20 bg-purple-500/5 p-3 md:p-4">
-          <p className="text-xs md:text-sm text-neutral-400">Active A/B Tests</p>
-          <p className="mt-1 text-xl md:text-2xl font-bold text-purple-400">{activeTests}</p>
-          <Link href="/ab-tests" className="text-xs text-purple-400 hover:text-purple-300">
-            View tests →
-          </Link>
-        </div>
-        <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-3 md:p-4">
-          <p className="text-xs md:text-sm text-neutral-400">Pending Proposals</p>
-          <p className="mt-1 text-xl md:text-2xl font-bold text-amber-400">{pendingProposals}</p>
-          <Link href="/proposals" className="text-xs text-amber-400 hover:text-amber-300">
-            Review proposals →
-          </Link>
-        </div>
-      </div>
-
-      {/* Quick Actions */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
-        {/* Review Queue CTA */}
-        <Link
-          href="/review"
-          className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 hover:border-sky-500/50 transition-all group hover:scale-[1.02]"
-        >
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-lg font-semibold group-hover:text-sky-400 transition-colors flex items-center gap-2">
-                Review Queue
-                <span className="text-neutral-600 group-hover:text-sky-400/50 transition-colors">
-                  →
-                </span>
-              </h2>
-              <p className="mt-0.5 text-xs text-neutral-500">Triage and approve new content</p>
-              <p className="mt-2 text-sm text-neutral-300">
-                {statusCounts.enriched || 0} items waiting
-              </p>
-            </div>
-            <span className="text-3xl opacity-80 group-hover:opacity-100 transition-opacity">
-              📋
-            </span>
-          </div>
-        </Link>
-
-        {/* Prompts CTA */}
-        <Link
-          href="/prompts"
-          className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 hover:border-purple-500/50 transition-all group hover:scale-[1.02]"
-        >
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-lg font-semibold group-hover:text-purple-400 transition-colors flex items-center gap-2">
-                Prompt Engineering
-                <span className="text-neutral-600 group-hover:text-purple-400/50 transition-colors">
-                  →
-                </span>
-              </h2>
-              <p className="mt-0.5 text-xs text-neutral-500">Edit and test agent prompts</p>
-              <p className="mt-2 text-sm text-neutral-300">Manage prompt versions</p>
-            </div>
-            <span className="text-3xl opacity-80 group-hover:opacity-100 transition-opacity">
-              💬
-            </span>
-          </div>
-        </Link>
-
-        {/* Golden Sets CTA */}
-        <Link
-          href="/golden-sets"
-          className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 hover:border-amber-500/50 transition-all group hover:scale-[1.02]"
-        >
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-lg font-semibold group-hover:text-amber-400 transition-colors flex items-center gap-2">
-                Golden Sets
-                <span className="text-neutral-600 group-hover:text-amber-400/50 transition-colors">
-                  →
-                </span>
-              </h2>
-              <p className="mt-0.5 text-xs text-neutral-500">Maintain evaluation datasets</p>
-              <p className="mt-2 text-sm text-neutral-300">Test prompts against curated cases</p>
-            </div>
-            <span className="text-3xl opacity-80 group-hover:opacity-100 transition-opacity">
-              ⭐
-            </span>
-          </div>
-        </Link>
       </div>
 
       {/* Issues / Alerts Section */}

--- a/admin-next/src/app/(dashboard)/review/items-status-grid.tsx
+++ b/admin-next/src/app/(dashboard)/review/items-status-grid.tsx
@@ -183,27 +183,43 @@ export function ItemsStatusGrid({
                         key={status.code}
                         href={buildFilterUrl(status.name, currentSource, currentTime, currentView)}
                         className={cn(
-                          'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-colors',
+                          'inline-flex items-center rounded-full text-xs overflow-hidden transition-colors',
                           isActive
-                            ? `${config.activeColor} text-white border-transparent`
+                            ? 'border-transparent ring-2 ring-offset-1 ring-offset-neutral-900'
                             : status.count > 0
-                              ? `${cat.bgColor} ${cat.borderColor} hover:bg-opacity-20`
-                              : 'bg-neutral-800/50 border-neutral-700 hover:bg-neutral-700/50',
-                          'border',
+                              ? cat.borderColor
+                              : 'border-neutral-700',
+                          isActive && config.activeColor.replace('bg-', 'ring-'),
+                          'border hover:opacity-80',
                         )}
                         title={`Code ${status.code}: ${status.name} (${status.count} items)`}
                       >
-                        <span className={isActive ? 'text-white' : 'text-neutral-400'}>
+                        <span
+                          className={cn(
+                            'px-2 py-1 font-mono',
+                            isActive
+                              ? config.activeColor + ' text-white'
+                              : 'bg-neutral-800/80 text-neutral-400',
+                          )}
+                        >
+                          {status.code}
+                        </span>
+                        <span
+                          className={cn(
+                            'px-2 py-1',
+                            isActive ? 'text-white ' + config.activeColor : 'text-neutral-300',
+                          )}
+                        >
                           {status.name.replace(/_/g, ' ')}
                         </span>
                         <span
                           className={cn(
-                            'font-semibold',
+                            'px-2 py-1 font-semibold',
                             isActive
-                              ? 'text-white'
+                              ? config.activeColor + ' text-white'
                               : status.count > 0
-                                ? cat.color
-                                : 'text-neutral-500',
+                                ? cat.bgColor + ' ' + cat.color
+                                : 'bg-neutral-800/50 text-neutral-500',
                           )}
                         >
                           {status.count}

--- a/admin-next/src/app/(dashboard)/review/page.tsx
+++ b/admin-next/src/app/(dashboard)/review/page.tsx
@@ -287,7 +287,7 @@ export default async function ReviewPage({
   const status = itemId || urlSearch || searchQuery ? 'all' : params.status || 'pending_review';
   const source = params.source || '';
   const timeWindow = params.time || '';
-  const viewMode = params.view || 'split'; // 'list' or 'split'
+  const viewMode = params.view || 'card'; // 'card', 'list', or 'split'
 
   // Load status codes from status_lookup table (single source of truth)
   const statusCodes = await loadStatusCodes();
@@ -318,7 +318,7 @@ export default async function ReviewPage({
     const searchParams = new URLSearchParams();
     const merged = { status, source, time: timeWindow, view: viewMode, ...newParams };
     Object.entries(merged).forEach(([key, value]) => {
-      if (value && value !== 'split') searchParams.set(key, value); // split is default
+      if (value && value !== 'card') searchParams.set(key, value); // card is default
     });
     return `/review?${searchParams.toString()}`;
   };

--- a/admin-next/src/components/dashboard/PipelineStatusGrid.tsx
+++ b/admin-next/src/components/dashboard/PipelineStatusGrid.tsx
@@ -156,17 +156,22 @@ export function PipelineStatusGrid({ statusData }: PipelineStatusGridProps) {
                     <div
                       key={status.code}
                       className={cn(
-                        'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs',
-                        status.count > 0 ? cat.bgColor : 'bg-neutral-800/50',
+                        'inline-flex items-center rounded-full text-xs overflow-hidden',
                         status.count > 0 ? cat.borderColor : 'border-neutral-700',
                         'border',
                       )}
                       title={`Code ${status.code}: ${status.name}`}
                     >
-                      <span className="text-neutral-400">{status.name.replace(/_/g, ' ')}</span>
+                      <span className="px-2 py-1 bg-neutral-800/80 text-neutral-400 font-mono">
+                        {status.code}
+                      </span>
+                      <span className="px-2 py-1 text-neutral-300">
+                        {status.name.replace(/_/g, ' ')}
+                      </span>
                       <span
                         className={cn(
-                          'font-semibold',
+                          'px-2 py-1 font-semibold',
+                          status.count > 0 ? cat.bgColor : 'bg-neutral-800/50',
                           status.count > 0 ? cat.color : 'text-neutral-500',
                         )}
                       >


### PR DESCRIPTION
## Dashboard Cleanup
- Remove Activity Today section (4 tiles)
- Remove Active A/B Tests and Pending Proposals tiles
- Remove Quick Actions section (Review Queue, Prompt Engineering, Golden Sets)

## Sidebar Changes
- Move Pipeline Health to Observability submenu (first item)
- Remove icons from Process Queue and Trigger Build buttons

## Status Pills Redesign
New format: `[code | status | count]`
Example: `[100 | discovered | 5]`

Applied to both Dashboard (PipelineStatusGrid) and Items page (ItemsStatusGrid)

## Menu Structure
```
📈 Observability
├── Pipeline Health (moved from top-level)
├── Metrics Dashboard
├── Quality Trends
├── Drift Detection
└── Alerts
```