### PR TITLE
fix: pill styling - count stands out

### DIFF
--- a/admin-next/src/app/(dashboard)/review/items-status-grid.tsx
+++ b/admin-next/src/app/(dashboard)/review/items-status-grid.tsx
@@ -185,7 +185,7 @@ export function ItemsStatusGrid({
                         className={cn(
                           'inline-flex items-center rounded-full text-xs overflow-hidden transition-colors',
                           isActive
-                            ? 'border-transparent ring-2 ring-offset-1 ring-offset-neutral-900'
+                            ? 'ring-2 ring-offset-1 ring-offset-neutral-900'
                             : status.count > 0
                               ? cat.borderColor
                               : 'border-neutral-700',
@@ -197,24 +197,22 @@ export function ItemsStatusGrid({
                         <span
                           className={cn(
                             'px-2 py-1 font-mono',
-                            isActive
-                              ? config.activeColor + ' text-white'
-                              : 'bg-neutral-800/80 text-neutral-400',
+                            isActive ? config.activeColor + ' text-white' : 'text-neutral-400',
                           )}
                         >
                           {status.code}
                         </span>
                         <span
                           className={cn(
-                            'px-2 py-1',
-                            isActive ? 'text-white ' + config.activeColor : 'text-neutral-300',
+                            'px-2 py-1 border-r border-neutral-700',
+                            isActive ? config.activeColor + ' text-white' : 'text-neutral-400',
                           )}
                         >
                           {status.name.replace(/_/g, ' ')}
                         </span>
                         <span
                           className={cn(
-                            'px-2 py-1 font-semibold',
+                            'px-2 py-1 font-bold',
                             isActive
                               ? config.activeColor + ' text-white'
                               : status.count > 0

--- a/admin-next/src/components/dashboard/PipelineStatusGrid.tsx
+++ b/admin-next/src/components/dashboard/PipelineStatusGrid.tsx
@@ -162,15 +162,13 @@ export function PipelineStatusGrid({ statusData }: PipelineStatusGridProps) {
                       )}
                       title={`Code ${status.code}: ${status.name}`}
                     >
-                      <span className="px-2 py-1 bg-neutral-800/80 text-neutral-400 font-mono">
-                        {status.code}
-                      </span>
-                      <span className="px-2 py-1 text-neutral-300">
+                      <span className="px-2 py-1 text-neutral-400 font-mono">{status.code}</span>
+                      <span className="px-2 py-1 text-neutral-400 border-r border-neutral-700">
                         {status.name.replace(/_/g, ' ')}
                       </span>
                       <span
                         className={cn(
-                          'px-2 py-1 font-semibold',
+                          'px-2 py-1 font-bold',
                           status.count > 0 ? cat.bgColor : 'bg-neutral-800/50',
                           status.count > 0 ? cat.color : 'text-neutral-500',
                         )}


### PR DESCRIPTION
## Fix
Code and status now have same neutral gray styling, only count has colored background.

**Before:** Code and count both had colored backgrounds, causing confusion
**After:** Code + status = neutral gray | Count = colored (stands out)