### PR TITLE
improve: migrate scorer.js to AgentRunner pattern

### DIFF
--- a/services/agent-api/src/lib/agent-registry.js
+++ b/services/agent-api/src/lib/agent-registry.js
@@ -22,9 +22,9 @@ export async function getAgentFunction(agentName) {
       const { runTagger } = await import('../agents/tagger.js');
       return runTagger(input, options);
     },
-    scorer: async (input) => {
+    scorer: async (input, options) => {
       const { scoreRelevance } = await import('../agents/scorer.js');
-      return scoreRelevance(input);
+      return scoreRelevance(input, options);
     },
   };
   return agentMap[agentName] || null;

--- a/services/agent-api/tests/lib/agent-registry.spec.js
+++ b/services/agent-api/tests/lib/agent-registry.spec.js
@@ -97,15 +97,16 @@ describe('agent-registry', () => {
       expect(runTagger).toHaveBeenCalledWith(input, options);
     });
 
-    it('scorer agent function calls scoreRelevance (no options)', async () => {
+    it('scorer agent function calls scoreRelevance with options', async () => {
       const { getAgentFunction } = await import('../../src/lib/agent-registry.js');
       const { scoreRelevance } = await import('../../src/agents/scorer.js');
 
       const fn = await getAgentFunction('scorer');
       const input = { id: 'abc', payload: { title: 'Test' } };
-      await fn(input);
+      const options = { promptOverride: { version: 'test-v1' } };
+      await fn(input, options);
 
-      expect(scoreRelevance).toHaveBeenCalledWith(input);
+      expect(scoreRelevance).toHaveBeenCalledWith(input, options);
     });
   });
 });


### PR DESCRIPTION
## Summary
Migrates `scorer.js` to use the `AgentRunner` pattern, bringing it in line with other agents (tagger, summarizer, screener).

## Changes
- **scorer.js**: Refactored `scoreRelevance()` to use `runner.run()` for LLM calls
- **agent-registry.js**: Updated to pass `options` to scorer (enables prompt override)
- **scorer.spec.js**: Added `AgentRunner` mock that bridges to existing `mockCreate`

## Benefits
- ✅ Consistent architecture across all agents
- ✅ Automatic run logging to `agent_run` table
- ✅ LangSmith tracing support
- ✅ Prompt override for head-to-head comparisons
- ✅ Usage now includes `model` field for traceability

## Testing
All 321 tests pass, including 39 scorer-specific tests.

## Notes
- Fast paths (stale content, rejection patterns, trusted sources) remain outside AgentRunner
- Only the LLM call is wrapped in `runner.run()`
- Backward compatible - existing callers don't need changes