### PR TITLE
fix: PDF extraction and thumbnailer improvements

### DIFF
--- a/services/agent-api/src/agents/thumbnailer.js
+++ b/services/agent-api/src/agents/thumbnailer.js
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { AgentRunner } from '../lib/runner.js';
 import { chromium } from 'playwright';
+import { isPdfUrl } from '../lib/pdf-extractor.js';
 
 const runner = new AgentRunner('thumbnailer');
 
@@ -155,7 +156,7 @@ export async function runThumbnailer(queueItem) {
       }
 
       // PDFs - download, store, and render first page as thumbnail
-      if (lowerUrl.endsWith('.pdf') || lowerUrl.includes('.pdf?')) {
+      if (isPdfUrl(targetUrl)) {
         console.log(`   📄 Processing PDF: ${targetUrl}`);
         return await processPdf(
           targetUrl,


### PR DESCRIPTION
## Problem
PDF extraction and summarization integration had issues with thumbnailer not detecting arXiv PDF URLs.

## Root Cause
Thumbnailer used simple string check ( extension) instead of the comprehensive  function used by content fetcher.

## Solution
- Import  from  into thumbnailer
- Replace simple string check with  function
- Ensures consistent PDF detection across codebase (arXiv, query params, etc.)

## Files Changed
- `services/agent-api/src/agents/thumbnailer.js` - Use isPdfUrl for PDF detection

## Testing
- ✅ PDF extraction verified (175K chars, 67 pages)
- ✅ Summary quality excellent (includes full PDF details)
- ⏳ Thumbnailer fix deployed, ready to test

## Related
Part of PDF summarization verification testing.