### PR TITLE
improve: head-to-head comparison UX

### DIFF
--- a/admin-next/src/app/(dashboard)/review/[id]/actions.tsx
+++ b/admin-next/src/app/(dashboard)/review/[id]/actions.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
 import { approveQueueItemAction } from '../actions';
 import type { QueueItem } from '@bfsi/types';
@@ -174,6 +175,13 @@ export function ReviewActions({ item }: { item: QueueItem }) {
             ✓ This item has been published
           </p>
         )}
+
+        <Link
+          href={`/evals/head-to-head?item=${item.id}`}
+          className="block w-full rounded-lg border border-neutral-700 bg-neutral-800 px-4 py-2 text-sm font-medium text-neutral-300 hover:bg-neutral-700 hover:text-white text-center transition-colors"
+        >
+          Compare head-to-head
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Improves the UX for selecting items in the Head-to-Head Comparison page.

## Changes
- **Search input** - Type to filter items by source or title
- **Status filter dropdown** - Filter by pipeline status (fetches from `status_lookup`)
- **Source | Title format** - Shows source name + title for better item identification
- **Compare head-to-head button** - Added to item detail page Actions panel
- **URL param support** - Reads `?item=` param to pre-select item when navigating from detail page

## Files Changed
- `admin-next/src/app/(dashboard)/evals/head-to-head/page.tsx`
- `admin-next/src/app/(dashboard)/review/[id]/actions.tsx`