### PR TITLE
feat: match admin card/detail views to live website

### DIFF
--- a/admin-next/src/app/(dashboard)/review/[id]/page.tsx
+++ b/admin-next/src/app/(dashboard)/review/[id]/page.tsx
@@ -239,9 +239,9 @@ export default async function ReviewDetailPage({
       </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Main Content - Left 2 columns */}
-        <div className="lg:col-span-2 space-y-6">
-          {/* Thumbnail - mimics published site layout */}
+        {/* Main Content - Left 2 columns - mimics live site layout */}
+        <div className="lg:col-span-2 space-y-4">
+          {/* Thumbnail - 16:9 aspect ratio like live site */}
           {(() => {
             const thumbnailUrl =
               (payload.thumbnail_url as string) ||
@@ -279,35 +279,104 @@ export default async function ReviewDetailPage({
             );
           })()}
 
-          {/* Long Summary Only - mimics published site */}
-          <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-6">
-            <div className="flex items-center justify-between mb-2">
-              <h2 className="text-lg font-semibold">AI Summary</h2>
-              <span
-                className={`text-xs ${
-                  summary.long && summary.long.length >= 400 && summary.long.length <= 600
-                    ? 'text-emerald-400'
-                    : 'text-amber-400'
-                }`}
-              >
-                {summary.long?.length || 0} chars
-              </span>
-            </div>
-            <div className="text-neutral-200 bg-neutral-800/50 rounded-lg p-3">
-              {summary.long ? (
-                <MarkdownRenderer
-                  content={summary.long}
-                  className="prose prose-invert prose-sm max-w-none prose-headings:text-neutral-200 prose-headings:font-semibold prose-headings:text-sm prose-p:my-1 prose-ul:my-1 prose-li:my-0"
-                />
-              ) : (
-                <p className="text-neutral-500 italic">No summary available</p>
-              )}
-            </div>
+          {/* Summary - no header, just content like live site */}
+          <div className="text-sm text-neutral-200">
+            {summary.long ? (
+              <MarkdownRenderer
+                content={summary.long}
+                className="prose prose-invert prose-sm max-w-none prose-headings:text-neutral-200 prose-headings:font-semibold prose-headings:text-sm prose-p:my-2 prose-ul:my-2 prose-li:my-0.5"
+              />
+            ) : (
+              <p className="text-neutral-500 italic">No summary available</p>
+            )}
           </div>
 
-          {/* Tags - Dynamic from taxonomy_config with validation */}
+          {/* Tags - colored like live site */}
+          <div className="flex flex-wrap gap-2 text-xs">
+            {((payload.audiences as string[]) || []).map((code: string) => (
+              <span
+                key={`aud-${code}`}
+                className="rounded-md border border-amber-800/50 bg-amber-900/20 px-2 py-0.5 text-amber-300"
+              >
+                {code}
+              </span>
+            ))}
+            {((payload.geographies as string[]) || []).map((code: string) => (
+              <span
+                key={`geo-${code}`}
+                className="rounded-md border border-teal-800/50 bg-teal-900/20 px-2 py-0.5 text-teal-300"
+              >
+                {code}
+              </span>
+            ))}
+            {((payload.industries as string[]) || []).map((code: string) => (
+              <span
+                key={`ind-${code}`}
+                className="rounded-md border border-cyan-800/50 bg-cyan-900/20 px-2 py-0.5 text-cyan-300"
+              >
+                {code}
+              </span>
+            ))}
+            {((payload.topics as string[]) || []).map((code: string) => (
+              <span
+                key={`top-${code}`}
+                className="rounded-md border border-purple-800/50 bg-purple-900/20 px-2 py-0.5 text-purple-300"
+              >
+                {code}
+              </span>
+            ))}
+            {((payload.regulator_codes as string[]) || []).map((code: string) => (
+              <span
+                key={`reg-${code}`}
+                className="rounded-md border border-rose-800/50 bg-rose-900/20 px-2 py-0.5 text-rose-300"
+              >
+                {code}
+              </span>
+            ))}
+            {((payload.regulation_codes as string[]) || []).map((code: string) => (
+              <span
+                key={`regn-${code}`}
+                className="rounded-md border border-orange-800/50 bg-orange-900/20 px-2 py-0.5 text-orange-300"
+              >
+                {code}
+              </span>
+            ))}
+            {((payload.process_codes as string[]) || []).map((code: string) => (
+              <span
+                key={`proc-${code}`}
+                className="rounded-md border border-emerald-800/50 bg-emerald-900/20 px-2 py-0.5 text-emerald-300"
+              >
+                {code}
+              </span>
+            ))}
+          </div>
+
+          {/* Open on source button - like live site */}
+          <div className="mt-2">
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-sky-600 bg-sky-600/10 px-5 py-2.5 text-sm font-semibold text-sky-300 hover:bg-sky-600/20 transition-colors"
+            >
+              Open on {(payload.source_name as string) || 'original'}
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                />
+              </svg>
+            </a>
+          </div>
+
+          {/* Separator before admin-only sections */}
+          <hr className="border-neutral-800 my-6" />
+
+          {/* Tags & Classification - admin view with validation */}
           <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-6">
-            <h2 className="text-lg font-semibold mb-4">Tags & Classification</h2>
+            <h2 className="text-lg font-semibold mb-4">Tags & Classification (Admin View)</h2>
             <TagDisplay
               payload={payload}
               taxonomyConfig={taxonomyConfig}

--- a/admin-next/src/app/(dashboard)/review/card-view.tsx
+++ b/admin-next/src/app/(dashboard)/review/card-view.tsx
@@ -38,8 +38,17 @@ function ItemCard({
     payload.thumbnail_url ||
     (typeof payload.thumbnail_path === 'string' ? payload.thumbnail_path : undefined);
 
+  const detailUrl = `/review/${item.id}?view=card&status=${status}`;
+
   return (
     <li className="rounded-2xl border border-neutral-800 bg-neutral-900/60 p-5 shadow-sm ring-1 ring-neutral-800/40 transition-all hover:border-neutral-700 hover:ring-neutral-700 hover:bg-neutral-900 relative">
+      {/* Clickable overlay for whole card - like live site */}
+      <a
+        href={detailUrl}
+        className="absolute inset-0 rounded-2xl focus:outline-none focus:ring-2 focus:ring-sky-500 z-0"
+        aria-label={`View details for ${payload.title || 'Untitled'}`}
+      />
+
       {/* Status Badge Overlay */}
       <div className="absolute top-3 right-3 z-10">
         <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-neutral-800 text-neutral-400 ring-1 ring-inset ring-neutral-700">
@@ -47,169 +56,239 @@ function ItemCard({
         </span>
       </div>
 
-      {/* Title */}
-      <h3 className="text-xl font-semibold text-sky-200 line-clamp-2 pr-16">
-        {payload.title || 'Untitled'}
-      </h3>
+      {/* Content wrapper - pointer-events-none to let card link work, re-enable for interactive elements */}
+      <div className="relative z-10 pointer-events-none">
+        {/* Title */}
+        <h3 className="text-xl font-semibold text-sky-200 line-clamp-2 pr-16">
+          {payload.title || 'Untitled'}
+        </h3>
 
-      {/* Meta */}
-      <div className="mt-1 text-sm text-neutral-400">
-        {formatDate(payload.date_published)} · {payload.source_name || 'Unknown'}
-      </div>
+        {/* Meta - matches live site format */}
+        <div className="mt-1 text-sm text-neutral-200">
+          <span className="text-neutral-400">Published</span>{' '}
+          {formatDate(payload.date_published) || 'Unknown'}
+          {payload.source_name && <span> · {payload.source_name}</span>}
+        </div>
 
-      {/* Content area - shows thumbnail OR expanded content */}
-      {isExpanded ? (
-        <>
-          {/* Expanded: Medium summary (long summary is for detail page only) */}
-          <div className="mt-2 max-h-48 overflow-y-auto rounded-md border border-neutral-800 bg-neutral-800/40 p-3">
-            {summary.medium ? (
-              <p className="text-sm text-neutral-300">{summary.medium}</p>
-            ) : (
-              <p className="text-sm text-neutral-500 italic">No summary available</p>
-            )}
-          </div>
+        {/* Content area - shows thumbnail OR expanded content */}
+        {isExpanded ? (
+          <>
+            {/* Expanded: Medium summary (long summary is for detail page only) */}
+            <div className="mt-2 max-h-48 overflow-y-auto rounded-md border border-neutral-800 bg-neutral-800/40 p-3">
+              {summary.medium ? (
+                <p className="text-sm text-neutral-300">{summary.medium}</p>
+              ) : (
+                <p className="text-sm text-neutral-500 italic">No summary available</p>
+              )}
+            </div>
 
-          {/* All Tags when expanded */}
-          <div className="mt-3 flex flex-wrap gap-1.5">
-            {payload.audiences?.map((a: string) => (
-              <span
-                key={a}
-                className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20"
-              >
-                {a}
-              </span>
-            ))}
-            {payload.geographies?.map((g: string) => (
-              <span
-                key={g}
-                className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-teal-500/10 text-teal-300 ring-1 ring-inset ring-teal-500/20"
-              >
-                {g}
-              </span>
-            ))}
-            {payload.topics?.map((t: string) => (
-              <span
-                key={t}
-                className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-violet-500/10 text-violet-300 ring-1 ring-inset ring-violet-500/20"
-              >
-                {t}
-              </span>
-            ))}
-          </div>
-        </>
-      ) : (
-        <>
-          {/* Collapsed: Thumbnail */}
-          <div
-            className="relative mt-2 w-full rounded-md border border-neutral-800 bg-neutral-800/40"
-            style={{ aspectRatio: '16 / 9', overflow: 'hidden' }}
-          >
-            {thumbnailUrl ? (
-              <Image
-                src={thumbnailUrl}
-                alt={payload.source_name || 'Preview'}
-                fill
-                className="object-cover"
-                sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
-                unoptimized
-              />
-            ) : (
-              <div className="absolute inset-0 flex items-center justify-center">
-                <svg
-                  className="h-10 w-10 text-neutral-700"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+            {/* All Tags when expanded - with colored backgrounds like live site */}
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {(payload.audiences as string[])?.map((a: string) => (
+                <span
+                  key={a}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="1.5"
-                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  />
-                </svg>
-              </div>
-            )}
-          </div>
-
-          {/* Short Summary when collapsed */}
-          {summary.short && (
-            <p className="mt-2 text-sm text-neutral-300 line-clamp-2">{summary.short}</p>
-          )}
-
-          {/* Minimal tags when collapsed - audience + geography + count */}
-          {(() => {
-            const audiences = (payload.audiences as string[]) || [];
-            const geographies = (payload.geographies as string[]) || [];
-            const topics = (payload.topics as string[]) || [];
-            const industries = (payload.industries as string[]) || [];
-            const regulators = (payload.regulator_codes as string[]) || [];
-            const regulations = (payload.regulation_codes as string[]) || [];
-            const obligations = (payload.obligation_codes as string[]) || [];
-            const processes = (payload.process_codes as string[]) || [];
-
-            // Extra tags = everything except first audience and first geography
-            const extraTagCount =
-              Math.max(0, audiences.length - 1) +
-              Math.max(0, geographies.length - 1) +
-              industries.length +
-              topics.length +
-              regulators.length +
-              regulations.length +
-              obligations.length +
-              processes.length;
-
-            return (
-              <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                {audiences[0] && (
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">
-                    {audiences[0]}
-                  </span>
-                )}
-                {geographies[0] && (
-                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-teal-500/10 text-teal-300 ring-1 ring-inset ring-teal-500/20">
-                    {geographies[0]}
-                  </span>
-                )}
-                {extraTagCount > 0 && (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onToggle();
-                    }}
-                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-700/50 text-neutral-400 ring-1 ring-inset ring-neutral-600/30 hover:bg-neutral-600/50 hover:text-neutral-300 transition-colors"
+                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                    />
+                  </svg>
+                  {a}
+                </span>
+              ))}
+              {(payload.geographies as string[])?.map((g: string) => (
+                <span
+                  key={g}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-teal-500/10 text-teal-300 ring-1 ring-inset ring-teal-500/20"
+                >
+                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  {g}
+                </span>
+              ))}
+              {(payload.industries as string[])?.map((i: string) => (
+                <span
+                  key={i}
+                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20"
+                >
+                  {i}
+                </span>
+              ))}
+              {(payload.topics as string[])?.map((t: string) => (
+                <span
+                  key={t}
+                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-violet-500/10 text-violet-300 ring-1 ring-inset ring-violet-500/20"
+                >
+                  {t}
+                </span>
+              ))}
+              {(payload.regulator_codes as string[])?.map((r: string) => (
+                <span
+                  key={r}
+                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-rose-500/10 text-rose-300 ring-1 ring-inset ring-rose-500/20"
+                >
+                  {r}
+                </span>
+              ))}
+              {(payload.regulation_codes as string[])?.map((r: string) => (
+                <span
+                  key={r}
+                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-500/10 text-orange-300 ring-1 ring-inset ring-orange-500/20"
+                >
+                  {r}
+                </span>
+              ))}
+              {(payload.process_codes as string[])?.map((p: string) => (
+                <span
+                  key={p}
+                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-500/10 text-cyan-300 ring-1 ring-inset ring-cyan-500/20"
+                >
+                  {p}
+                </span>
+              ))}
+            </div>
+          </>
+        ) : (
+          <>
+            {/* Collapsed: Thumbnail */}
+            <div
+              className="relative mt-2 w-full rounded-md border border-neutral-800 bg-neutral-800/40"
+              style={{ aspectRatio: '16 / 9', overflow: 'hidden' }}
+            >
+              {thumbnailUrl ? (
+                <Image
+                  src={thumbnailUrl}
+                  alt={payload.source_name || 'Preview'}
+                  fill
+                  className="object-cover"
+                  sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                  unoptimized
+                />
+              ) : (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <svg
+                    className="h-10 w-10 text-neutral-700"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
                   >
-                    +{extraTagCount} more
-                  </button>
-                )}
-              </div>
-            );
-          })()}
-        </>
-      )}
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="1.5"
+                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    />
+                  </svg>
+                </div>
+              )}
+            </div>
 
-      {/* Action Row */}
-      <div className="mt-3 pt-3 border-t border-neutral-800 flex items-center justify-between gap-2">
-        <a
-          href={`/review/${item.id}?view=card&status=${status}`}
-          className="text-xs text-sky-400 hover:text-sky-300"
-          onClick={(e) => e.stopPropagation()}
-        >
-          Full View →
-        </a>
-        <div className="flex gap-2">
+            {/* Short Summary when collapsed */}
+            {summary.short && (
+              <p className="mt-2 text-sm text-neutral-300 line-clamp-2">{summary.short}</p>
+            )}
+
+            {/* Minimal tags when collapsed - audience + geography + count */}
+            {(() => {
+              const audiences = (payload.audiences as string[]) || [];
+              const geographies = (payload.geographies as string[]) || [];
+              const topics = (payload.topics as string[]) || [];
+              const industries = (payload.industries as string[]) || [];
+              const regulators = (payload.regulator_codes as string[]) || [];
+              const regulations = (payload.regulation_codes as string[]) || [];
+              const obligations = (payload.obligation_codes as string[]) || [];
+              const processes = (payload.process_codes as string[]) || [];
+
+              // Extra tags = everything except first audience and first geography
+              const extraTagCount =
+                Math.max(0, audiences.length - 1) +
+                Math.max(0, geographies.length - 1) +
+                industries.length +
+                topics.length +
+                regulators.length +
+                regulations.length +
+                obligations.length +
+                processes.length;
+
+              return (
+                <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                  {audiences[0] && (
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">
+                      <svg
+                        className="h-3 w-3"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                        />
+                      </svg>
+                      {audiences[0]}
+                    </span>
+                  )}
+                  {geographies[0] && (
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-teal-500/10 text-teal-300 ring-1 ring-inset ring-teal-500/20">
+                      <svg
+                        className="h-3 w-3"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                        />
+                      </svg>
+                      {geographies[0]}
+                    </span>
+                  )}
+                  {extraTagCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onToggle();
+                      }}
+                      className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-700/50 text-neutral-400 ring-1 ring-inset ring-neutral-600/30 hover:bg-neutral-600/50 hover:text-neutral-300 transition-colors"
+                    >
+                      +{extraTagCount} more
+                    </button>
+                  )}
+                </div>
+              );
+            })()}
+          </>
+        )}
+
+        {/* Action Row - no Full View button, whole card is clickable */}
+        <div className="mt-3 pt-3 border-t border-neutral-800 flex items-center justify-end gap-2">
           <a
             href={item.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs text-neutral-400 hover:text-neutral-300"
+            className="text-xs text-neutral-400 hover:text-neutral-300 pointer-events-auto"
             onClick={(e) => e.stopPropagation()}
           >
             Source ↗
           </a>
           <button
-            className="inline-flex items-center gap-1 text-xs text-sky-300 hover:text-sky-200 transition-colors px-2 py-0.5 rounded hover:bg-neutral-800/50"
+            className="inline-flex items-center gap-1 text-xs text-sky-300 hover:text-sky-200 transition-colors px-2 py-0.5 rounded hover:bg-neutral-800/50 pointer-events-auto"
             onClick={(e) => {
               e.stopPropagation();
               onToggle();


### PR DESCRIPTION
## Summary
Updates admin card and detail page views to closely match the published website experience.

## Card View Changes
- **Whole card clickable** - like live site, removed Full View button
- **Meta format**: 'Published [date] · [source]' 
- **Icons on tags**: Person icon for audience, globe icon for geography
- **Expanded view**: Shows all tags with colors (audience amber, geography teal, topics violet, etc.)
- **Collapsed view**: Shows first audience + geography + '+X more' count

## Detail Page Changes
- **Removed 'AI Summary' header** - just shows content like live site
- **Added colored tags** underneath summary (same colors as live site)
- **Added 'Open on [source]' button** - matches live site CTA
- **Kept admin-only sections** below a separator (Tags & Classification with validation)

## User Story
As a content creator, I want to view cards, expanded cards and detail pages as they will be published as much as possible, so that I am in complete control of the final user experience.

## Files Changed
- `admin-next/src/app/(dashboard)/review/card-view.tsx`
- `admin-next/src/app/(dashboard)/review/[id]/page.tsx`