### PR TITLE
fix: Remove is_current column, use stage=PRD as single source of truth

### DIFF
--- a/admin-next/src/app/(dashboard)/evals/head-to-head/page.tsx
+++ b/admin-next/src/app/(dashboard)/evals/head-to-head/page.tsx
@@ -10,7 +10,6 @@ interface PromptVersion {
   id: string;
   agent_name: string;
   version: string;
-  is_current: boolean;
   stage: string;
 }
 
@@ -67,10 +66,7 @@ function HeadToHeadContent() {
     setLoading(true);
 
     const [promptsRes, itemsRes, statusRes] = await Promise.all([
-      supabase
-        .from('prompt_version')
-        .select('id, agent_name, version, is_current, stage')
-        .order('agent_name'),
+      supabase.from('prompt_version').select('id, agent_name, version, stage').order('agent_name'),
       supabase
         .from('ingestion_queue')
         .select('id, url, payload, discovered_at, status_code')
@@ -215,7 +211,7 @@ function HeadToHeadContent() {
               <option value="">Select version...</option>
               {agentPrompts.map((p) => (
                 <option key={p.id} value={p.id}>
-                  {p.version} ({p.stage}) {p.is_current ? '★' : ''}
+                  {p.version} ({p.stage}) {p.stage === 'PRD' ? '★' : ''}
                 </option>
               ))}
             </select>
@@ -231,7 +227,7 @@ function HeadToHeadContent() {
               <option value="">Select version...</option>
               {agentPrompts.map((p) => (
                 <option key={p.id} value={p.id}>
-                  {p.version} ({p.stage}) {p.is_current ? '★' : ''}
+                  {p.version} ({p.stage}) {p.stage === 'PRD' ? '★' : ''}
                 </option>
               ))}
             </select>

--- a/admin-next/src/app/(dashboard)/evals/llm-judge/page.tsx
+++ b/admin-next/src/app/(dashboard)/evals/llm-judge/page.tsx
@@ -21,7 +21,7 @@ interface PromptVersion {
   id: string;
   agent_name: string;
   version: string;
-  is_current: boolean;
+  stage: string;
 }
 
 export default function LLMJudgePage() {
@@ -45,10 +45,7 @@ export default function LLMJudgePage() {
         .eq('eval_type', 'llm_judge')
         .order('created_at', { ascending: false })
         .limit(50),
-      supabase
-        .from('prompt_version')
-        .select('id, agent_name, version, is_current')
-        .order('agent_name'),
+      supabase.from('prompt_version').select('id, agent_name, version, stage').order('agent_name'),
     ]);
 
     if (!runsRes.error) setRuns(runsRes.data || []);
@@ -143,7 +140,7 @@ export default function LLMJudgePage() {
               <option value="">Select version...</option>
               {agentPrompts.map((p) => (
                 <option key={p.id} value={p.id}>
-                  {p.version} {p.is_current ? '(current)' : ''}
+                  {p.version} {p.stage === 'PRD' ? '(live)' : ''}
                 </option>
               ))}
             </select>

--- a/admin-next/src/app/(dashboard)/prompts/components/AgentDetail.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/components/AgentDetail.tsx
@@ -22,7 +22,7 @@ export function AgentDetail({
   onView,
   onTest,
 }: AgentDetailProps) {
-  const currentPrompt = prompts.find((p) => p.is_current);
+  const currentPrompt = prompts.find((p) => p.stage === 'PRD');
 
   return (
     <div className="h-full flex flex-col rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 overflow-hidden">
@@ -75,7 +75,7 @@ export function AgentDetail({
             <div
               key={p.version}
               className={`flex items-center justify-between p-3 rounded-lg ${
-                p.is_current
+                p.stage === 'PRD'
                   ? 'bg-emerald-500/10 border border-emerald-500/30'
                   : 'bg-neutral-800/30'
               }`}
@@ -85,11 +85,10 @@ export function AgentDetail({
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span
-                      className={`font-medium ${p.is_current ? 'text-emerald-300' : 'text-white'}`}
+                      className={`font-medium ${p.stage === 'PRD' ? 'text-emerald-300' : 'text-white'}`}
                     >
                       {p.version}
                     </span>
-                    {p.is_current && <span className="text-xs text-emerald-400">(current)</span>}
                     {p.stage && (
                       <span
                         className={`text-xs rounded-full px-2 py-0.5 ${getStageBadge(p.stage).className}`}
@@ -131,7 +130,7 @@ export function AgentDetail({
                     → PRD
                   </button>
                 )}
-                {!p.is_current && currentPrompt && (
+                {p.stage !== 'PRD' && currentPrompt && (
                   <button
                     onClick={() => onDiff(currentPrompt, p)}
                     className="text-xs text-purple-400 hover:text-purple-300"

--- a/admin-next/src/app/(dashboard)/prompts/components/AgentTable.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/components/AgentTable.tsx
@@ -52,7 +52,7 @@ export function AgentTable({ agents, promptsByAgent, onEdit, onTest }: AgentTabl
       <tbody className="divide-y divide-neutral-800">
         {agents.map((agentName) => {
           const agentPrompts = promptsByAgent[agentName];
-          const currentPrompt = agentPrompts.find((p) => p.is_current);
+          const currentPrompt = agentPrompts.find((p) => p.stage === 'PRD');
           const historyCount = agentPrompts.length - (currentPrompt ? 1 : 0);
 
           return (

--- a/admin-next/src/app/(dashboard)/prompts/components/PromptEditModal.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/components/PromptEditModal.tsx
@@ -39,7 +39,6 @@ export function PromptEditModal({ prompt, mode, onClose, onSave }: PromptEditMod
         notes: notes || null,
         model_id: prompt.model_id,
         stage: 'DEV',
-        is_current: false,
       });
 
       if (error) {

--- a/admin-next/src/app/(dashboard)/prompts/components/ViewVersionModal.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/components/ViewVersionModal.tsx
@@ -21,18 +21,23 @@ export function ViewVersionModal({ prompt, onClose, onRollback }: ViewVersionMod
           </p>
         </div>
         <div className="flex items-center gap-2">
-          {prompt.is_current ? (
-            <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-2 py-0.5 text-xs">
-              Current
-            </span>
-          ) : (
-            <button
-              onClick={onRollback}
-              className="rounded-lg bg-amber-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-500"
+          {prompt.stage && (
+            <span
+              className={`rounded-full px-2 py-0.5 text-xs ${
+                prompt.stage === 'PRD'
+                  ? 'bg-emerald-500/20 text-emerald-300'
+                  : 'bg-neutral-700 text-neutral-400'
+              }`}
             >
-              Make Current
-            </button>
+              {prompt.stage === 'PRD' ? 'Live' : prompt.stage}
+            </span>
           )}
+          <button
+            onClick={onRollback}
+            className="rounded-lg bg-amber-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-500"
+          >
+            Make Current
+          </button>
         </div>
       </div>
 

--- a/admin-next/src/app/(dashboard)/prompts/hooks/usePrompts.ts
+++ b/admin-next/src/app/(dashboard)/prompts/hooks/usePrompts.ts
@@ -68,14 +68,17 @@ export function usePrompts() {
       return false;
     }
 
+    // Retire current PRD version
     await supabase
       .from('prompt_version')
-      .update({ is_current: false })
-      .eq('agent_name', prompt.agent_name);
+      .update({ stage: 'RET', retired_at: new Date().toISOString() })
+      .eq('agent_name', prompt.agent_name)
+      .eq('stage', 'PRD');
 
+    // Promote selected version to PRD
     const { error } = await supabase
       .from('prompt_version')
-      .update({ is_current: true })
+      .update({ stage: 'PRD', deployed_at: new Date().toISOString() })
       .eq('agent_name', prompt.agent_name)
       .eq('version', prompt.version);
 

--- a/admin-next/src/app/(dashboard)/prompts/page.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/page.tsx
@@ -16,7 +16,7 @@ export default function PromptsPage() {
     if (!manifest) return null;
 
     const currentPromptNames = new Set(
-      prompts.filter((p) => p.is_current).map((p) => p.agent_name),
+      prompts.filter((p) => p.stage === 'PRD').map((p) => p.agent_name),
     );
 
     const requiredPrompts = manifest.required_prompts.filter((p) => p.required);

--- a/admin-next/src/app/(dashboard)/review/[id]/data-loaders.ts
+++ b/admin-next/src/app/(dashboard)/review/[id]/data-loaders.ts
@@ -83,7 +83,7 @@ export async function getCurrentPrompts() {
   const { data } = await supabase
     .from('prompt_version')
     .select('id, version, agent_name')
-    .eq('is_current', true)
+    .eq('stage', 'PRD')
     .in('agent_name', ['summarizer', 'tagger', 'thumbnail-generator']);
 
   return (data || []) as { id: string; version: string; agent_name: string }[];

--- a/packages/types/src/prompt.ts
+++ b/packages/types/src/prompt.ts
@@ -10,7 +10,6 @@ export interface PromptVersion {
   prompt_text: string;
   model_id?: string;
   stage?: PromptStage;
-  is_current: boolean;
   created_at: string;
   notes?: string;
   // Timestamp tracking for production lifecycle

--- a/scripts/check-prompt-coverage.js
+++ b/scripts/check-prompt-coverage.js
@@ -73,8 +73,8 @@ async function main() {
   // Try prompt_version (new canonical name) first
   const result1 = await supabase
     .from('prompt_version')
-    .select('agent_name, version, is_current')
-    .eq('is_current', true);
+    .select('agent_name, version, stage')
+    .eq('stage', 'PRD');
 
   if (!result1.error) {
     prompts = result1.data;
@@ -82,8 +82,8 @@ async function main() {
     // Fall back to prompt_versions (old name) for backwards compatibility
     const result2 = await supabase
       .from('prompt_versions')
-      .select('agent_name, version, is_current')
-      .eq('is_current', true);
+      .select('agent_name, version, stage')
+      .eq('stage', 'PRD');
     prompts = result2.data;
     promptError = result2.error;
   }

--- a/services/agent-api/src/lib/discovery-config.js
+++ b/services/agent-api/src/lib/discovery-config.js
@@ -51,7 +51,7 @@ export async function loadDiscoveryConfig() {
     .from('prompt_version')
     .select('prompt_text')
     .eq('agent_name', 'discoverer-config')
-    .eq('is_current', true)
+    .eq('stage', 'PRD')
     .single();
 
   // Extract keywords from taxonomy labels

--- a/services/agent-api/src/lib/evals.js
+++ b/services/agent-api/src/lib/evals.js
@@ -53,7 +53,7 @@ export async function runGoldenEval(agentName, agentFn, options = {}) {
     .from('prompt_version')
     .select('version')
     .eq('agent_name', agentName)
-    .eq('is_current', true)
+    .eq('stage', 'PRD')
     .single();
 
   // Create eval run
@@ -146,7 +146,7 @@ export async function runLLMJudgeEval(agentName, agentFn, inputs, options = {}) 
     .from('prompt_version')
     .select('version')
     .eq('agent_name', agentName)
-    .eq('is_current', true)
+    .eq('stage', 'PRD')
     .single();
 
   // Create eval run

--- a/services/agent-api/src/lib/prompt-eval.js
+++ b/services/agent-api/src/lib/prompt-eval.js
@@ -287,7 +287,7 @@ export async function getPromptEvalStatus(agentName) {
     .from('v_prompt_eval_status')
     .select('*')
     .eq('agent_name', agentName)
-    .eq('is_current', true)
+    .eq('stage', 'PRD')
     .single();
 
   if (error) return null;

--- a/services/agent-api/src/lib/runner.js
+++ b/services/agent-api/src/lib/runner.js
@@ -118,7 +118,7 @@ export class AgentRunner {
       .from('prompt_version')
       .select('*')
       .eq('agent_name', this.agentName)
-      .eq('is_current', true)
+      .eq('stage', 'PRD')
       .single();
 
     if (promptError || !data) {

--- a/services/agent-api/src/routes/agents.js
+++ b/services/agent-api/src/routes/agents.js
@@ -375,14 +375,14 @@ router.get('/eval/status/:agentName', async (req, res) => {
         id,
         agent_name,
         version,
-        is_current,
+        stage,
         last_eval_status,
         last_eval_score,
         last_eval_at
       `,
       )
       .eq('agent_name', agentName)
-      .eq('is_current', true)
+      .eq('stage', 'PRD')
       .single();
 
     if (error) throw error;

--- a/services/agent-api/src/scripts/validate-agent-registry.js
+++ b/services/agent-api/src/scripts/validate-agent-registry.js
@@ -97,9 +97,9 @@ async function main() {
 
   const { data: rows, error } = await supabase
     .from('prompt_version')
-    .select('agent_name, version, is_current')
+    .select('agent_name, version, stage')
     .in('agent_name', requiredAgentNames)
-    .eq('is_current', true);
+    .eq('stage', 'PRD');
 
   if (error) {
     console.error(`CRITICAL: Failed to query prompt_version: ${error.message}`);

--- a/supabase/migrations/20251219232000_remove_is_current_use_stage_prd.sql
+++ b/supabase/migrations/20251219232000_remove_is_current_use_stage_prd.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- Migration: Remove is_current column, use stage='PRD' as single source of truth
+-- ============================================================================
+-- Root cause: is_current and stage can be out of sync, causing confusion
+-- Solution: stage='PRD' means the version is active/live/current
+-- The unique constraint idx_prompt_version_unique_prd ensures only one PRD per agent
+-- ============================================================================
+
+-- 1. For each agent where is_current=true but stage != 'PRD':
+--    - First retire the old PRD version
+--    - Then promote the is_current version to PRD
+--    Must be done in this order to avoid unique constraint violation
+
+-- Step 1a: Retire all PRD versions where a different version has is_current=true
+UPDATE prompt_version
+SET stage = 'RET', retired_at = NOW()
+WHERE stage = 'PRD'
+  AND agent_name IN (
+    SELECT agent_name 
+    FROM prompt_version 
+    WHERE is_current = true AND stage != 'PRD'
+  );
+
+-- Step 1b: Now promote is_current versions to PRD (safe now that old PRDs are retired)
+UPDATE prompt_version
+SET stage = 'PRD', deployed_at = NOW()
+WHERE is_current = true AND stage != 'PRD';
+
+-- 2. Ensure all stage='PRD' versions have is_current=true (for safety during transition)
+UPDATE prompt_version
+SET is_current = true
+WHERE stage = 'PRD' AND is_current = false;
+
+-- 3. Drop the unique index on is_current (no longer needed)
+DROP INDEX IF EXISTS prompt_version_one_current_per_agent;
+
+-- 4. Recreate v_prompt_eval_status view without is_current column
+DROP VIEW IF EXISTS v_prompt_eval_status;
+
+CREATE OR REPLACE VIEW v_prompt_eval_status
+WITH (security_invoker = true) AS
+SELECT 
+  pv.id,
+  pv.agent_name,
+  pv.version,
+  pv.stage,
+  pv.last_eval_status,
+  pv.last_eval_score,
+  pv.last_eval_at,
+  er.eval_type,
+  er.passed,
+  er.failed,
+  er.total_examples,
+  er.baseline_score,
+  er.score_delta,
+  er.regression_detected
+FROM prompt_version pv
+LEFT JOIN eval_run er ON er.id = pv.last_eval_run_id;
+
+COMMENT ON VIEW v_prompt_eval_status IS 'Prompt versions with their latest eval status (stage=PRD means active/live)';
+
+-- 5. Drop the is_current column
+ALTER TABLE prompt_version DROP COLUMN is_current;
+
+-- 6. Add comment to clarify new behavior
+COMMENT ON COLUMN prompt_version.stage IS 'Deployment stage: DEV (draft), TST (testing), PRD (active/live), RET (retired). Only one PRD version per agent (enforced by idx_prompt_version_unique_prd).';


### PR DESCRIPTION
## Problem
The UI showed confusing labels: v2.5 displayed as "Current" (DEV stage) while v2.4 showed as "Live" (PRD stage). This was caused by `is_current` and `stage` columns being out of sync, creating two sources of truth for which prompt version is active.

## Root Cause
The `prompt_version` table had both `is_current` (boolean) and `stage` (DEV/TST/PRD/RET) columns tracking similar concepts. These could diverge, causing confusion about which version agents actually use at runtime.

## Solution
1. **Removed `is_current` column** - Use `stage = 'PRD'` as single source of truth
2. **Updated all backend code** - Agents query `stage = 'PRD'` instead of `is_current = true`
3. **Refactored admin UI** - Replaced all `is_current` checks with `stage === 'PRD'`
4. **Removed "Current" badges** - Only show stage badges (Draft/Test/Live/Retired)
5. **Migration handles data sync** - Retires old PRD, promotes `is_current` versions to PRD before dropping column
6. **Updated view** - Recreated `v_prompt_eval_status` without `is_current` dependency

## Changes
**Backend (9 files):**
- `services/agent-api/src/lib/runner.js` - Query stage=PRD for active prompt
- `services/agent-api/src/lib/discovery-config.js` - Use stage=PRD
- `services/agent-api/src/lib/evals.js` - Use stage=PRD (2 occurrences)
- `services/agent-api/src/lib/prompt-eval.js` - Use stage=PRD
- `services/agent-api/src/routes/agents.js` - Select stage instead of is_current
- `services/agent-api/src/scripts/validate-agent-registry.js` - Use stage=PRD
- `scripts/check-prompt-coverage.js` - Use stage=PRD

**Admin UI (11 files):**
- `admin-next/src/app/(dashboard)/prompts/page.tsx` - Filter by stage=PRD
- `admin-next/src/app/(dashboard)/prompts/[agent]/page.tsx` - Remove Current badges, use stage=PRD
- `admin-next/src/app/(dashboard)/prompts/components/AgentTable.tsx` - Use stage=PRD
- `admin-next/src/app/(dashboard)/prompts/components/AgentDetail.tsx` - Remove Current badge
- `admin-next/src/app/(dashboard)/prompts/components/ViewVersionModal.tsx` - Show stage badge
- `admin-next/src/app/(dashboard)/prompts/components/PromptEditModal.tsx` - Remove is_current field
- `admin-next/src/app/(dashboard)/prompts/hooks/usePrompts.ts` - Stage-based rollback
- `admin-next/src/app/(dashboard)/review/[id]/data-loaders.ts` - Use stage=PRD
- `admin-next/src/app/(dashboard)/evals/llm-judge/page.tsx` - Use stage=PRD
- `admin-next/src/app/(dashboard)/evals/head-to-head/page.tsx` - Use stage=PRD
- `packages/types/src/prompt.ts` - Remove is_current from type

**Database:**
- `supabase/migrations/20251219232000_remove_is_current_use_stage_prd.sql` - Migration to drop column

## Impact
- **Clearer semantics**: PRD = Active/Live version (single source of truth)
- **No more confusion**: Stage badges clearly show deployment status
- **Simpler logic**: No need to keep is_current and stage in sync
- **Better UX**: Users see "Live" badge for active versions, not ambiguous "Current"

Closes https://linear.app/knowledge-base/issue/KB-XXX
