### PR TITLE
debug: Add validation logging to diagnose topic_codes filtering

### DIFF
--- a/services/agent-api/src/agents/tagger.js
+++ b/services/agent-api/src/agents/tagger.js
@@ -290,10 +290,17 @@ URL: ${url}`;
       );
       const exclusiveIndustries = enforceIndustryMutualExclusivity(validatedIndustries);
 
+      // Debug topic validation
+      const rawTopics = result.topic_codes;
+      const validatedTopics = conditionalValidate(rawTopics, validCodes.topics, 'topic', 'topic');
+      console.log('🔍 [tagger] Before validation:', JSON.stringify(rawTopics));
+      console.log('🔍 [tagger] After validation:', JSON.stringify(validatedTopics));
+      console.log('🔍 [tagger] validCodes.topics size:', validCodes.topics?.size || 0);
+
       const validatedResult = {
         ...result,
         industry_codes: exclusiveIndustries,
-        topic_codes: conditionalValidate(result.topic_codes, validCodes.topics, 'topic', 'topic'),
+        topic_codes: validatedTopics,
         geography_codes: conditionalValidate(
           result.geography_codes,
           validCodes.geographies,


### PR DESCRIPTION
## Problem
LLM outputs valid topics but database stores [null]. No rejection warnings are logged.

## Investigation
- LLM outputs: `[{"code":"technology","confidence":0.9},{"code":"methods","confidence":0.85},{"code":"agentic","confidence":0.8}]`
- Database stores: `[null]`
- No warnings logged about invalid codes or null filtering
- This means validateCodes is silently returning empty array

## Debug Logging Added
1. Log topic_codes before validation
2. Log topic_codes after validation  
3. Log validCodes.topics size to see what valid codes are loaded

## Expected Output
After deployment, logs will show:
```
🔍 [tagger] Before validation: [{"code":"technology",...}]
🔍 [tagger] After validation: []
🔍 [tagger] validCodes.topics size: 0
```

This will confirm if validCodes.topics is empty (not loading from database) or if codes don't match.

## Files Changed
- `services/agent-api/src/agents/tagger.js` - Add debug logging around topic validation

## Next Steps
1. Deploy this PR
2. Re-tag article to see debug output
3. Fix validation based on findings (likely taxonomy loading issue)