### PR TITLE
fix: Update ab-tests components to use stage=PRD instead of is_current

### DIFF
--- a/admin-next/src/app/(dashboard)/evals/ab-tests/create-test-modal.tsx
+++ b/admin-next/src/app/(dashboard)/evals/ab-tests/create-test-modal.tsx
@@ -23,7 +23,7 @@ export function CreateTestModal({ agents, prompts, onClose, onCreated }: CreateT
   const supabase = createClient();
 
   const agentPrompts = prompts.filter((p) => p.agent_name === agentName);
-  const currentPrompt = agentPrompts.find((p) => p.is_current);
+  const currentPrompt = agentPrompts.find((p) => p.stage === 'PRD');
 
   useEffect(() => {
     if (currentPrompt) {
@@ -113,7 +113,7 @@ export function CreateTestModal({ agents, prompts, onClose, onCreated }: CreateT
                 <option value="">Select version</option>
                 {agentPrompts.map((p) => (
                   <option key={p.version} value={p.version}>
-                    {p.version} {p.is_current ? '(current)' : ''}
+                    {p.version} {p.stage === 'PRD' ? '(live)' : ''}
                   </option>
                 ))}
               </select>
@@ -130,7 +130,7 @@ export function CreateTestModal({ agents, prompts, onClose, onCreated }: CreateT
                 <option value="">Select version</option>
                 {agentPrompts.map((p) => (
                   <option key={p.version} value={p.version}>
-                    {p.version} {p.is_current ? '(current)' : ''}
+                    {p.version} {p.stage === 'PRD' ? '(live)' : ''}
                   </option>
                 ))}
               </select>

--- a/admin-next/src/app/(dashboard)/evals/ab-tests/test-detail-modal.tsx
+++ b/admin-next/src/app/(dashboard)/evals/ab-tests/test-detail-modal.tsx
@@ -43,14 +43,17 @@ export function TestDetailModal({ test, onClose, onUpdate }: TestDetailModalProp
 
     const winnerVersion = winner === 'a' ? test.variant_a_version : test.variant_b_version;
 
+    // Retire current PRD version
     await supabase
       .from('prompt_version')
-      .update({ is_current: false })
-      .eq('agent_name', test.agent_name);
+      .update({ stage: 'RET', retired_at: new Date().toISOString() })
+      .eq('agent_name', test.agent_name)
+      .eq('stage', 'PRD');
 
+    // Promote winner to PRD
     const { error } = await supabase
       .from('prompt_version')
-      .update({ is_current: true })
+      .update({ stage: 'PRD', deployed_at: new Date().toISOString() })
       .eq('agent_name', test.agent_name)
       .eq('version', winnerVersion);
 


### PR DESCRIPTION
## Problem
The Vercel build failed after PR #372 was merged because two ab-tests components still referenced the removed `is_current` property.

## Root Cause
The ab-tests components were missed in the initial refactor that removed `is_current` column. These files were updated after PR #372 was already merged.

## Solution
Updated both ab-tests components to use `stage === 'PRD'` instead of `is_current`:
- Replace `is_current` checks with `stage === 'PRD'`
- Update winner promotion logic to use stage-based approach (retire old PRD, promote winner to PRD)

## Files Changed
- `admin-next/src/app/(dashboard)/evals/ab-tests/create-test-modal.tsx` - Use stage=PRD for current prompt detection
- `admin-next/src/app/(dashboard)/evals/ab-tests/test-detail-modal.tsx` - Stage-based winner promotion

## Testing
Build should now pass without TypeScript errors.

Fixes the build failure from PR #372.