### PR TITLE
improve: Light mode styling with DRY CSS component classes

### DIFF
--- a/src/components/FilterPanel.astro
+++ b/src/components/FilterPanel.astro
@@ -25,19 +25,21 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
     role="dialog"
     aria-modal="true"
     aria-labelledby="panel-title"
-    class="absolute inset-0 sm:inset-4 sm:rounded-2xl bg-neutral-950 border border-neutral-800 flex flex-col overflow-hidden"
+    class="absolute inset-0 sm:inset-4 sm:rounded-2xl filter-panel-bg border flex flex-col overflow-hidden"
   >
     <!-- Header -->
-    <div class="flex items-center justify-between px-4 py-3 border-b border-neutral-800">
+    <div
+      class="flex items-center justify-between px-4 py-3 border-b border-neutral-200 dark:border-neutral-800"
+    >
       <div class="flex items-center gap-3">
-        <h3 id="panel-title" class="text-lg font-semibold">Filters</h3>
-        <span id="panel-result-count" class="text-sm text-neutral-400">
+        <h3 id="panel-title" class="text-lg font-semibold text-primary">Filters</h3>
+        <span id="panel-result-count" class="text-sm text-secondary">
           <span id="panel-count-number" class="font-semibold text-sky-300">0</span> results
         </span>
       </div>
       <button
         id="close-panel"
-        class="rounded-lg p-2 text-neutral-400 hover:text-white hover:bg-neutral-800 transition-colors"
+        class="rounded-lg p-2 text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
         aria-label="Close filters"
       >
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -57,12 +59,12 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
         {
           audienceFilter && audienceValues.length > 0 && (
             <details
-              class="filter-group border border-neutral-800 rounded-lg overflow-hidden"
+              class="filter-group filter-group-bg rounded-lg overflow-hidden"
               data-filter-key="audience"
               open
             >
-              <summary class="flex items-center justify-between px-4 py-3 cursor-pointer bg-neutral-900/50 hover:bg-neutral-800/50 transition-colors">
-                <span class="text-sm font-medium text-neutral-200">View for</span>
+              <summary class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors">
+                <span class="text-sm font-medium text-primary">View for</span>
                 <svg
                   class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
                   fill="none"
@@ -77,7 +79,7 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
                   />
                 </svg>
               </summary>
-              <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800">
+              <div class="px-4 py-3 filter-group-content border-t">
                 <div class="flex flex-wrap gap-2">
                   {audienceValues.map((v) => (
                     <label class="filter-checkbox cursor-pointer">
@@ -87,9 +89,9 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
                         value={v.value}
                         class="sr-only peer"
                       />
-                      <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm border border-neutral-700 bg-neutral-900 text-neutral-300 transition-all peer-checked:border-amber-500 peer-checked:bg-amber-500/10 peer-checked:text-amber-300 hover:border-neutral-600 hover:bg-neutral-800">
+                      <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm filter-chip transition-all peer-checked:border-amber-500 peer-checked:bg-amber-500/10 peer-checked:text-amber-600 dark:peer-checked:text-amber-300">
                         {v.value}
-                        <span class="text-xs text-neutral-500">{v.count}</span>
+                        <span class="text-xs filter-chip-count">{v.count}</span>
                       </span>
                     </label>
                   ))}
@@ -101,14 +103,14 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
 
         <!-- Industry Filter -->
         <details
-          class="filter-group border border-neutral-800 rounded-lg overflow-hidden"
+          class="filter-group filter-group-bg rounded-lg overflow-hidden"
           data-filter-key="industry"
           open
         >
           <summary
-            class="flex items-center justify-between px-4 py-3 cursor-pointer bg-neutral-900/50 hover:bg-neutral-800/50 transition-colors"
+            class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors"
           >
-            <span class="text-sm font-medium text-neutral-200">Industry</span>
+            <span class="text-sm font-medium text-primary">Industry</span>
             <svg
               class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
               fill="none"
@@ -122,7 +124,7 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
                 d="M19 9l-7 7-7-7"></path>
             </svg>
           </summary>
-          <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800">
+          <div class="px-4 py-3 filter-group-content border-t">
             <HierarchicalFilter
               filterKey="industry"
               items={industryWithCounts}
@@ -135,13 +137,13 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
 
         <!-- Process Filter -->
         <details
-          class="filter-group border border-neutral-800 rounded-lg overflow-hidden"
+          class="filter-group filter-group-bg rounded-lg overflow-hidden"
           data-filter-key="process"
         >
           <summary
-            class="flex items-center justify-between px-4 py-3 cursor-pointer bg-neutral-900/50 hover:bg-neutral-800/50 transition-colors"
+            class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors"
           >
-            <span class="text-sm font-medium text-neutral-200">Process</span>
+            <span class="text-sm font-medium text-primary">Process</span>
             <svg
               class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
               fill="none"
@@ -155,7 +157,7 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
                 d="M19 9l-7 7-7-7"></path>
             </svg>
           </summary>
-          <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800">
+          <div class="px-4 py-3 filter-group-content border-t">
             <HierarchicalFilter
               filterKey="process"
               items={processWithCounts}
@@ -168,13 +170,13 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
 
         <!-- Geography Filter -->
         <details
-          class="filter-group border border-neutral-800 rounded-lg overflow-hidden"
+          class="filter-group filter-group-bg rounded-lg overflow-hidden"
           data-filter-key="geography"
         >
           <summary
-            class="flex items-center justify-between px-4 py-3 cursor-pointer bg-neutral-900/50 hover:bg-neutral-800/50 transition-colors"
+            class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors"
           >
-            <span class="text-sm font-medium text-neutral-200">Geography</span>
+            <span class="text-sm font-medium text-primary">Geography</span>
             <svg
               class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
               fill="none"
@@ -188,7 +190,7 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
                 d="M19 9l-7 7-7-7"></path>
             </svg>
           </summary>
-          <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800">
+          <div class="px-4 py-3 filter-group-content border-t">
             <HierarchicalFilter
               filterKey="geography"
               items={geographyWithCounts}
@@ -207,11 +209,11 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
             if (filterValues.length === 0) return null;
             return (
               <details
-                class="filter-group border border-neutral-800 rounded-lg overflow-hidden"
+                class="filter-group filter-group-bg rounded-lg overflow-hidden"
                 data-filter-key={filter.column_name}
               >
-                <summary class="flex items-center justify-between px-4 py-3 cursor-pointer bg-neutral-900/50 hover:bg-neutral-800/50 transition-colors">
-                  <span class="text-sm font-medium text-neutral-200">{filter.display_label}</span>
+                <summary class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors">
+                  <span class="text-sm font-medium text-primary">{filter.display_label}</span>
                   <svg
                     class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
                     fill="none"
@@ -226,7 +228,7 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
                     />
                   </svg>
                 </summary>
-                <div class="px-4 py-3 bg-neutral-950/50 border-t border-neutral-800">
+                <div class="px-4 py-3 filter-group-content border-t">
                   <div class="flex flex-wrap gap-2">
                     {filterValues.map((v) => (
                       <label class="filter-checkbox cursor-pointer">
@@ -236,9 +238,9 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
                           value={v.value}
                           class="sr-only peer"
                         />
-                        <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm border border-neutral-700 bg-neutral-900 text-neutral-300 transition-all peer-checked:border-sky-500 peer-checked:bg-sky-500/10 peer-checked:text-sky-300 hover:border-neutral-600 hover:bg-neutral-800">
+                        <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm filter-chip transition-all peer-checked:border-sky-500 peer-checked:bg-sky-500/10 peer-checked:text-sky-600 dark:peer-checked:text-sky-300">
                           {v.value}
-                          <span class="text-xs text-neutral-500">{v.count}</span>
+                          <span class="text-xs filter-chip-count">{v.count}</span>
                         </span>
                       </label>
                     ))}
@@ -252,10 +254,12 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
     </div>
 
     <!-- Footer -->
-    <div class="px-4 py-3 border-t border-neutral-800 flex items-center justify-between gap-4">
+    <div
+      class="px-4 py-3 border-t border-neutral-200 dark:border-neutral-800 flex items-center justify-between gap-4"
+    >
       <button
         id="clear-all-filters"
-        class="px-4 py-2 text-sm font-medium text-neutral-400 hover:text-white transition-colors"
+        class="px-4 py-2 text-sm font-medium text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-white transition-colors"
       >
         Clear all
       </button>

--- a/src/components/HierarchicalFilter.astro
+++ b/src/components/HierarchicalFilter.astro
@@ -64,23 +64,23 @@ const displayItems = flattenItems(items, flattenRoots);
 const colorClasses: Record<string, { checkbox: string; pill: string }> = {
   cyan: {
     checkbox: 'text-cyan-500 focus:ring-cyan-500',
-    pill: 'peer-checked:border-cyan-500 peer-checked:bg-cyan-500/10 peer-checked:text-cyan-300',
+    pill: 'peer-checked:border-cyan-500 peer-checked:bg-cyan-500/10 peer-checked:text-cyan-700 dark:peer-checked:text-cyan-300',
   },
   sky: {
     checkbox: 'text-sky-500 focus:ring-sky-500',
-    pill: 'peer-checked:border-sky-500 peer-checked:bg-sky-500/10 peer-checked:text-sky-300',
+    pill: 'peer-checked:border-sky-500 peer-checked:bg-sky-500/10 peer-checked:text-sky-700 dark:peer-checked:text-sky-300',
   },
   emerald: {
     checkbox: 'text-emerald-500 focus:ring-emerald-500',
-    pill: 'peer-checked:border-emerald-500 peer-checked:bg-emerald-500/10 peer-checked:text-emerald-300',
+    pill: 'peer-checked:border-emerald-500 peer-checked:bg-emerald-500/10 peer-checked:text-emerald-700 dark:peer-checked:text-emerald-300',
   },
   amber: {
     checkbox: 'text-amber-500 focus:ring-amber-500',
-    pill: 'peer-checked:border-amber-500 peer-checked:bg-amber-500/10 peer-checked:text-amber-300',
+    pill: 'peer-checked:border-amber-500 peer-checked:bg-amber-500/10 peer-checked:text-amber-700 dark:peer-checked:text-amber-300',
   },
   purple: {
     checkbox: 'text-purple-500 focus:ring-purple-500',
-    pill: 'peer-checked:border-purple-500 peer-checked:bg-purple-500/10 peer-checked:text-purple-300',
+    pill: 'peer-checked:border-purple-500 peer-checked:bg-purple-500/10 peer-checked:text-purple-700 dark:peer-checked:text-purple-300',
   },
 };
 
@@ -93,10 +93,10 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
     <div class="space-y-2">
       {displayItems.map((l1) => (
         <details
-          class={`${cascadeClass}-l1 border border-neutral-800/50 rounded-md overflow-hidden`}
+          class={`${cascadeClass}-l1 border border-neutral-200 dark:border-neutral-800/50 rounded-md overflow-hidden`}
           data-code={l1.code}
         >
-          <summary class="flex items-center justify-between px-3 py-2 cursor-pointer bg-neutral-900/30 hover:bg-neutral-800/30 transition-colors text-xs">
+          <summary class="flex items-center justify-between px-3 py-2 cursor-pointer bg-neutral-50 dark:bg-neutral-900/30 hover:bg-neutral-100 dark:hover:bg-neutral-800/30 transition-colors text-xs">
             <div class="flex items-center gap-2">
               <input
                 type="checkbox"
@@ -104,17 +104,19 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                 value={l1.code}
                 class:list={[
                   checkboxClass,
-                  'h-3.5 w-3.5 rounded border-neutral-600 bg-neutral-800 focus:ring-offset-0 cursor-pointer',
+                  'h-3.5 w-3.5 rounded border-neutral-400 dark:border-neutral-600 bg-white dark:bg-neutral-800 focus:ring-offset-0 cursor-pointer',
                   colors.checkbox,
                 ]}
                 data-level="1"
                 data-code={l1.code}
                 onclick="event.stopPropagation()"
               />
-              <span class="font-medium text-neutral-400 uppercase tracking-wider">{l1.name}</span>
+              <span class="font-medium text-neutral-600 dark:text-neutral-400 uppercase tracking-wider">
+                {l1.name}
+              </span>
             </div>
             <svg
-              class="w-3.5 h-3.5 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
+              class="w-3.5 h-3.5 text-neutral-400 dark:text-neutral-600 transition-transform [details[open]>&]:rotate-180"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -127,15 +129,15 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
               />
             </svg>
           </summary>
-          <div class="px-3 py-2 bg-neutral-950/30 space-y-1.5">
+          <div class="px-3 py-2 bg-neutral-100/50 dark:bg-neutral-950/30 space-y-1.5">
             {/* L2 items - always rows with checkboxes, collapsible if they have children */}
             {l1.children?.map((l2) => (
               <details
-                class={`${cascadeClass}-l2 ml-2 border border-neutral-800/40 rounded overflow-hidden`}
+                class={`${cascadeClass}-l2 ml-2 border border-neutral-200 dark:border-neutral-800/40 rounded overflow-hidden`}
                 data-code={l2.code}
                 data-parent={l1.code}
               >
-                <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-neutral-900/20 hover:bg-neutral-800/30 transition-colors">
+                <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-white dark:bg-neutral-900/20 hover:bg-neutral-50 dark:hover:bg-neutral-800/30 transition-colors">
                   <div class="flex items-center gap-2">
                     <input
                       type="checkbox"
@@ -143,7 +145,7 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                       value={l2.code}
                       class:list={[
                         checkboxClass,
-                        'h-3 w-3 rounded border-neutral-600 bg-neutral-800 focus:ring-offset-0 cursor-pointer',
+                        'h-3 w-3 rounded border-neutral-400 dark:border-neutral-600 bg-white dark:bg-neutral-800 focus:ring-offset-0 cursor-pointer',
                         colors.checkbox,
                       ]}
                       data-level="2"
@@ -151,10 +153,10 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                       data-parent={l1.code}
                       onclick="event.stopPropagation()"
                     />
-                    <span class="text-[11px] font-medium text-neutral-400 uppercase tracking-wide">
+                    <span class="text-[11px] font-medium text-neutral-600 dark:text-neutral-400 uppercase tracking-wide">
                       {l2.name}
                       {l2.count ? (
-                        <span class="text-neutral-500 font-normal normal-case ml-1">
+                        <span class="text-neutral-400 dark:text-neutral-500 font-normal normal-case ml-1">
                           {l2.count}
                         </span>
                       ) : null}
@@ -162,7 +164,7 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                   </div>
                   {l2.children && l2.children.length > 0 && (
                     <svg
-                      class="w-3 h-3 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
+                      class="w-3 h-3 text-neutral-400 dark:text-neutral-600 transition-transform [details[open]>&]:rotate-180"
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
@@ -177,16 +179,16 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                   )}
                 </summary>
                 {l2.children && l2.children.length > 0 && (
-                  <div class="px-2.5 py-2 bg-neutral-950/20 flex flex-wrap gap-1.5">
+                  <div class="px-2.5 py-2 bg-neutral-100/30 dark:bg-neutral-950/20 flex flex-wrap gap-1.5">
                     {l2.children?.map((l3) =>
                       l3.children && l3.children.length > 0 ? (
                         // L3 with children - collapsible (e.g. European Union → countries)
                         <details
-                          class={`${cascadeClass}-l3 w-full border border-neutral-800/40 rounded overflow-hidden`}
+                          class={`${cascadeClass}-l3 w-full border border-neutral-200 dark:border-neutral-800/40 rounded overflow-hidden`}
                           data-code={l3.code}
                           data-parent={l2.code}
                         >
-                          <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-neutral-900/20 hover:bg-neutral-800/30 transition-colors">
+                          <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-white dark:bg-neutral-900/20 hover:bg-neutral-50 dark:hover:bg-neutral-800/30 transition-colors">
                             <div class="flex items-center gap-2">
                               <input
                                 type="checkbox"
@@ -194,7 +196,7 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                                 value={l3.code}
                                 class:list={[
                                   checkboxClass,
-                                  'h-3 w-3 rounded border-neutral-600 bg-neutral-800 focus:ring-offset-0 cursor-pointer',
+                                  'h-3 w-3 rounded border-neutral-400 dark:border-neutral-600 bg-white dark:bg-neutral-800 focus:ring-offset-0 cursor-pointer',
                                   colors.checkbox,
                                 ]}
                                 data-level="3"
@@ -202,17 +204,17 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                                 data-parent={l2.code}
                                 onclick="event.stopPropagation()"
                               />
-                              <span class="text-[11px] font-medium text-neutral-400 uppercase tracking-wide">
+                              <span class="text-[11px] font-medium text-neutral-600 dark:text-neutral-400 uppercase tracking-wide">
                                 {l3.name}
                                 {l3.count ? (
-                                  <span class="text-neutral-500 font-normal normal-case ml-1">
+                                  <span class="text-neutral-400 dark:text-neutral-500 font-normal normal-case ml-1">
                                     {l3.count}
                                   </span>
                                 ) : null}
                               </span>
                             </div>
                             <svg
-                              class="w-3 h-3 text-neutral-600 transition-transform [details[open]>&]:rotate-180"
+                              class="w-3 h-3 text-neutral-400 dark:text-neutral-600 transition-transform [details[open]>&]:rotate-180"
                               fill="none"
                               stroke="currentColor"
                               viewBox="0 0 24 24"
@@ -225,7 +227,7 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                               />
                             </svg>
                           </summary>
-                          <div class="px-2.5 py-2 bg-neutral-950/20 flex flex-wrap gap-1.5">
+                          <div class="px-2.5 py-2 bg-neutral-100/30 dark:bg-neutral-950/20 flex flex-wrap gap-1.5">
                             {l3.children?.map((l4) => (
                               <label class="filter-checkbox cursor-pointer">
                                 <input
@@ -240,14 +242,16 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                                 <span
                                   class:list={[
                                     'inline-flex items-center gap-1 px-2 py-1 rounded text-xs',
-                                    'border border-neutral-700/70 bg-neutral-900/70 text-neutral-400',
-                                    'transition-all hover:border-neutral-600 hover:bg-neutral-800',
+                                    'border border-neutral-300 dark:border-neutral-700/70 bg-white dark:bg-neutral-900/70 text-neutral-600 dark:text-neutral-400',
+                                    'transition-all hover:border-neutral-400 dark:hover:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-800',
                                     colors.pill,
                                   ]}
                                 >
                                   {l4.name}
                                   {l4.count ? (
-                                    <span class="text-neutral-500">{l4.count}</span>
+                                    <span class="text-neutral-400 dark:text-neutral-500">
+                                      {l4.count}
+                                    </span>
                                   ) : null}
                                 </span>
                               </label>
@@ -269,13 +273,15 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                           <span
                             class:list={[
                               'inline-flex items-center gap-1 px-2 py-1 rounded text-xs',
-                              'border border-neutral-700/70 bg-neutral-900/70 text-neutral-400',
-                              'transition-all hover:border-neutral-600 hover:bg-neutral-800',
+                              'border border-neutral-300 dark:border-neutral-700/70 bg-white dark:bg-neutral-900/70 text-neutral-600 dark:text-neutral-400',
+                              'transition-all hover:border-neutral-400 dark:hover:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-800',
                               colors.pill,
                             ]}
                           >
                             {l3.name}
-                            {l3.count ? <span class="text-neutral-500">{l3.count}</span> : null}
+                            {l3.count ? (
+                              <span class="text-neutral-400 dark:text-neutral-500">{l3.count}</span>
+                            ) : null}
                           </span>
                         </label>
                       ),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -135,7 +135,7 @@ const expandItemThumb = (t?: string | null) => {
 
         <a
           href="/publications"
-          class="text-sm font-medium text-sky-200 underline underline-offset-2 focus:outline-none focus:ring-2 focus:ring-sky-500"
+          class="text-sm font-medium link-secondary underline underline-offset-2 focus:outline-none focus:ring-2 focus:ring-sky-500"
         >
           Browse all →
         </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,89 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/*
+ * Shared component styles for light/dark mode
+ * Use these classes instead of repeating dark: variants everywhere
+ */
+@layer components {
+  /* Panel backgrounds */
+  .panel-bg {
+    @apply bg-white dark:bg-neutral-950 border-neutral-200 dark:border-neutral-800;
+  }
+
+  .panel-bg-subtle {
+    @apply bg-neutral-50 dark:bg-neutral-900/50;
+  }
+
+  .panel-bg-inset {
+    @apply bg-neutral-100 dark:bg-neutral-950/50;
+  }
+
+  /* Text colors */
+  .text-primary {
+    @apply text-neutral-900 dark:text-neutral-100;
+  }
+
+  .text-secondary {
+    @apply text-neutral-600 dark:text-neutral-400;
+  }
+
+  .text-muted {
+    @apply text-neutral-500 dark:text-neutral-500;
+  }
+
+  /* Form inputs */
+  .input-base {
+    @apply border border-neutral-300 dark:border-neutral-700 
+           bg-white dark:bg-neutral-900 
+           text-neutral-900 dark:text-neutral-100
+           placeholder:text-neutral-400 dark:placeholder:text-neutral-500
+           focus:border-sky-500 focus:ring-2 focus:ring-sky-500/20;
+  }
+
+  .select-base {
+    @apply border border-neutral-300 dark:border-neutral-700 
+           bg-white dark:bg-neutral-900 
+           text-neutral-700 dark:text-neutral-200
+           focus:border-sky-500 focus:ring-1 focus:ring-sky-500/20;
+  }
+
+  /* Links */
+  .link-primary {
+    @apply text-sky-600 dark:text-sky-400 hover:text-sky-700 dark:hover:text-sky-300;
+  }
+
+  .link-secondary {
+    @apply text-sky-700 dark:text-sky-200 hover:text-sky-800 dark:hover:text-sky-100;
+  }
+
+  /* Filter panel specific */
+  .filter-panel-bg {
+    @apply bg-white dark:bg-neutral-950 border-neutral-200 dark:border-neutral-800;
+  }
+
+  .filter-group-bg {
+    @apply border border-neutral-200 dark:border-neutral-800;
+  }
+
+  .filter-group-header {
+    @apply bg-neutral-50 dark:bg-neutral-900/50 hover:bg-neutral-100 dark:hover:bg-neutral-800/50;
+  }
+
+  .filter-group-content {
+    @apply bg-neutral-100/50 dark:bg-neutral-950/50 border-neutral-200 dark:border-neutral-800;
+  }
+
+  .filter-chip {
+    @apply border border-neutral-300 dark:border-neutral-700 
+           bg-white dark:bg-neutral-900 
+           text-neutral-700 dark:text-neutral-300
+           hover:border-neutral-400 dark:hover:border-neutral-600 
+           hover:bg-neutral-50 dark:hover:bg-neutral-800;
+  }
+
+  .filter-chip-count {
+    @apply text-neutral-500 dark:text-neutral-500;
+  }
+}


### PR DESCRIPTION
## Summary

Add light mode support to filter panel and related components with a DRY approach using shared CSS component classes.

### New shared CSS classes in `global.css`
- **Panel backgrounds**: `panel-bg`, `panel-bg-subtle`, `panel-bg-inset`
- **Text colors**: `text-primary`, `text-secondary`, `text-muted`
- **Form elements**: `input-base`, `select-base`
- **Links**: `link-primary`, `link-secondary`
- **Filter panel**: `filter-panel-bg`, `filter-group-*`, `filter-chip`

### Component updates
- **FilterPanel.astro**: White background, light borders, proper text contrast in light mode
- **HierarchicalFilter.astro**: Light backgrounds, visible checkboxes, text contrast
- **index.astro**: 'Browse all' link uses `link-secondary` for better contrast

### Note on dropdowns
Native select dropdown menus are styled by the OS/browser, not CSS. The select elements themselves now have proper light mode styling.