### PR TITLE
fix: add API key to head-to-head route

### DIFF
--- a/admin-next/src/app/api/evals/head-to-head/route.ts
+++ b/admin-next/src/app/api/evals/head-to-head/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 export const dynamic = 'force-dynamic';
 
 const AGENT_API_URL = process.env.AGENT_API_URL || 'https://bfsi-insights.onrender.com';
+const AGENT_API_KEY = process.env.AGENT_API_KEY || '';
 
 export async function POST(request: Request) {
   try {
@@ -18,7 +19,10 @@ export async function POST(request: Request) {
 
     const response = await fetch(`${AGENT_API_URL}/api/evals/head-to-head`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': AGENT_API_KEY,
+      },
       body: JSON.stringify({
         agent_name: agentName,
         version_a_id: versionAId,


### PR DESCRIPTION
## Problem
Head-to-head comparison failing with 'Unauthorized: Invalid or missing API key' error.

## Root Cause
The `/api/evals/head-to-head` route was not passing the `X-API-Key` header to the Agent API.

## Solution
Added `AGENT_API_KEY` env var and `X-API-Key` header to the fetch request.

## Files Changed
- `admin-next/src/app/api/evals/head-to-head/route.ts`