### PR TITLE
improve: Better filter text contrast with DRY CSS classes

### DIFF
--- a/src/components/HierarchicalFilter.astro
+++ b/src/components/HierarchicalFilter.astro
@@ -92,28 +92,19 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
   displayItems.length > 0 ? (
     <div class="space-y-2">
       {displayItems.map((l1) => (
-        <details
-          class={`${cascadeClass}-l1 border border-neutral-200 dark:border-neutral-800/50 rounded-md overflow-hidden`}
-          data-code={l1.code}
-        >
-          <summary class="flex items-center justify-between px-3 py-2 cursor-pointer bg-neutral-50 dark:bg-neutral-900/30 hover:bg-neutral-100 dark:hover:bg-neutral-800/30 transition-colors text-xs">
+        <details class={`${cascadeClass}-l1 hier-filter-l1`} data-code={l1.code}>
+          <summary class="flex items-center justify-between px-3 py-2 cursor-pointer hier-filter-l1-header transition-colors text-xs">
             <div class="flex items-center gap-2">
               <input
                 type="checkbox"
                 name={`filter-${filterKey}`}
                 value={l1.code}
-                class:list={[
-                  checkboxClass,
-                  'h-3.5 w-3.5 rounded border-neutral-400 dark:border-neutral-600 bg-white dark:bg-neutral-800 focus:ring-offset-0 cursor-pointer',
-                  colors.checkbox,
-                ]}
+                class:list={[checkboxClass, 'h-3.5 w-3.5 hier-filter-checkbox', colors.checkbox]}
                 data-level="1"
                 data-code={l1.code}
                 onclick="event.stopPropagation()"
               />
-              <span class="font-medium text-neutral-600 dark:text-neutral-400 uppercase tracking-wider">
-                {l1.name}
-              </span>
+              <span class="hier-filter-l1-text">{l1.name}</span>
             </div>
             <svg
               class="w-3.5 h-3.5 text-neutral-400 dark:text-neutral-600 transition-transform [details[open]>&]:rotate-180"
@@ -129,31 +120,27 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
               />
             </svg>
           </summary>
-          <div class="px-3 py-2 bg-neutral-100/50 dark:bg-neutral-950/30 space-y-1.5">
+          <div class="px-3 py-2 hier-filter-content space-y-1.5">
             {/* L2 items - always rows with checkboxes, collapsible if they have children */}
             {l1.children?.map((l2) => (
               <details
-                class={`${cascadeClass}-l2 ml-2 border border-neutral-200 dark:border-neutral-800/40 rounded overflow-hidden`}
+                class={`${cascadeClass}-l2 ml-2 hier-filter-l2`}
                 data-code={l2.code}
                 data-parent={l1.code}
               >
-                <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-white dark:bg-neutral-900/20 hover:bg-neutral-50 dark:hover:bg-neutral-800/30 transition-colors">
+                <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer hier-filter-l2-header transition-colors">
                   <div class="flex items-center gap-2">
                     <input
                       type="checkbox"
                       name={`filter-${filterKey}`}
                       value={l2.code}
-                      class:list={[
-                        checkboxClass,
-                        'h-3 w-3 rounded border-neutral-400 dark:border-neutral-600 bg-white dark:bg-neutral-800 focus:ring-offset-0 cursor-pointer',
-                        colors.checkbox,
-                      ]}
+                      class:list={[checkboxClass, 'h-3 w-3 hier-filter-checkbox', colors.checkbox]}
                       data-level="2"
                       data-code={l2.code}
                       data-parent={l1.code}
                       onclick="event.stopPropagation()"
                     />
-                    <span class="text-[11px] font-medium text-neutral-600 dark:text-neutral-400 uppercase tracking-wide">
+                    <span class="text-[11px] hier-filter-l2-text">
                       {l2.name}
                       {l2.count ? (
                         <span class="text-neutral-400 dark:text-neutral-500 font-normal normal-case ml-1">
@@ -179,16 +166,16 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                   )}
                 </summary>
                 {l2.children && l2.children.length > 0 && (
-                  <div class="px-2.5 py-2 bg-neutral-100/30 dark:bg-neutral-950/20 flex flex-wrap gap-1.5">
+                  <div class="px-2.5 py-2 hier-filter-content flex flex-wrap gap-1.5">
                     {l2.children?.map((l3) =>
                       l3.children && l3.children.length > 0 ? (
                         // L3 with children - collapsible (e.g. European Union → countries)
                         <details
-                          class={`${cascadeClass}-l3 w-full border border-neutral-200 dark:border-neutral-800/40 rounded overflow-hidden`}
+                          class={`${cascadeClass}-l3 w-full hier-filter-l2`}
                           data-code={l3.code}
                           data-parent={l2.code}
                         >
-                          <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer bg-white dark:bg-neutral-900/20 hover:bg-neutral-50 dark:hover:bg-neutral-800/30 transition-colors">
+                          <summary class="flex items-center justify-between px-2.5 py-1.5 cursor-pointer hier-filter-l2-header transition-colors">
                             <div class="flex items-center gap-2">
                               <input
                                 type="checkbox"
@@ -196,7 +183,7 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                                 value={l3.code}
                                 class:list={[
                                   checkboxClass,
-                                  'h-3 w-3 rounded border-neutral-400 dark:border-neutral-600 bg-white dark:bg-neutral-800 focus:ring-offset-0 cursor-pointer',
+                                  'h-3 w-3 hier-filter-checkbox',
                                   colors.checkbox,
                                 ]}
                                 data-level="3"
@@ -204,7 +191,7 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                                 data-parent={l2.code}
                                 onclick="event.stopPropagation()"
                               />
-                              <span class="text-[11px] font-medium text-neutral-600 dark:text-neutral-400 uppercase tracking-wide">
+                              <span class="text-[11px] hier-filter-l2-text">
                                 {l3.name}
                                 {l3.count ? (
                                   <span class="text-neutral-400 dark:text-neutral-500 font-normal normal-case ml-1">
@@ -227,7 +214,7 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                               />
                             </svg>
                           </summary>
-                          <div class="px-2.5 py-2 bg-neutral-100/30 dark:bg-neutral-950/20 flex flex-wrap gap-1.5">
+                          <div class="px-2.5 py-2 hier-filter-content flex flex-wrap gap-1.5">
                             {l3.children?.map((l4) => (
                               <label class="filter-checkbox cursor-pointer">
                                 <input
@@ -242,8 +229,8 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                                 <span
                                   class:list={[
                                     'inline-flex items-center gap-1 px-2 py-1 rounded text-xs',
-                                    'border border-neutral-300 dark:border-neutral-700/70 bg-white dark:bg-neutral-900/70 text-neutral-600 dark:text-neutral-400',
-                                    'transition-all hover:border-neutral-400 dark:hover:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-800',
+                                    'hier-filter-pill',
+                                    'transition-all',
                                     colors.pill,
                                   ]}
                                 >
@@ -273,8 +260,8 @@ const checkboxClass = cascadeClass ? `${cascadeClass}-checkbox` : '';
                           <span
                             class:list={[
                               'inline-flex items-center gap-1 px-2 py-1 rounded text-xs',
-                              'border border-neutral-300 dark:border-neutral-700/70 bg-white dark:bg-neutral-900/70 text-neutral-600 dark:text-neutral-400',
-                              'transition-all hover:border-neutral-400 dark:hover:border-neutral-600 hover:bg-neutral-50 dark:hover:bg-neutral-800',
+                              'hier-filter-pill',
+                              'transition-all',
                               colors.pill,
                             ]}
                           >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -86,4 +86,45 @@
   .filter-chip-count {
     @apply text-neutral-500 dark:text-neutral-500;
   }
+
+  /* Hierarchical filter items */
+  .hier-filter-l1 {
+    @apply border border-neutral-200 dark:border-neutral-800/50 rounded-md overflow-hidden;
+  }
+
+  .hier-filter-l1-header {
+    @apply bg-neutral-50 dark:bg-neutral-900/30 hover:bg-neutral-100 dark:hover:bg-neutral-800/30;
+  }
+
+  .hier-filter-l1-text {
+    @apply font-medium text-neutral-800 dark:text-neutral-300 uppercase tracking-wider;
+  }
+
+  .hier-filter-l2 {
+    @apply border border-neutral-200 dark:border-neutral-800/40 rounded overflow-hidden;
+  }
+
+  .hier-filter-l2-header {
+    @apply bg-white dark:bg-neutral-900/20 hover:bg-neutral-50 dark:hover:bg-neutral-800/30;
+  }
+
+  .hier-filter-l2-text {
+    @apply font-medium text-neutral-700 dark:text-neutral-400 uppercase tracking-wide;
+  }
+
+  .hier-filter-content {
+    @apply bg-neutral-100/50 dark:bg-neutral-950/30;
+  }
+
+  .hier-filter-checkbox {
+    @apply rounded border-neutral-400 dark:border-neutral-600 bg-white dark:bg-neutral-800 focus:ring-offset-0 cursor-pointer;
+  }
+
+  .hier-filter-pill {
+    @apply border border-neutral-300 dark:border-neutral-700/70 
+           bg-white dark:bg-neutral-900/70 
+           text-neutral-700 dark:text-neutral-400
+           hover:border-neutral-400 dark:hover:border-neutral-600 
+           hover:bg-neutral-50 dark:hover:bg-neutral-800;
+  }
 }


### PR DESCRIPTION
## Summary

Fix filter text readability in light mode by increasing contrast and refactoring to use shared CSS classes.

### Changes

**New CSS classes in `global.css`:**
- `hier-filter-l1`, `hier-filter-l1-header`, `hier-filter-l1-text`
- `hier-filter-l2`, `hier-filter-l2-header`, `hier-filter-l2-text`
- `hier-filter-content`, `hier-filter-checkbox`, `hier-filter-pill`

**Key fix:**
- L1 text changed from `text-neutral-600` to `text-neutral-800` for better readability
- L2 text changed from `text-neutral-600` to `text-neutral-700`

**Refactored `HierarchicalFilter.astro`:**
- Now uses shared CSS classes instead of inline Tailwind
- Centralizes light/dark mode styling in one place
- Reduces code duplication