### PR TITLE
improve: UX and accessibility for light mode + both modes

### DIFF
--- a/docs/ux-accessibility-analysis.md
+++ b/docs/ux-accessibility-analysis.md
@@ -1,0 +1,90 @@
+# UX & Accessibility Analysis
+
+> Analysis date: 2025-12-19
+
+## Overview
+
+This document analyzes the BFSI Insights website from UX and accessibility perspectives. Focus is on adding light mode support (dark mode colors are fine) and accessibility improvements for both modes.
+
+---
+
+## Issues to Address
+
+| Category     | Issue                                               | Priority |
+| ------------ | --------------------------------------------------- | -------- |
+| **Contrast** | "Published" label gray on dark (~3:1) - needs 4.5:1 | High     |
+| **Contrast** | Breadcrumb text too light                           | High     |
+| **Contrast** | Some tag colors may not meet WCAG AA                | Medium   |
+| **Layout**   | Expanded card height differs from neighbors         | Medium   |
+| **UX**       | "View for" dropdown label unclear                   | Low      |
+| **Touch**    | Expand/Collapse button slightly small               | Low      |
+| **A11y**     | Focus states need improvement                       | Medium   |
+| **A11y**     | Screen reader labels missing                        | Medium   |
+
+---
+
+## User Story
+
+**Title:** Improve Website Contrast & Accessibility
+
+**As a** user with varying abilities,  
+**I want** the BFSI Insights website to have proper color contrast and accessibility features,  
+**So that** I can read content comfortably and navigate with keyboard/screen reader.
+
+### Acceptance Criteria
+
+#### Contrast & Readability
+
+- [ ] "Published" label meets WCAG AA (4.5:1 contrast ratio)
+- [ ] Breadcrumb text meets WCAG AA contrast
+- [ ] All tag colors meet 3:1 contrast against their backgrounds
+- [ ] Date/source text is clearly readable
+
+#### Layout Consistency
+
+- [ ] Expanded cards maintain same height as collapsed neighbors (use max-height with scroll if needed)
+
+#### Label Clarity
+
+- [ ] Change "View for:" to "Audience view:"
+
+#### Touch Targets
+
+- [ ] Slightly increase Expand/Collapse button size (min 44x44px)
+
+#### Keyboard & Focus
+
+- [ ] All interactive elements have visible focus indicators
+- [ ] Expand/Collapse can be triggered via Enter/Space
+- [ ] `aria-expanded` attribute on expandable cards
+
+#### Screen Reader
+
+- [ ] "New" badge has sr-only descriptive text
+- [ ] Tags have aria-labels with category
+- [ ] Cards use proper semantic structure
+
+### Out of Scope
+
+- "+X more" tag behavior changes
+- Homepage search
+- Mobile card width
+- Clickable tag filtering
+- Major layout redesign
+
+---
+
+## Implementation Status
+
+### Phase 1: Astro Website
+
+- [ ] Fix contrast: Published label, breadcrumbs, tags
+- [ ] Fix expanded card height consistency
+- [ ] Change "View for" → "Audience view"
+- [ ] Increase Expand/Collapse button size
+- [ ] Add focus states
+- [ ] Add aria labels
+
+### Phase 2: Admin (React)
+
+- [ ] Mirror all Phase 1 changes

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -12,7 +12,10 @@ const { segments } = Astro.props;
 ---
 
 <!-- Desktop Breadcrumbs -->
-<nav aria-label="Breadcrumb" class="hidden sm:block mb-6 text-sm text-neutral-400">
+<nav
+  aria-label="Breadcrumb"
+  class="hidden sm:block mb-6 text-sm text-neutral-500 dark:text-neutral-400"
+>
   <ol class="flex items-center space-x-2">
     {
       segments.map((segment, idx) => {
@@ -21,7 +24,7 @@ const { segments } = Astro.props;
           <li class="flex items-center">
             {idx > 0 && (
               <svg
-                class="w-4 h-4 mx-2 text-neutral-600"
+                class="w-4 h-4 mx-2 text-neutral-400 dark:text-neutral-600"
                 fill="currentColor"
                 viewBox="0 0 20 20"
                 aria-hidden="true"
@@ -34,13 +37,16 @@ const { segments } = Astro.props;
               </svg>
             )}
             {isLast ? (
-              <span class="text-neutral-200 font-medium truncate max-w-md" aria-current="page">
+              <span
+                class="text-neutral-800 dark:text-neutral-200 font-medium truncate max-w-md"
+                aria-current="page"
+              >
                 {segment.label}
               </span>
             ) : (
               <a
                 href={segment.href}
-                class="hover:text-neutral-200 hover:underline transition-colors"
+                class="hover:text-neutral-800 dark:hover:text-neutral-200 hover:underline transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 rounded"
               >
                 {segment.label}
               </a>
@@ -53,12 +59,12 @@ const { segments } = Astro.props;
 </nav>
 
 <!-- Mobile Back Link -->
-<nav aria-label="Breadcrumb" class="sm:hidden mb-6">
+<nav aria-label="Breadcrumb" class="sm:hidden mb-6 text-neutral-600 dark:text-neutral-400">
   {
     segments.length > 1 && (
       <a
         href={segments[segments.length - 2]?.href || '/'}
-        class="inline-flex items-center gap-2 text-sm text-neutral-400 hover:text-neutral-200 transition-colors"
+        class="inline-flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-400 hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 rounded"
       >
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path

--- a/src/features/publications/PublicationCard.astro
+++ b/src/features/publications/PublicationCard.astro
@@ -108,7 +108,7 @@ const candidates = [...itemThumbs];
 ---
 
 <li
-  class="group rounded-2xl border border-neutral-800 bg-neutral-900/60 p-5 shadow-sm ring-1 ring-neutral-800/40 transition-all hover:border-neutral-700 hover:ring-neutral-700 hover:bg-neutral-900 relative"
+  class="group rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900/60 p-5 shadow-sm ring-1 ring-neutral-200/40 dark:ring-neutral-800/40 transition-all hover:border-neutral-300 dark:hover:border-neutral-700 hover:ring-neutral-300 dark:hover:ring-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-900 relative"
   aria-labelledby={`t-${item.slug}`}
   data-audience={audience}
   data-audiences={audiences.join(',') || ''}
@@ -144,37 +144,43 @@ const candidates = [...itemThumbs];
     <div class="flex items-center gap-2">
       <h3
         id={`t-${item.slug}`}
-        class="text-xl font-semibold text-sky-200 line-clamp-2"
+        class="text-xl font-semibold text-sky-700 dark:text-sky-200 line-clamp-2"
         title={displayTitle}
       >
         {displayTitle}
       </h3>
       {
         isHome && isNew && (
-          <span class="ml-1 align-middle rounded-full bg-emerald-400/10 px-2 py-0.5 text-xs font-semibold text-emerald-300 ring-1 ring-inset ring-emerald-400/30">
+          <span class="ml-1 align-middle rounded-full bg-emerald-100 dark:bg-emerald-400/10 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:text-emerald-300 ring-1 ring-inset ring-emerald-300 dark:ring-emerald-400/30">
             New
+            <span class="sr-only"> - published within the last 7 days</span>
           </span>
         )
       }
       {
         isHome && isUpdated && (
-          <span class="ml-1 align-middle rounded-full bg-amber-400/10 px-2 py-0.5 text-xs font-semibold text-amber-300 ring-1 ring-inset ring-amber-400/30">
+          <span class="ml-1 align-middle rounded-full bg-amber-100 dark:bg-amber-400/10 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-300 dark:ring-amber-400/30">
             Updated
+            <span class="sr-only"> - modified within the last 7 days</span>
           </span>
         )
       }
     </div>
 
-    <div class="relative mt-1 text-sm text-neutral-200">
+    <div class="relative mt-1 text-sm text-neutral-700 dark:text-neutral-200">
       <span
         class="date-display"
         data-published={fmt(item.date_published ?? undefined)}
         data-added={fmt(item.date_added ?? undefined)}
       >
-        <span class="date-label text-neutral-400">Published</span>
+        <span class="date-label text-neutral-600 dark:text-neutral-400">Published</span>
         <span class="date-value">{fmt(item.date_published ?? undefined)}</span>
       </span>
-      {item.source_name && <span> · {item.source_name}</span>}
+      {
+        item.source_name && (
+          <span class="text-neutral-600 dark:text-neutral-200"> · {item.source_name}</span>
+        )
+      }
       {item.authors?.length > 0 && <span> · {item.authors[0]}</span>}
     </div>
 
@@ -182,7 +188,7 @@ const candidates = [...itemThumbs];
     <div class="card-collapsed">
       <!-- Thumbnail area (fixed height) -->
       <div
-        class="relative mt-2 w-full rounded-md border border-neutral-800 bg-neutral-800/40"
+        class="relative mt-2 w-full rounded-md border border-neutral-200 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-800/40"
         style="aspect-ratio: 16 / 9; overflow: hidden;"
       >
         {
@@ -225,7 +231,9 @@ const candidates = [...itemThumbs];
 
       {
         item.summary_short && (
-          <p class="mt-2 text-sm text-neutral-300 line-clamp-2">{item.summary_short}</p>
+          <p class="mt-2 text-sm text-neutral-600 dark:text-neutral-300 line-clamp-2">
+            {item.summary_short}
+          </p>
         )
       }
     </div>
@@ -233,13 +241,15 @@ const candidates = [...itemThumbs];
     <!-- Expanded view: Medium summary + all tags -->
     <div class="card-expanded hidden">
       <div
-        class="mt-2 max-h-48 overflow-y-auto rounded-md border border-neutral-800 bg-neutral-800/40 p-3"
+        class="mt-2 max-h-48 overflow-y-auto rounded-md border border-neutral-200 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-800/40 p-3"
       >
         {
           item.summary_medium ? (
-            <p class="text-sm text-neutral-300">{item.summary_medium}</p>
+            <p class="text-sm text-neutral-600 dark:text-neutral-300">{item.summary_medium}</p>
           ) : (
-            <p class="text-sm text-neutral-500 italic">No summary available</p>
+            <p class="text-sm text-neutral-400 dark:text-neutral-500 italic">
+              No summary available
+            </p>
           )
         }
       </div>
@@ -248,49 +258,49 @@ const candidates = [...itemThumbs];
       <div class="mt-3 flex flex-wrap gap-1.5">
         {
           audiences.map((a: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-500/10 text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-300 dark:ring-amber-500/20">
               {a}
             </span>
           ))
         }
         {
           geographies.map((g: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-teal-500/10 text-teal-300 ring-1 ring-inset ring-teal-500/20">
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-teal-100 dark:bg-teal-500/10 text-teal-700 dark:text-teal-300 ring-1 ring-inset ring-teal-300 dark:ring-teal-500/20">
               {g}
             </span>
           ))
         }
         {
           industries.map((i: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-500/10 text-blue-300 ring-1 ring-inset ring-blue-500/20">
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-500/10 text-blue-700 dark:text-blue-300 ring-1 ring-inset ring-blue-300 dark:ring-blue-500/20">
               {i}
             </span>
           ))
         }
         {
           topic.map((t: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-violet-500/10 text-violet-300 ring-1 ring-inset ring-violet-500/20">
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-violet-100 dark:bg-violet-500/10 text-violet-700 dark:text-violet-300 ring-1 ring-inset ring-violet-300 dark:ring-violet-500/20">
               {t}
             </span>
           ))
         }
         {
           regulators.map((r: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-rose-500/10 text-rose-300 ring-1 ring-inset ring-rose-500/20">
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-rose-100 dark:bg-rose-500/10 text-rose-700 dark:text-rose-300 ring-1 ring-inset ring-rose-300 dark:ring-rose-500/20">
               {r}
             </span>
           ))
         }
         {
           regulations.map((r: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-500/10 text-orange-300 ring-1 ring-inset ring-orange-500/20">
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 dark:bg-orange-500/10 text-orange-700 dark:text-orange-300 ring-1 ring-inset ring-orange-300 dark:ring-orange-500/20">
               {r}
             </span>
           ))
         }
         {
           processes.map((p: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-500/10 text-cyan-300 ring-1 ring-inset ring-cyan-500/20">
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-100 dark:bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 ring-1 ring-inset ring-cyan-300 dark:ring-cyan-500/20">
               {p}
             </span>
           ))
@@ -304,8 +314,17 @@ const candidates = [...itemThumbs];
         {/* Card view: audience + geography only */}
         {
           audience && (
-            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-300 ring-1 ring-inset ring-amber-500/20">
-              <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <span
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-500/10 text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-300 dark:ring-amber-500/20"
+              aria-label={`Audience: ${audience}`}
+            >
+              <svg
+                class="h-3 w-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
@@ -319,8 +338,17 @@ const candidates = [...itemThumbs];
         }
         {
           geography && (
-            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-teal-500/10 text-teal-300 ring-1 ring-inset ring-teal-500/20">
-              <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <span
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-teal-100 dark:bg-teal-500/10 text-teal-700 dark:text-teal-300 ring-1 ring-inset ring-teal-300 dark:ring-teal-500/20"
+              aria-label={`Geography: ${geography}`}
+            >
+              <svg
+                class="h-3 w-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
@@ -338,7 +366,7 @@ const candidates = [...itemThumbs];
             <button
               type="button"
               data-expand-card="true"
-              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-700/50 text-neutral-400 ring-1 ring-inset ring-neutral-600/30 hover:bg-neutral-600/50 hover:text-neutral-300 transition-colors pointer-events-auto"
+              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-200 dark:bg-neutral-700/50 text-neutral-600 dark:text-neutral-400 ring-1 ring-inset ring-neutral-300 dark:ring-neutral-600/30 hover:bg-neutral-300 dark:hover:bg-neutral-600/50 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors pointer-events-auto"
             >
               +{extraTagCount} more
             </button>
@@ -346,12 +374,13 @@ const candidates = [...itemThumbs];
         }
       </div>
 
-      <!-- Expand/Collapse button -->
+      <!-- Expand/Collapse button - min 44px touch target -->
       <button
-        class="relative z-30 flex-shrink-0 inline-flex items-center gap-1 text-xs text-sky-300 hover:text-sky-200 transition-colors px-2 py-0.5 rounded hover:bg-neutral-800/50 pointer-events-auto"
+        class="relative z-30 flex-shrink-0 inline-flex items-center justify-center gap-1 text-sm text-sky-600 dark:text-sky-300 hover:text-sky-700 dark:hover:text-sky-200 transition-colors min-w-[44px] min-h-[44px] px-3 py-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800/50 focus:outline-none focus:ring-2 focus:ring-sky-500 pointer-events-auto"
         type="button"
         data-expand-card="true"
-        aria-label="Expand card"
+        aria-expanded="false"
+        aria-label="Expand card to show more details"
       >
         <span class="expand-label">Expand</span>
         <span class="collapse-label hidden">Collapse</span>

--- a/src/features/publications/card-expand.ts
+++ b/src/features/publications/card-expand.ts
@@ -8,6 +8,7 @@ function toggleCard(card: HTMLElement, expand: boolean) {
   const expanded = card.querySelector('.card-expanded');
   const expandLabel = card.querySelector('.expand-label');
   const collapseLabel = card.querySelector('.collapse-label');
+  const expandButtons = card.querySelectorAll('[data-expand-card]');
 
   if (!collapsed || !expanded) return;
 
@@ -17,12 +18,16 @@ function toggleCard(card: HTMLElement, expand: boolean) {
     expandLabel?.classList.add('hidden');
     collapseLabel?.classList.remove('hidden');
     card.dataset.expanded = 'true';
+    // Update aria-expanded on all expand buttons
+    expandButtons.forEach((btn) => btn.setAttribute('aria-expanded', 'true'));
   } else {
     collapsed.classList.remove('hidden');
     expanded.classList.add('hidden');
     expandLabel?.classList.remove('hidden');
     collapseLabel?.classList.add('hidden');
     delete card.dataset.expanded;
+    // Update aria-expanded on all expand buttons
+    expandButtons.forEach((btn) => btn.setAttribute('aria-expanded', 'false'));
   }
 }
 

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -76,7 +76,7 @@ const ogImage = thumbCandidates[0];
     <button
       id="back-btn"
       type="button"
-      class="mb-4 inline-flex items-center gap-1.5 text-sm text-sky-400 hover:text-sky-300 transition-colors"
+      class="mb-4 inline-flex items-center gap-1.5 text-sm text-sky-600 dark:text-sky-400 hover:text-sky-700 dark:hover:text-sky-300 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 rounded"
     >
       <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"
@@ -95,15 +95,20 @@ const ogImage = thumbCandidates[0];
 
     <header>
       <h1 class="text-3xl font-bold tracking-tight">{item.title}</h1>
-      <div class="mt-2 text-sm text-neutral-300">
+      <div class="mt-2 text-sm text-neutral-600 dark:text-neutral-300">
         {
           item.date_published && (
             <span title="Date published">
-              <span class="text-neutral-400">Published</span> {fmt(item.date_published)}
+              <span class="text-neutral-500 dark:text-neutral-400">Published</span>{' '}
+              {fmt(item.date_published)}
             </span>
           )
         }
-        {item.source_name && <span> · {item.source_name}</span>}
+        {
+          item.source_name && (
+            <span class="text-neutral-600 dark:text-neutral-300"> · {item.source_name}</span>
+          )
+        }
         {item.authors?.length ? <span> · {item.authors[0]}</span> : null}
       </div>
     </header>
@@ -114,7 +119,7 @@ const ogImage = thumbCandidates[0];
           <div style="aspect-ratio: 16 / 9" />
           <div
             id="skeleton"
-            class="absolute inset-0 rounded-md border border-neutral-800 bg-neutral-800/40"
+            class="absolute inset-0 rounded-md border border-neutral-200 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-800/40"
           />
           <img
             src={thumbCandidates[0]}
@@ -122,7 +127,7 @@ const ogImage = thumbCandidates[0];
             alt={`${item.source_name || 'Source'} preview`}
             width="960"
             height="540"
-            class="absolute inset-0 h-full w-full rounded-md border border-neutral-800 object-cover"
+            class="absolute inset-0 h-full w-full rounded-md border border-neutral-200 dark:border-neutral-800 object-cover"
             loading="eager"
             onload="const s=document.getElementById('skeleton'); if(s) s.style.display='none'"
             onerror="const n=this.dataset.next||''; if(n){ const parts=n.split('|'); const nx=parts.shift(); this.dataset.next=parts.join('|'); if(nx){ this.src=nx; return; } } const s2=document.getElementById('skeleton'); if(s2) s2.style.display='none'; this.style.display='none'"
@@ -134,7 +139,7 @@ const ogImage = thumbCandidates[0];
     {
       item.summary_long && (
         <div
-          class="mt-4 text-sm text-neutral-200 prose prose-invert prose-sm max-w-none"
+          class="mt-4 text-sm text-neutral-700 dark:text-neutral-200 prose dark:prose-invert prose-sm max-w-none"
           set:html={marked.parse(item.summary_long)}
         />
       )
@@ -145,7 +150,7 @@ const ogImage = thumbCandidates[0];
         (item.audiences || [item.audience])
           .filter((c): c is string => Boolean(c))
           .map((code) => (
-            <span class="rounded-md border border-amber-800/50 bg-amber-900/20 px-2 py-0.5 text-amber-300">
+            <span class="rounded-md border border-amber-300 dark:border-amber-800/50 bg-amber-100 dark:bg-amber-900/20 px-2 py-0.5 text-amber-700 dark:text-amber-300">
               {code}
             </span>
           ))
@@ -154,56 +159,56 @@ const ogImage = thumbCandidates[0];
         (item.geographies || [item.geography])
           .filter((c): c is string => Boolean(c))
           .map((code) => (
-            <span class="rounded-md border border-teal-800/50 bg-teal-900/20 px-2 py-0.5 text-teal-300">
+            <span class="rounded-md border border-teal-300 dark:border-teal-800/50 bg-teal-100 dark:bg-teal-900/20 px-2 py-0.5 text-teal-700 dark:text-teal-300">
               {code}
             </span>
           ))
       }
       {
         item.content_type && (
-          <span class="rounded-md border border-neutral-800 bg-neutral-900 px-2 py-0.5 text-neutral-300">
+          <span class="rounded-md border border-neutral-300 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900 px-2 py-0.5 text-neutral-700 dark:text-neutral-300">
             {item.content_type}
           </span>
         )
       }
       {
         (item.industries || []).map((code: string) => (
-          <span class="rounded-md border border-cyan-800/50 bg-cyan-900/20 px-2 py-0.5 text-cyan-300">
+          <span class="rounded-md border border-cyan-300 dark:border-cyan-800/50 bg-cyan-100 dark:bg-cyan-900/20 px-2 py-0.5 text-cyan-700 dark:text-cyan-300">
             {code}
           </span>
         ))
       }
       {
         (item.topics || []).map((code: string) => (
-          <span class="rounded-md border border-purple-800/50 bg-purple-900/20 px-2 py-0.5 text-purple-300">
+          <span class="rounded-md border border-purple-300 dark:border-purple-800/50 bg-purple-100 dark:bg-purple-900/20 px-2 py-0.5 text-purple-700 dark:text-purple-300">
             {code}
           </span>
         ))
       }
       {
         (item.regulators || []).map((code: string) => (
-          <span class="rounded-md border border-rose-800/50 bg-rose-900/20 px-2 py-0.5 text-rose-300">
+          <span class="rounded-md border border-rose-300 dark:border-rose-800/50 bg-rose-100 dark:bg-rose-900/20 px-2 py-0.5 text-rose-700 dark:text-rose-300">
             {code}
           </span>
         ))
       }
       {
         (item.regulations || []).map((code: string) => (
-          <span class="rounded-md border border-orange-800/50 bg-orange-900/20 px-2 py-0.5 text-orange-300">
+          <span class="rounded-md border border-orange-300 dark:border-orange-800/50 bg-orange-100 dark:bg-orange-900/20 px-2 py-0.5 text-orange-700 dark:text-orange-300">
             {code}
           </span>
         ))
       }
       {
         (item.obligations || []).map((code: string) => (
-          <span class="rounded-md border border-yellow-800/50 bg-yellow-900/20 px-2 py-0.5 text-yellow-300">
+          <span class="rounded-md border border-yellow-300 dark:border-yellow-800/50 bg-yellow-100 dark:bg-yellow-900/20 px-2 py-0.5 text-yellow-700 dark:text-yellow-300">
             {code}
           </span>
         ))
       }
       {
         (item.processes || []).map((code: string) => (
-          <span class="rounded-md border border-emerald-800/50 bg-emerald-900/20 px-2 py-0.5 text-emerald-300">
+          <span class="rounded-md border border-emerald-300 dark:border-emerald-800/50 bg-emerald-100 dark:bg-emerald-900/20 px-2 py-0.5 text-emerald-700 dark:text-emerald-300">
             {code}
           </span>
         ))
@@ -215,7 +220,7 @@ const ogImage = thumbCandidates[0];
         href={item.url}
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-2 rounded-lg border border-sky-600 bg-sky-600/10 px-5 py-2.5 text-sm font-semibold text-sky-300 hover:bg-sky-600/20 transition-colors"
+        class="inline-flex items-center gap-2 rounded-lg border border-sky-600 bg-sky-100 dark:bg-sky-600/10 px-5 py-2.5 text-sm font-semibold text-sky-700 dark:text-sky-300 hover:bg-sky-200 dark:hover:bg-sky-600/20 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500"
         aria-label={`Open original on ${item.source_name || 'source'} for ${item.title}`}
         title={`Opens ${item.source_name || 'the publisher'} in a new tab`}
       >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -115,11 +115,13 @@ const expandItemThumb = (t?: string | null) => {
       <h3 class="text-xl font-semibold">Latest</h3>
 
       <div class="flex items-center gap-3">
-        <label for="persona-filter" class="text-sm text-neutral-400">View for:</label>
+        <label for="persona-filter" class="text-sm text-neutral-600 dark:text-neutral-400"
+          >Audience view:</label
+        >
 
         <select
           id="persona-filter"
-          class="rounded-lg border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-300 focus:outline-none focus:ring-2 focus:ring-sky-500"
+          class="rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-1.5 text-sm text-neutral-700 dark:text-neutral-300 focus:outline-none focus:ring-2 focus:ring-sky-500"
         >
           <option value="all">Everyone ({latest.length})</option>
           {


### PR DESCRIPTION
## Summary

Add light mode support and accessibility improvements to the Astro website.

### Light mode support
- Add light mode color variants to PublicationCard (cards, tags, buttons)
- Add light mode colors to Breadcrumbs component
- Add light mode colors to detail page
- Add light mode colors to audience filter dropdown

### UX improvements
- Change 'View for:' to 'Audience view:' for clarity
- Increase Expand/Collapse button size to 44x44px touch target

### Accessibility (both modes)
- Add `aria-expanded` attribute to expand buttons
- Toggle `aria-expanded` in card-expand.ts
- Add sr-only text for New/Updated badges
- Add aria-labels to audience/geography tags
- Add `focus:ring-2` focus states to interactive elements
- Add `aria-hidden` to decorative SVG icons

### Docs
- Add `docs/ux-accessibility-analysis.md` with user story and acceptance criteria