### PR TITLE
improve: publications UI fixes - filter order, tag display, button alignment

### DIFF
--- a/src/components/FilterPanel.astro
+++ b/src/components/FilterPanel.astro
@@ -15,7 +15,13 @@ const { flatFilters, values, industryWithCounts, processWithCounts, geographyWit
 
 const audienceFilter = flatFilters.find((f) => f.column_name === 'audience');
 const audienceValues = audienceFilter ? values[audienceFilter.column_name] || [] : [];
-const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
+const topicFilter = flatFilters.find((f) => f.column_name === 'topic');
+const topicValues = topicFilter ? values[topicFilter.column_name] || [] : [];
+const contentTypeFilter = flatFilters.find((f) => f.column_name === 'content_type');
+const contentTypeValues = contentTypeFilter ? values[contentTypeFilter.column_name] || [] : [];
+const otherFilters = flatFilters.filter(
+  (f) => !['audience', 'topic', 'content_type'].includes(f.column_name),
+);
 ---
 
 <div id="filter-panel" class="fixed inset-0 z-50 hidden">
@@ -55,7 +61,7 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
     <!-- Filter groups (scrollable) -->
     <div class="flex-1 overflow-y-auto p-4">
       <div class="max-w-3xl mx-auto space-y-3">
-        <!-- View For (Audience) -->
+        <!-- Audience Filter -->
         {
           audienceFilter && audienceValues.length > 0 && (
             <details
@@ -64,7 +70,7 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
               open
             >
               <summary class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors">
-                <span class="text-sm font-medium text-primary">View for</span>
+                <span class="text-sm font-medium text-primary">Audience</span>
                 <svg
                   class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
                   fill="none"
@@ -101,6 +107,40 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
           )
         }
 
+        <!-- Geography Filter -->
+        <details
+          class="filter-group filter-group-bg rounded-lg overflow-hidden"
+          data-filter-key="geography"
+        >
+          <summary
+            class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors"
+          >
+            <span class="text-sm font-medium text-primary">Geography</span>
+            <svg
+              class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </summary>
+          <div class="px-4 py-3 filter-group-content border-t">
+            <HierarchicalFilter
+              filterKey="geography"
+              items={geographyWithCounts}
+              color="sky"
+              emptyMessage="No geography tags yet"
+              cascadeClass="geography"
+              hideRoots={['GLOBAL']}
+            />
+          </div>
+        </details>
+
         <!-- Industry Filter -->
         <details
           class="filter-group filter-group-bg rounded-lg overflow-hidden"
@@ -135,6 +175,96 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
           </div>
         </details>
 
+        <!-- Topic Filter -->
+        {
+          topicFilter && topicValues.length > 0 && (
+            <details
+              class="filter-group filter-group-bg rounded-lg overflow-hidden"
+              data-filter-key="topic"
+            >
+              <summary class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors">
+                <span class="text-sm font-medium text-primary">Topic</span>
+                <svg
+                  class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </summary>
+              <div class="px-4 py-3 filter-group-content border-t">
+                <div class="flex flex-wrap gap-2">
+                  {topicValues.map((v) => (
+                    <label class="filter-checkbox cursor-pointer">
+                      <input
+                        type="checkbox"
+                        name="filter-topic"
+                        value={v.value}
+                        class="sr-only peer"
+                      />
+                      <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm filter-chip transition-all peer-checked:border-violet-500 peer-checked:bg-violet-500/10 peer-checked:text-violet-600 dark:peer-checked:text-violet-300">
+                        {v.value}
+                        <span class="text-xs filter-chip-count">{v.count}</span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </details>
+          )
+        }
+
+        <!-- Content Type Filter -->
+        {
+          contentTypeFilter && contentTypeValues.length > 0 && (
+            <details
+              class="filter-group filter-group-bg rounded-lg overflow-hidden"
+              data-filter-key="content_type"
+            >
+              <summary class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors">
+                <span class="text-sm font-medium text-primary">Content Type</span>
+                <svg
+                  class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </summary>
+              <div class="px-4 py-3 filter-group-content border-t">
+                <div class="flex flex-wrap gap-2">
+                  {contentTypeValues.map((v) => (
+                    <label class="filter-checkbox cursor-pointer">
+                      <input
+                        type="checkbox"
+                        name="filter-content_type"
+                        value={v.value}
+                        class="sr-only peer"
+                      />
+                      <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm filter-chip transition-all peer-checked:border-rose-500 peer-checked:bg-rose-500/10 peer-checked:text-rose-600 dark:peer-checked:text-rose-300">
+                        {v.value}
+                        <span class="text-xs filter-chip-count">{v.count}</span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            </details>
+          )
+        }
+
         <!-- Process Filter -->
         <details
           class="filter-group filter-group-bg rounded-lg overflow-hidden"
@@ -164,40 +294,6 @@ const otherFilters = flatFilters.filter((f) => f.column_name !== 'audience');
               color="emerald"
               emptyMessage="No process tags yet"
               cascadeClass="process"
-            />
-          </div>
-        </details>
-
-        <!-- Geography Filter -->
-        <details
-          class="filter-group filter-group-bg rounded-lg overflow-hidden"
-          data-filter-key="geography"
-        >
-          <summary
-            class="flex items-center justify-between px-4 py-3 cursor-pointer filter-group-header transition-colors"
-          >
-            <span class="text-sm font-medium text-primary">Geography</span>
-            <svg
-              class="w-4 h-4 text-neutral-500 transition-transform [details[open]>&]:rotate-180"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M19 9l-7 7-7-7"></path>
-            </svg>
-          </summary>
-          <div class="px-4 py-3 filter-group-content border-t">
-            <HierarchicalFilter
-              filterKey="geography"
-              items={geographyWithCounts}
-              color="sky"
-              emptyMessage="No geography tags yet"
-              cascadeClass="geography"
-              flattenRoots={['GLOBAL']}
             />
           </div>
         </details>

--- a/src/components/HierarchicalFilter.astro
+++ b/src/components/HierarchicalFilter.astro
@@ -28,6 +28,8 @@ interface Props {
   cascadeClass?: string;
   /** L1 codes to flatten - item stays at L1 (no children), its children become L1 siblings */
   flattenRoots?: string[];
+  /** L1 codes to hide from filter UI entirely (still valid as tags) */
+  hideRoots?: string[];
 }
 
 const {
@@ -37,6 +39,7 @@ const {
   emptyMessage = 'No items available',
   cascadeClass,
   flattenRoots = [],
+  hideRoots = [],
 } = Astro.props;
 
 // Flatten specified roots: item becomes childless L1, its children become L1 siblings
@@ -58,7 +61,13 @@ const flattenItems = (items: TaxonomyItem[], rootsToFlatten: string[]): Taxonomy
   return result;
 };
 
-const displayItems = flattenItems(items, flattenRoots);
+// Hide specified roots completely from the filter UI
+const filterHiddenRoots = (items: TaxonomyItem[], rootsToHide: string[]): TaxonomyItem[] => {
+  if (rootsToHide.length === 0) return items;
+  return items.filter((item) => !rootsToHide.includes(item.code));
+};
+
+const displayItems = filterHiddenRoots(flattenItems(items, flattenRoots), hideRoots);
 
 // Color scheme mappings
 const colorClasses: Record<string, { checkbox: string; pill: string }> = {

--- a/src/features/publications/PublicationCard.astro
+++ b/src/features/publications/PublicationCard.astro
@@ -63,18 +63,32 @@ const regulations = item.regulations || [];
 const obligations = item.obligations || [];
 const processes = item.processes || [];
 
+// Filter to show only deepest (leaf) tags - exclude parent tags when children exist
+// Tags use hierarchical codes like 'banking', 'banking-payments', 'banking-payments-real-time-instant'
+const getDeepestTags = (tags: string[]): string[] => {
+  if (!tags || tags.length === 0) return [];
+  return tags.filter((tag) => {
+    // Keep this tag only if no other tag starts with it (plus separator)
+    return !tags.some((other) => other !== tag && other.startsWith(tag + '-'));
+  });
+};
+
+const deepestIndustries = getDeepestTags(industries);
+const deepestGeographies = getDeepestTags(geographies);
+const deepestProcesses = getDeepestTags(processes);
+
 // Count extra tags (everything except first audience and first geography shown on card)
-// Extra audiences (beyond first), extra geographies (beyond first), plus all other tags
+// Use deepest tags for counts to be consistent
 const extraTagCount =
   Math.max(0, audiences.length - 1) +
-  Math.max(0, geographies.length - 1) +
-  industries.length +
+  Math.max(0, deepestGeographies.length - 1) +
+  deepestIndustries.length +
   topic.length +
   content_type.length +
   regulators.length +
   regulations.length +
   obligations.length +
-  processes.length;
+  deepestProcesses.length;
 
 const isNew =
   isHome && item.date_added
@@ -254,8 +268,9 @@ const candidates = [...itemThumbs];
         }
       </div>
 
-      <!-- All tags when expanded -->
+      <!-- All tags when expanded (showing only deepest/leaf tags, in same order as collapsed view) -->
       <div class="mt-3 flex flex-wrap gap-1.5">
+        {/* First show audience (same as collapsed view) */}
         {
           audiences.map((a: string) => (
             <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-500/10 text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-300 dark:ring-amber-500/20">
@@ -263,15 +278,17 @@ const candidates = [...itemThumbs];
             </span>
           ))
         }
+        {/* Then geography (same as collapsed view) */}
         {
-          geographies.map((g: string) => (
+          deepestGeographies.map((g: string) => (
             <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-teal-100 dark:bg-teal-500/10 text-teal-700 dark:text-teal-300 ring-1 ring-inset ring-teal-300 dark:ring-teal-500/20">
               {g}
             </span>
           ))
         }
+        {/* Now the additional tags that were hidden */}
         {
-          industries.map((i: string) => (
+          deepestIndustries.map((i: string) => (
             <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-500/10 text-blue-700 dark:text-blue-300 ring-1 ring-inset ring-blue-300 dark:ring-blue-500/20">
               {i}
             </span>
@@ -299,7 +316,7 @@ const candidates = [...itemThumbs];
           ))
         }
         {
-          processes.map((p: string) => (
+          deepestProcesses.map((p: string) => (
             <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-100 dark:bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 ring-1 ring-inset ring-cyan-300 dark:ring-cyan-500/20">
               {p}
             </span>
@@ -308,8 +325,8 @@ const candidates = [...itemThumbs];
       </div>
     </div>
 
-    <!-- Tags row - pushed to bottom, leave space for absolute button -->
-    <div class="mt-auto pt-3 pr-24">
+    <!-- Tags row - pushed to bottom, with expand button inline -->
+    <div class="mt-auto pt-3 flex items-end justify-between gap-2">
       <div class="flex flex-wrap items-center gap-1.5">
         {/* Card view: audience + geography only */}
         {
@@ -360,31 +377,30 @@ const candidates = [...itemThumbs];
             </span>
           )
         }
-        {/* +X indicator for extra tags - expands card */}
+        {/* +X indicator for extra tags - expands card (hidden when expanded) */}
         {
           extraTagCount > 0 && (
             <button
               type="button"
               data-expand-card="true"
-              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-200 dark:bg-neutral-700/50 text-neutral-600 dark:text-neutral-400 ring-1 ring-inset ring-neutral-300 dark:ring-neutral-600/30 hover:bg-neutral-300 dark:hover:bg-neutral-600/50 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors pointer-events-auto"
+              class="card-collapsed-only inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-neutral-200 dark:bg-neutral-700/50 text-neutral-600 dark:text-neutral-400 ring-1 ring-inset ring-neutral-300 dark:ring-neutral-600/30 hover:bg-neutral-300 dark:hover:bg-neutral-600/50 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors pointer-events-auto"
             >
               +{extraTagCount} more
             </button>
           )
         }
       </div>
+      <!-- Expand/Collapse button - inline with tags, aligned at bottom -->
+      <button
+        class="shrink-0 inline-flex items-center justify-center gap-1 text-sm text-sky-600 dark:text-sky-300 hover:text-sky-700 dark:hover:text-sky-200 transition-colors px-2 py-0.5 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800/50 focus:outline-none focus:ring-2 focus:ring-sky-500 pointer-events-auto"
+        type="button"
+        data-expand-card="true"
+        aria-expanded="false"
+        aria-label="Expand card to show more details"
+      >
+        <span class="expand-label">Expand</span>
+        <span class="collapse-label hidden">Collapse</span>
+      </button>
     </div>
-
-    <!-- Expand/Collapse button - fixed position at bottom-right so it doesn't move when content changes -->
-    <button
-      class="absolute bottom-4 right-4 z-30 inline-flex items-center justify-center gap-1 text-sm text-sky-600 dark:text-sky-300 hover:text-sky-700 dark:hover:text-sky-200 transition-colors min-w-[44px] min-h-[44px] px-3 py-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800/50 focus:outline-none focus:ring-2 focus:ring-sky-500 pointer-events-auto"
-      type="button"
-      data-expand-card="true"
-      aria-expanded="false"
-      aria-label="Expand card to show more details"
-    >
-      <span class="expand-label">Expand</span>
-      <span class="collapse-label hidden">Collapse</span>
-    </button>
   </div>
 </li>

--- a/src/features/publications/card-expand.ts
+++ b/src/features/publications/card-expand.ts
@@ -9,6 +9,7 @@ function toggleCard(card: HTMLElement, expand: boolean) {
   const expandLabel = card.querySelector('.expand-label');
   const collapseLabel = card.querySelector('.collapse-label');
   const expandButtons = card.querySelectorAll('[data-expand-card]');
+  const collapsedOnlyElements = card.querySelectorAll('.card-collapsed-only');
 
   if (!collapsed || !expanded) return;
 
@@ -18,6 +19,8 @@ function toggleCard(card: HTMLElement, expand: boolean) {
     expandLabel?.classList.add('hidden');
     collapseLabel?.classList.remove('hidden');
     card.dataset.expanded = 'true';
+    // Hide collapsed-only elements (like +X more button)
+    collapsedOnlyElements.forEach((el) => (el as HTMLElement).classList.add('hidden'));
     // Update aria-expanded on all expand buttons
     expandButtons.forEach((btn) => btn.setAttribute('aria-expanded', 'true'));
   } else {
@@ -26,12 +29,18 @@ function toggleCard(card: HTMLElement, expand: boolean) {
     expandLabel?.classList.remove('hidden');
     collapseLabel?.classList.add('hidden');
     delete card.dataset.expanded;
+    // Show collapsed-only elements
+    collapsedOnlyElements.forEach((el) => (el as HTMLElement).classList.remove('hidden'));
     // Update aria-expanded on all expand buttons
     expandButtons.forEach((btn) => btn.setAttribute('aria-expanded', 'false'));
   }
 }
 
 function bindExpandButton(btn: HTMLElement) {
+  // Prevent duplicate bindings
+  if (btn.dataset.expandBound === 'true') return;
+  btn.dataset.expandBound = 'true';
+
   btn.addEventListener('click', (e) => {
     e.preventDefault();
     e.stopPropagation();

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -220,12 +220,12 @@ const ogImage = thumbCandidates[0];
         href={item.url}
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-2 rounded-lg border border-sky-600 bg-sky-100 dark:bg-sky-600/10 px-5 py-2.5 text-sm font-semibold text-sky-700 dark:text-sky-300 hover:bg-sky-200 dark:hover:bg-sky-600/20 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500"
+        class="inline-flex items-center gap-1.5 rounded-lg border border-sky-600 bg-sky-100 dark:bg-sky-600/10 px-3 py-1.5 text-xs font-semibold text-sky-700 dark:text-sky-300 hover:bg-sky-200 dark:hover:bg-sky-600/20 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500"
         aria-label={`Open original on ${item.source_name || 'source'} for ${item.title}`}
         title={`Opens ${item.source_name || 'the publisher'} in a new tab`}
       >
         Open on {item.source_name || 'original'}
-        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
             stroke-linecap="round"
             stroke-linejoin="round"


### PR DESCRIPTION
## Changes

### Filter Panel
- Changed 'View for' label to 'Audience'
- Reordered filters: **Audience → Geography → Industry → Topic → Content Type → Process**
- Hide GLOBAL from geography filter UI (still valid as tag in publications)

### Publication Cards
- **Show only deepest/leaf tags** - exclude parent tags when children exist (e.g., show 'uk' but not 'europe' or 'global')
- **Fixed expand button alignment** - now inline with tags at bottom instead of absolute positioned
- **Hide +X more button when expanded** - no longer shows when all tags are visible
- **Fixed expand button working on all cards** - added duplicate binding guard
- **Maintain tag order in expanded view** - audience and geography appear first (matching collapsed view), then additional tags

### Detail Page
- Made 'Open on [source]' button smaller (text-xs, reduced padding) to match tag height

## Files Changed
- `src/components/FilterPanel.astro` - filter order and labels
- `src/components/HierarchicalFilter.astro` - hideRoots prop for GLOBAL
- `src/features/publications/PublicationCard.astro` - tag filtering, button layout
- `src/features/publications/card-expand.ts` - collapsed-only element handling
- `src/pages/[slug].astro` - button sizing