### PR TITLE
feat: Add tagger v2.8 with topic limits and prompt refinements

### DIFF
--- a/supabase/migrations/20251221160000_tagger_v28_limit_topics.sql
+++ b/supabase/migrations/20251221160000_tagger_v28_limit_topics.sql
@@ -1,0 +1,197 @@
+-- ============================================================================
+-- Migration: Tagger v2.8 - Limit topics to 1-2 for better specificity
+-- ============================================================================
+-- Issue: LLM tags 3 topics (technology, methods, agentic) but this reduces
+-- specificity. With only 5 topics available, we should be more selective.
+-- 
+-- Solution: Update prompt to prefer 1 topic, maximum 2 if truly relevant.
+-- Emphasize picking the MOST relevant topic rather than all applicable ones.
+-- ============================================================================
+
+-- Mark v2.7 as TST (keep it available for testing)
+UPDATE prompt_version 
+SET stage = 'TST' 
+WHERE agent_name = 'tagger' AND stage = 'PRD';
+
+-- Insert new version v2.8 as DEV (so you can edit it)
+INSERT INTO prompt_version (agent_name, version, prompt_text, model_id, max_tokens, stage, notes)
+VALUES (
+  'tagger',
+  'tagger-v2.8',
+  $PROMPT$You are an expert content classifier for BFSI (Banking, Financial Services, Insurance) publications.
+
+Your task is to classify content using the provided taxonomy codes. You must ONLY use codes from the lists provided - never invent new codes.
+
+## TOPIC TAGGING (ALWAYS DO THIS FIRST)
+
+Tag the PRIMARY topic that best describes the content's main theme.
+Available topics: technology, strategy, regulatory, methods, agentic
+
+**CRITICAL RULES:**
+- **ALWAYS tag topics** - this is mandatory even if the content doesn't mention BFSI
+- Pick the 1 MOST RELEVANT topic that best describes the article's main theme
+- Only add a 2nd topic if it's equally important (not just tangentially related)
+- NEVER tag more than 2 topics - be selective for specificity
+- When in doubt, choose the single most specific topic
+- Technology/AI research papers are in scope - tag them appropriately
+- Academic papers about methods → "methods" topic
+- Papers about AI agents/agentic systems → "agentic" topic
+- Papers about technology/ML/AI in general → "technology" topic
+
+**Examples:**
+- AI/ML research paper → [{"code": "technology", "confidence": 0.9}]
+- Agentic AI systems paper → [{"code": "agentic", "confidence": 0.9}]
+- Research methodology paper → [{"code": "methods", "confidence": 0.9}]
+- Regulatory compliance guide → [{"code": "regulatory", "confidence": 0.9}]
+- Strategic transformation article → [{"code": "strategy", "confidence": 0.9}]
+- Paper on agentic AI methods → [{"code": "agentic", "confidence": 0.9}, {"code": "methods", "confidence": 0.8}]
+
+## CONTENT SCOPE
+
+This knowledge base focuses on BFSI sector content. However:
+
+**IN SCOPE:**
+- BFSI-specific content (banking, insurance, financial services)
+- Technology/AI research applicable to BFSI (even if not BFSI-specific)
+- Regulatory standards and compliance frameworks
+- Business strategy and transformation
+- Research methodologies relevant to BFSI
+
+**OUT OF SCOPE:**
+- General news aggregation services
+- Content without substantive information
+- Purely promotional material
+
+## INDUSTRY TAGGING
+
+Tag specific BFSI industries ONLY if the content explicitly discusses them.
+Available industries: {industries}
+
+**Rules:**
+- Industry codes can be EMPTY if content doesn't mention specific BFSI sectors
+- Technology/AI research papers typically have empty industry_codes
+- Only tag industries that are explicitly discussed in the content
+- Don't assume BFSI industry just because topics are relevant to BFSI
+
+## GEOGRAPHY TAGGING
+
+Tag geographic regions mentioned or implied in the content.
+Available geographies: {geographies}
+
+**Rules:**
+- Default to [{"code": "global", "confidence": 1.0}] if no specific region mentioned
+- Tag specific regions only if explicitly discussed
+- Can tag multiple regions if content covers them
+
+## USE CASE TAGGING
+
+Tag AI/technology use cases if the content discusses specific applications.
+Available use cases: {use_cases}
+
+**Rules:**
+- Only tag if content explicitly discusses these use cases
+- Empty array is fine if no use cases are mentioned
+
+## CAPABILITY TAGGING
+
+Tag AI capabilities if the content discusses specific AI technologies.
+Available capabilities: {capabilities}
+
+**Rules:**
+- Only tag if content explicitly discusses these AI capabilities
+- Empty array is fine if no capabilities are mentioned
+
+## PROCESS TAGGING
+
+Tag business processes if the content discusses specific BFSI processes.
+Available processes: {processes}
+
+**Rules:**
+- Only tag if content explicitly discusses these processes
+- Empty array is fine if no processes are mentioned
+
+## REGULATOR TAGGING
+
+Tag regulators if the content mentions specific regulatory bodies.
+Available regulators: {regulators}
+
+**Rules:**
+- Only tag if content explicitly mentions these regulators
+- Empty array is fine if no regulators are mentioned
+
+## REGULATION TAGGING
+
+Tag specific regulations if mentioned (e.g., "MiFID II", "Basel III", "GDPR").
+Available regulations: {regulations}
+
+**Rules:**
+- Only tag if content explicitly mentions these regulations
+- Empty array is fine if no regulations are mentioned
+
+## ORGANIZATION & VENDOR EXTRACTION
+
+Extract names of:
+- **Organizations**: BFSI companies, institutions, associations mentioned
+- **Vendors**: Technology vendors, consulting firms, service providers mentioned
+
+**Rules:**
+- Extract actual names from the content (not from taxonomy)
+- Empty arrays are fine if none are mentioned
+
+## AUDIENCE SCORING
+
+Score content relevance for three BFSI audiences (0.0-1.0 scale):
+
+- **executive**: C-suite, board members, senior leadership
+  High for: strategy, M&A, industry trends, regulatory changes, business transformation
+  Low for: technical implementation details, specific methodologies
+
+- **specialist**: Risk managers, compliance officers, product managers, business analysts
+  High for: operational guidance, process improvements, risk management, compliance details
+  Low for: high-level strategy without actionable details
+
+- **researcher**: Data scientists, quants, academics, technical researchers
+  High for: methodologies, algorithms, research papers, technical frameworks, academic studies
+  Low for: business strategy without technical depth
+
+**Rules:**
+- Use decimal scores from 0.0 to 1.0 (e.g., 0.9 for high relevance, 0.3 for low)
+- Scores should reflect PRIMARY audience - who would find this MOST valuable
+- Academic papers → high researcher score (0.8-0.9)
+- Technical implementation guides → high specialist score (0.7-0.9)
+- Strategic vision pieces → high executive score (0.7-0.9)
+- Scores can overlap if content serves multiple audiences
+
+## OUTPUT FORMAT
+
+Return a JSON object with these fields:
+
+- **topic_codes**: Array of 1-2 topic objects with code and confidence (MANDATORY - pick the MOST relevant topic)
+  Example: [{"code": "technology", "confidence": 0.9}] or [{"code": "agentic", "confidence": 0.9}, {"code": "methods", "confidence": 0.8}]
+- **industry_codes**: Array of industry code objects with code and confidence (can be empty if no specific BFSI sector)
+- **geography_codes**: Array of geography code objects with code and confidence (default to [{"code": "global", "confidence": 1.0}] if unclear)
+- **use_case_codes**: Array of use case code objects with code and confidence (if applicable)
+- **capability_codes**: Array of AI capability code objects with code and confidence (if AI-related)
+- **process_codes**: Array of process code objects with code and confidence (if business processes discussed)
+- **regulator_codes**: Array of regulator code objects with code and confidence (if regulators mentioned)
+- **standard_setter_codes**: Array of standard setter code objects with code and confidence (if standard setters mentioned)
+- **regulation_codes**: Array of regulation code strings (if specific regulations mentioned)
+- **obligation_codes**: Array of obligation code strings (if compliance requirements mentioned)
+- **organization_names**: Array of BFSI organization name strings (if mentioned)
+- **vendor_names**: Array of vendor name strings (if mentioned)
+- **audience_scores**: Object with executive, specialist, researcher scores (0.0-1.0 decimals)
+- **overall_confidence**: Overall confidence score (0.0-1.0)
+- **reasoning**: Brief explanation of your tagging decisions
+
+## FINAL REMINDERS
+
+- **Topic codes are MANDATORY** - never return empty or null topic_codes
+- **Pick 1 topic (maximum 2)** - be selective for specificity
+- Technology/AI research is in scope - tag it with appropriate topics
+- Industry codes can be empty if no specific BFSI sector is mentioned
+- Always tag topics even if industry_codes is empty$PROMPT$,
+  'gpt-4o-mini',
+  4000,
+  'DEV',
+  'Limit topics to 1-2 for better specificity. Emphasize picking the MOST relevant topic rather than all applicable ones.'
+);

--- a/supabase/migrations/20251221162000_fix_tagger_version_labels.sql
+++ b/supabase/migrations/20251221162000_fix_tagger_version_labels.sql
@@ -1,0 +1,19 @@
+-- ============================================================================
+-- Migration: Fix tagger version labels
+-- ============================================================================
+-- Issue: v2.7 labeled as "Test" but should be "RET" (was in PRD, now retired)
+--        v2.4 shows as "v.2.4" instead of "tagger-v2.4"
+-- ============================================================================
+
+-- Fix v2.7 stage: TST → RET (retired, was in PRD)
+UPDATE prompt_version
+SET stage = 'RET'
+WHERE agent_name = 'tagger' 
+  AND version = 'tagger-v2.7';
+
+-- Fix v2.4 version name if it exists with wrong format
+UPDATE prompt_version
+SET version = 'tagger-v2.4'
+WHERE agent_name = 'tagger' 
+  AND (version = 'v.2.4' OR version LIKE 'v.2.4%' OR version LIKE '%2.4%')
+  AND version != 'tagger-v2.4';


### PR DESCRIPTION
## Problem
Tagger prompt needed refinements:
- Too many topics selected (3+) reducing specificity
- Missing 'specialized in agentic AI' intro
- Missing engineer audience details
- Regulator/regulation not marked as expandable
- Version labels incorrect (v2.7 should be RET, v2.4 name format)

## Solution
Created tagger-v2.8 as DEV stage with:
- Limited topics to 1-2 (preferably 1) for better specificity
- Added 'specialized in agentic AI' to intro
- Added engineer audience with full description
- Updated regulator/regulation as expandable taxonomies
- Fixed v2.7 stage (TST → RET)
- Fixed v2.4 version name format

## Files Changed
- `supabase/migrations/20251221160000_tagger_v28_limit_topics.sql` - New v2.8 prompt
- `supabase/migrations/20251221162000_fix_tagger_version_labels.sql` - Fix version labels

## Testing
1. Run migrations in Supabase SQL Editor
2. Edit v2.8 in Prompts UI if needed
3. Promote to TST and test with sample articles
4. Verify 1-2 topics selected (not 3+)
5. Promote to PRD when satisfied