### PR TITLE
fix: item selection and show status code before name

### DIFF
--- a/admin-next/src/app/(dashboard)/evals/head-to-head/page.tsx
+++ b/admin-next/src/app/(dashboard)/evals/head-to-head/page.tsx
@@ -249,7 +249,7 @@ function HeadToHeadContent() {
                 <option value="">All statuses</option>
                 {statuses.map((s) => (
                   <option key={s.code} value={s.code}>
-                    {s.name}
+                    {s.code} {s.name}
                   </option>
                 ))}
               </select>
@@ -264,7 +264,11 @@ function HeadToHeadContent() {
             <select
               value={selectedItem}
               onChange={(e) => setSelectedItem(e.target.value)}
-              className="w-full mt-2 rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+              onClick={(e) => {
+                const target = e.target as HTMLOptionElement;
+                if (target.value) setSelectedItem(target.value);
+              }}
+              className="w-full mt-2 rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white cursor-pointer"
               size={5}
             >
               {filteredItems.length === 0 ? (


### PR DESCRIPTION
## Problem
1. Clicking on an item in the multi-line select wasn't updating the selection state
2. Status dropdown showed name only (e.g., 'to_thumbnail') - codes are more intuitive for power users

## Solution
1. Added `onClick` handler to capture selection on click (in addition to onChange)
2. Changed status display to `{code} {name}` format (e.g., '230 to_thumbnail')

## Files Changed
- `admin-next/src/app/(dashboard)/evals/head-to-head/page.tsx`