### PR TITLE
improve: fix expanded card tags position and flatten geography filter

### DIFF
--- a/src/components/FilterPanel.astro
+++ b/src/components/FilterPanel.astro
@@ -136,7 +136,7 @@ const otherFilters = flatFilters.filter(
               color="sky"
               emptyMessage="No geography tags yet"
               cascadeClass="geography"
-              hideRoots={['GLOBAL']}
+              flattenRoots={['GLOBAL']}
             />
           </div>
         </details>

--- a/src/features/publications/PublicationCard.astro
+++ b/src/features/publications/PublicationCard.astro
@@ -252,7 +252,7 @@ const candidates = [...itemThumbs];
       }
     </div>
 
-    <!-- Expanded view: Medium summary + all tags -->
+    <!-- Expanded view: Medium summary only -->
     <div class="card-expanded hidden">
       <div
         class="mt-2 max-h-48 overflow-y-auto rounded-md border border-neutral-200 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-800/40 p-3"
@@ -265,62 +265,6 @@ const candidates = [...itemThumbs];
               No summary available
             </p>
           )
-        }
-      </div>
-
-      <!-- All tags when expanded (showing only deepest/leaf tags, in same order as collapsed view) -->
-      <div class="mt-3 flex flex-wrap gap-1.5">
-        {/* First show audience (same as collapsed view) */}
-        {
-          audiences.map((a: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-500/10 text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-300 dark:ring-amber-500/20">
-              {a}
-            </span>
-          ))
-        }
-        {/* Then geography (same as collapsed view) */}
-        {
-          deepestGeographies.map((g: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-teal-100 dark:bg-teal-500/10 text-teal-700 dark:text-teal-300 ring-1 ring-inset ring-teal-300 dark:ring-teal-500/20">
-              {g}
-            </span>
-          ))
-        }
-        {/* Now the additional tags that were hidden */}
-        {
-          deepestIndustries.map((i: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-500/10 text-blue-700 dark:text-blue-300 ring-1 ring-inset ring-blue-300 dark:ring-blue-500/20">
-              {i}
-            </span>
-          ))
-        }
-        {
-          topic.map((t: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-violet-100 dark:bg-violet-500/10 text-violet-700 dark:text-violet-300 ring-1 ring-inset ring-violet-300 dark:ring-violet-500/20">
-              {t}
-            </span>
-          ))
-        }
-        {
-          regulators.map((r: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-rose-100 dark:bg-rose-500/10 text-rose-700 dark:text-rose-300 ring-1 ring-inset ring-rose-300 dark:ring-rose-500/20">
-              {r}
-            </span>
-          ))
-        }
-        {
-          regulations.map((r: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 dark:bg-orange-500/10 text-orange-700 dark:text-orange-300 ring-1 ring-inset ring-orange-300 dark:ring-orange-500/20">
-              {r}
-            </span>
-          ))
-        }
-        {
-          deepestProcesses.map((p: string) => (
-            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-100 dark:bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 ring-1 ring-inset ring-cyan-300 dark:ring-cyan-500/20">
-              {p}
-            </span>
-          ))
         }
       </div>
     </div>
@@ -388,6 +332,42 @@ const candidates = [...itemThumbs];
               +{extraTagCount} more
             </button>
           )
+        }
+        {/* Extra tags shown when expanded - appear after audience/geography */}
+        {
+          deepestIndustries.map((i: string) => (
+            <span class="card-expanded-only hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-500/10 text-blue-700 dark:text-blue-300 ring-1 ring-inset ring-blue-300 dark:ring-blue-500/20">
+              {i}
+            </span>
+          ))
+        }
+        {
+          topic.map((t: string) => (
+            <span class="card-expanded-only hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-violet-100 dark:bg-violet-500/10 text-violet-700 dark:text-violet-300 ring-1 ring-inset ring-violet-300 dark:ring-violet-500/20">
+              {t}
+            </span>
+          ))
+        }
+        {
+          regulators.map((r: string) => (
+            <span class="card-expanded-only hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-rose-100 dark:bg-rose-500/10 text-rose-700 dark:text-rose-300 ring-1 ring-inset ring-rose-300 dark:ring-rose-500/20">
+              {r}
+            </span>
+          ))
+        }
+        {
+          regulations.map((r: string) => (
+            <span class="card-expanded-only hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 dark:bg-orange-500/10 text-orange-700 dark:text-orange-300 ring-1 ring-inset ring-orange-300 dark:ring-orange-500/20">
+              {r}
+            </span>
+          ))
+        }
+        {
+          deepestProcesses.map((p: string) => (
+            <span class="card-expanded-only hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-cyan-100 dark:bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 ring-1 ring-inset ring-cyan-300 dark:ring-cyan-500/20">
+              {p}
+            </span>
+          ))
         }
       </div>
       <!-- Expand/Collapse button - inline with tags, aligned at bottom -->

--- a/src/features/publications/card-expand.ts
+++ b/src/features/publications/card-expand.ts
@@ -10,6 +10,7 @@ function toggleCard(card: HTMLElement, expand: boolean) {
   const collapseLabel = card.querySelector('.collapse-label');
   const expandButtons = card.querySelectorAll('[data-expand-card]');
   const collapsedOnlyElements = card.querySelectorAll('.card-collapsed-only');
+  const expandedOnlyElements = card.querySelectorAll('.card-expanded-only');
 
   if (!collapsed || !expanded) return;
 
@@ -21,6 +22,8 @@ function toggleCard(card: HTMLElement, expand: boolean) {
     card.dataset.expanded = 'true';
     // Hide collapsed-only elements (like +X more button)
     collapsedOnlyElements.forEach((el) => (el as HTMLElement).classList.add('hidden'));
+    // Show expanded-only elements (extra tags)
+    expandedOnlyElements.forEach((el) => (el as HTMLElement).classList.remove('hidden'));
     // Update aria-expanded on all expand buttons
     expandButtons.forEach((btn) => btn.setAttribute('aria-expanded', 'true'));
   } else {
@@ -31,6 +34,8 @@ function toggleCard(card: HTMLElement, expand: boolean) {
     delete card.dataset.expanded;
     // Show collapsed-only elements
     collapsedOnlyElements.forEach((el) => (el as HTMLElement).classList.remove('hidden'));
+    // Hide expanded-only elements
+    expandedOnlyElements.forEach((el) => (el as HTMLElement).classList.add('hidden'));
     // Update aria-expanded on all expand buttons
     expandButtons.forEach((btn) => btn.setAttribute('aria-expanded', 'false'));
   }

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -220,7 +220,7 @@ const ogImage = thumbCandidates[0];
         href={item.url}
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center gap-1.5 rounded-lg border border-sky-600 bg-sky-100 dark:bg-sky-600/10 px-3 py-1.5 text-xs font-semibold text-sky-700 dark:text-sky-300 hover:bg-sky-200 dark:hover:bg-sky-600/20 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500"
+        class="inline-flex items-center gap-1.5 rounded-lg border border-sky-600 bg-sky-100 dark:bg-sky-600/10 px-2 py-0.5 text-xs font-medium text-sky-700 dark:text-sky-300 hover:bg-sky-200 dark:hover:bg-sky-600/20 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500"
         aria-label={`Open original on ${item.source_name || 'source'} for ${item.title}`}
         title={`Opens ${item.source_name || 'the publisher'} in a new tab`}
       >


### PR DESCRIPTION
## Changes

### Publication Cards - Expanded View
- **Fixed tag positioning** - extra tags now appear in the same bottom row AFTER audience/geography tags, not below the summary
- Added  class to show extra tags inline when card is expanded
- Tags maintain consistent order: audience → geography → industry → topic → regulators → regulations → processes

### Geography Filter
- **Flattened GLOBAL level** - changed from  to 
- Promotes GLOBAL's children (Europe/EMEA, Asia-Pacific, Americas, Other) to L1
- Removes the unnecessary GLOBAL parent level in the filter UI

### Detail Page Button
- **Reduced Open on button size** to match tag height
- Changed padding from `px-3 py-1.5` to `px-2 py-0.5`
- Changed font from `font-semibold` to `font-medium`

## Files Changed
- `src/features/publications/PublicationCard.astro` - moved tags to bottom row, added card-expanded-only
- `src/features/publications/card-expand.ts` - handle card-expanded-only visibility
- `src/components/FilterPanel.astro` - flattenRoots for geography
- `src/pages/[slug].astro` - button size adjustment