### PR TITLE
fix: add missing mode prop to PromptEditModal in prompts list page

### DIFF
--- a/admin-next/src/app/(dashboard)/prompts/page.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/page.tsx
@@ -77,6 +77,7 @@ export default function PromptsPage() {
       {editingPrompt && (
         <PromptEditModal
           prompt={editingPrompt}
+          mode="create"
           onClose={() => setEditingPrompt(null)}
           onSave={() => {
             setEditingPrompt(null);


### PR DESCRIPTION
## Problem
After merging PR #366 (prompt version management UI), the build failed with a TypeScript error. The prompts list page was missing the required `mode` prop when calling PromptEditModal.

## Root Cause
PR #366 added a required `mode` prop ('edit' | 'create') to PromptEditModal to support both in-place editing and creating new versions. The agent detail page was updated to use this prop, but the prompts list page was missed.

## Solution
Added `mode="create"` to the PromptEditModal call in the prompts list page. This is correct because the list page always creates new versions (it doesn't support in-place editing).

## Files Changed
- `admin-next/src/app/(dashboard)/prompts/page.tsx` - Added mode prop

## Verification
- ✅ Build passes: `npm run build` succeeds
- ✅ TypeScript errors resolved
- ✅ Linter passes

## Related
- Fixes build error introduced in PR #366