### PR TITLE
fix: use correct case for global geography code

### DIFF
--- a/scripts/check-geography-codes.js
+++ b/scripts/check-geography-codes.js
@@ -1,0 +1,46 @@
+/**
+ * Check geography codes in database
+ */
+/* eslint-env node */
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.PUBLIC_SUPABASE_URL,
+  process.env.PUBLIC_SUPABASE_ANON_KEY,
+);
+
+async function checkGeographyCodes() {
+  console.log('Checking geography codes in kb_geography...\n');
+
+  const { data, error } = await supabase
+    .from('kb_geography')
+    .select('code, name, level, parent_code')
+    .order('level')
+    .order('code');
+
+  if (error) {
+    console.error('Error querying geography:', error);
+    return;
+  }
+
+  console.log(`Found ${data.length} geography codes:\n`);
+
+  // Group by level
+  const byLevel = {};
+  data.forEach((item) => {
+    if (!byLevel[item.level]) byLevel[item.level] = [];
+    byLevel[item.level].push(item);
+  });
+
+  Object.keys(byLevel)
+    .sort()
+    .forEach((level) => {
+      console.log(`\nLevel ${level}:`);
+      byLevel[level].forEach((item) => {
+        console.log(`  ${item.code} - ${item.name} (parent: ${item.parent_code || 'none'})`);
+      });
+    });
+}
+
+checkGeographyCodes().catch(console.error);

--- a/src/components/FilterPanel.astro
+++ b/src/components/FilterPanel.astro
@@ -136,7 +136,7 @@ const otherFilters = flatFilters.filter(
               color="sky"
               emptyMessage="No geography tags yet"
               cascadeClass="geography"
-              flattenRoots={['GLOBAL']}
+              flattenRoots={['global']}
             />
           </div>
         </details>


### PR DESCRIPTION
## Problem
Geography filter still showing GLOBAL at L1 despite previous attempts to remove it.

## Root Cause
The database uses lowercase `global` as the geography code, but FilterPanel was using uppercase `GLOBAL` in the flattenRoots prop. Case mismatch meant the filter function never matched the code.

## Solution
- Changed `flattenRoots={['GLOBAL']}` to `flattenRoots={['global']}` (lowercase)
- Added verification script to check geography codes in database
- Now correctly removes 'global' from L1 and promotes its children (Americas, Asia-Pacific, Europe/EMEA, Other) to top level

## Files Changed
- `src/components/FilterPanel.astro` - fixed case in flattenRoots prop
- `scripts/check-geography-codes.js` - verification script to check geography hierarchy

## Verification
Database shows:
- Level 1: `global` (lowercase)
- Level 2: `amer`, `apac`, `emea` (children of global)

After this fix, geography filter will show Americas, Asia-Pacific, Europe/EMEA at top level, matching Industry filter structure.