### PR TITLE
improve: darken status code numbers in dashboard pills

### DIFF
--- a/admin-next/src/components/ui/status-pill.tsx
+++ b/admin-next/src/components/ui/status-pill.tsx
@@ -27,7 +27,7 @@ function PillContent({
       <span
         className={cn(
           'pl-2 pr-1 py-1 font-mono',
-          isActive ? activeColor + ' text-white' : 'bg-neutral-700/50 text-neutral-300',
+          isActive ? activeColor + ' text-white' : 'bg-neutral-700/50 text-neutral-400',
         )}
       >
         {code}


### PR DESCRIPTION
## Problem
Status code numbers in the dashboard pills were displayed in white (text-neutral-300), making them equally prominent as the status names. This created visual clutter and made it harder to quickly scan status names.

## Solution
Changed status code numbers from  (white) to  (light grey).

This improves visual hierarchy:
- Status names remain prominent (text-neutral-300)
- Status codes are still visible but less distracting (text-neutral-400)
- Count numbers remain bold and colored

## Before/After
**Before:** Code numbers in white, same prominence as status name
**After:** Code numbers in light grey, status name more prominent

## Files Changed
- `admin-next/src/components/ui/status-pill.tsx` - Updated text color for status code

## Testing
- ✅ Build passes
- ✅ Linter passes
- ✅ Visual hierarchy improved