### PR TITLE
fix: Head-to-Head item selector - use correct column name

### DIFF
--- a/admin-next/src/app/(dashboard)/evals/head-to-head/page.tsx
+++ b/admin-next/src/app/(dashboard)/evals/head-to-head/page.tsx
@@ -18,7 +18,7 @@ interface QueueItem {
   payload: {
     title?: string;
   };
-  created_at: string;
+  discovered_at: string;
 }
 
 interface ComparisonResult {
@@ -57,8 +57,8 @@ export default function HeadToHeadPage() {
         .order('agent_name'),
       supabase
         .from('ingestion_queue')
-        .select('id, url, payload, created_at')
-        .order('created_at', { ascending: false })
+        .select('id, url, payload, discovered_at')
+        .order('discovered_at', { ascending: false })
         .limit(100),
     ]);
 


### PR DESCRIPTION
The ingestion_queue table uses `discovered_at`, not `created_at`. This was causing a 400 error when loading items.

## Changes
- Fix column name in query: `discovered_at` instead of `created_at`
- Update interface to match