### PR TITLE
fix: Use correct field name for published date in card view

### DIFF
--- a/admin-next/src/app/(dashboard)/review/card-view.tsx
+++ b/admin-next/src/app/(dashboard)/review/card-view.tsx
@@ -66,7 +66,7 @@ function ItemCard({
         {/* Meta - matches live site format */}
         <div className="mt-1 text-sm text-neutral-200">
           <span className="text-neutral-400">Published</span>{' '}
-          {formatDate(payload.date_published) || 'Unknown'}
+          {formatDate(payload.published_at as string) || 'Unknown'}
           {payload.source_name && <span> · {payload.source_name}</span>}
         </div>
 


### PR DESCRIPTION
## Problem
Card view shows 'Published Unknown' for all articles, but detail pages show the correct published date.

## Root Cause
Card view was using  but the correct field name is  (as used in the detail page).

## Solution
Changed card view to use  to match the detail page implementation.

## Files Changed
- `admin-next/src/app/(dashboard)/review/card-view.tsx` - Fixed field name from date_published to published_at

## Testing
1. Deploy and check card view - published dates should now display correctly
2. Verify both card view and detail page show the same dates