### PR TITLE
fix: Remove UPDATE that tries to retire v2.8 in PRD

### DIFF
--- a/supabase/migrations/20251221171000_tagger_v29_replace_methods_with_risk.sql
+++ b/supabase/migrations/20251221171000_tagger_v29_replace_methods_with_risk.sql
@@ -5,11 +5,8 @@
 -- Solution: Update tagger prompt to use 'risk' instead of 'methods'
 -- ============================================================================
 
--- Mark v2.8 as not current
-UPDATE prompt_version 
-SET stage = 'RET'
-WHERE agent_name = 'tagger' AND version = 'tagger-v2.8';
-
+-- v2.8 is in PRD, so v2.9 will be created in DEV for testing
+-- User will promote v2.9 to TST/PRD when ready, which will retire v2.8
 -- Insert new version v2.9 with 'risk' instead of 'methods'
 INSERT INTO prompt_version (agent_name, version, prompt_text, model_id, max_tokens, stage, notes)
 VALUES (


### PR DESCRIPTION
## Problem
The v2.9 migration (20251221171000) tried to UPDATE v2.8 from PRD to RET stage, which fails because v2.8 is currently in production. This prevented the INSERT statement from creating v2.9.

## Root Cause
Migration included an UPDATE statement that tried to retire v2.8 before creating v2.9, but v2.8 is in PRD stage and should not be retired until v2.9 is promoted to PRD.

## Solution
Removed the UPDATE statement. v2.9 will now be created in DEV stage without touching v2.8. When user promotes v2.9 to PRD, the promotion process will automatically retire v2.8.

## Files Changed
- `supabase/migrations/20251221171000_tagger_v29_replace_methods_with_risk.sql` - Removed UPDATE statement

## Testing
1. Run the corrected migration in Supabase SQL Editor
2. Verify v2.9 appears in Prompts UI in DEV stage
3. Verify v2.8 remains in PRD stage
4. Edit v2.9 if needed
5. Promote to TST and test with sample articles