### PR TITLE
fix: Filter out null values in tagger validation

### DIFF
--- a/services/agent-api/src/agents/tagger.js
+++ b/services/agent-api/src/agents/tagger.js
@@ -96,8 +96,15 @@ const TaggingSchema = z.object({
 function validateCodes(taggedItems, validSet, categoryName) {
   if (!taggedItems || !Array.isArray(taggedItems)) return [];
 
+  // Filter out null/undefined values first
+  const nonNullItems = taggedItems.filter((item) => item != null);
+  if (nonNullItems.length === 0) {
+    console.warn(`   ⚠️ All ${categoryName} codes were null/undefined`);
+    return [];
+  }
+
   const validated = [];
-  for (const item of taggedItems) {
+  for (const item of nonNullItems) {
     const code = typeof item === 'string' ? item : item.code;
     if (validSet.has(code)) {
       validated.push(item);


### PR DESCRIPTION
## Problem
Tagger outputs [null] for topic_codes on all articles, even though LLM reasoning correctly identifies topics.

## Root Cause
LLM returns [null] (array containing null) instead of valid topic objects. validateCodes processes this but doesn't filter out null values, so [null] gets stored in the database.

## Solution
Added null/undefined filtering in validateCodes before processing:
- Filters out null/undefined items first
- Logs warning if all codes are null
- Returns empty array instead of [null]

## Files Changed
- services/agent-api/src/agents/tagger.js - Add null filtering to validateCodes

## Testing
After deployment:
1. Re-tag an article
2. Check logs for "All codes were null/undefined" warning
3. Verify topic_codes is [] instead of [null]
4. Check debug logs to see what LLM actually returns

## Related
- Builds on PR #376 (debug logging)
- Still need to investigate why LLM outputs [null] instead of valid topics