### PR TITLE
fix: Sort versions alphabetically descending in agent detail page

### DIFF
--- a/admin-next/src/app/(dashboard)/prompts/[agent]/page.tsx
+++ b/admin-next/src/app/(dashboard)/prompts/[agent]/page.tsx
@@ -33,9 +33,9 @@ export default function AgentDetailPage() {
     if (error) {
       console.error('Error loading prompts:', error);
     } else {
-      // Sort: most recent first (by created_at)
+      // Sort by version descending (alphabetical)
       const sorted = (data || []).sort((a, b) => {
-        return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+        return b.version.localeCompare(a.version);
       });
       setPrompts(sorted);
       const current = sorted.find((p) => p.stage === 'PRD');


### PR DESCRIPTION
## Problem
Agent detail page was sorting versions by created_at instead of version name, causing incorrect ordering (v2.4 before v2.8).

## Solution
Changed sorting from created_at to version using localeCompare for alphabetical descending order.

## Files Changed
- `admin-next/src/app/(dashboard)/prompts/[agent]/page.tsx` - Changed sort from created_at to version

## Testing
After deployment, versions will display in correct order: tagger-v2.8, tagger-v2.7, tagger-v2.6, etc.