### PR TITLE
fix: Address SonarQube code quality issues

### DIFF
--- a/services/agent-api/src/agents/tagger.js
+++ b/services/agent-api/src/agents/tagger.js
@@ -225,7 +225,7 @@ export async function runTagger(queueItem, options = {}) {
       let systemPrompt = promptTemplate;
       for (const [key, value] of Object.entries(contextData)) {
         const placeholder = `{{${key}}}`;
-        systemPrompt = systemPrompt.replace(new RegExp(placeholder, 'g'), value || '');
+        systemPrompt = systemPrompt.replaceAll(placeholder, value || '');
       }
 
       // User content is just the article data

--- a/services/agent-api/src/lib/pdf-extractor.js
+++ b/services/agent-api/src/lib/pdf-extractor.js
@@ -10,7 +10,6 @@ import { createClient } from '@supabase/supabase-js';
 import process from 'node:process';
 import crypto from 'node:crypto';
 import { Buffer } from 'node:buffer';
-import { isPdfUrl as isPdfUrlUtil } from './url-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -36,7 +35,7 @@ const FETCH_HEADERS = {
  * Check if URL points to a PDF file
  * Re-exported from url-utils for backward compatibility
  */
-export { isPdfUrlUtil as isPdfUrl };
+export { isPdfUrl } from './url-utils.js';
 
 /**
  * Download PDF and return as Buffer

--- a/services/agent-api/src/routes/agents.js
+++ b/services/agent-api/src/routes/agents.js
@@ -231,7 +231,7 @@ router.post('/run/thumbnail', async (req, res) => {
             thumbnail: result.publicUrl,
             thumbnail_generated_at: new Date().toISOString(),
             enrichment_meta: {
-              ...(updatedItem?.payload?.enrichment_meta || {}),
+              ...updatedItem?.payload?.enrichment_meta,
               thumbnail: {
                 agent_type: 'utility',
                 implementation_version: getUtilityVersion('thumbnail-generator'),


### PR DESCRIPTION
Fixes 3 SonarQube code smell issues:

1. tagger.js: Use replaceAll() instead of replace() with regex
2. pdf-extractor.js: Use export...from syntax for isPdfUrl
3. agents.js: Remove unnecessary empty object in spread operator

All changes are minor code improvements with no functional changes.