### PR TITLE
fix: standardize entity tables with slug and uuid

### DIFF
--- a/check-audiences.sql
+++ b/check-audiences.sql
@@ -1,0 +1,4 @@
+-- Check what audiences are defined in kb_audience table
+SELECT code, name, description, scoring_guide
+FROM kb_audience
+ORDER BY code;

--- a/check-geographies.sql
+++ b/check-geographies.sql
@@ -1,0 +1,4 @@
+-- Check geography taxonomy codes
+SELECT code, name, parent_code, level
+FROM kb_geography
+ORDER BY level, parent_code NULLS FIRST, code;

--- a/check-status-300.sql
+++ b/check-status-300.sql
@@ -1,0 +1,29 @@
+-- Check all items in status 300 and their tag status
+SELECT 
+  id,
+  url,
+  payload->>'title' as title,
+  payload->>'source_name' as source_name,
+  payload->>'source' as source,
+  payload->>'source_slug' as source_slug,
+  CASE 
+    WHEN payload->'audience_scores' IS NOT NULL AND (payload->'audience_scores')::text != '{}' THEN 'YES'
+    ELSE 'NO'
+  END as has_audiences,
+  CASE 
+    WHEN payload->'geography_codes' IS NOT NULL AND jsonb_array_length(payload->'geography_codes') > 0 THEN 'YES'
+    ELSE 'NO'
+  END as has_geographies,
+  CASE 
+    WHEN payload->'industry_codes' IS NOT NULL AND jsonb_array_length(payload->'industry_codes') > 0 THEN 'YES'
+    ELSE 'NO'
+  END as has_industries,
+  CASE 
+    WHEN payload->'topic_codes' IS NOT NULL AND jsonb_array_length(payload->'topic_codes') > 0 THEN 'YES'
+    ELSE 'NO'
+  END as has_topics,
+  status_code
+FROM ingestion_queue
+WHERE status_code = 300
+ORDER BY discovered_at DESC
+LIMIT 10;

--- a/check-tagger-version.sql
+++ b/check-tagger-version.sql
@@ -1,0 +1,6 @@
+-- Check which tagger prompt version is currently active
+SELECT agent_name, version, notes, created_at
+FROM prompt_version
+WHERE agent_name = 'tagger'
+ORDER BY created_at DESC
+LIMIT 5;

--- a/fix-missing-tags.sql
+++ b/fix-missing-tags.sql
@@ -1,0 +1,24 @@
+-- Move items in status 300 (pending_review) that are missing tags back to status 220 (to_tag)
+-- This will trigger the tagging step in the enrichment pipeline
+
+UPDATE ingestion_queue
+SET status_code = 220
+WHERE status_code = 300
+  AND (
+    -- Check if any taxonomy fields are missing or empty
+    (payload->'audience_scores' IS NULL OR jsonb_typeof(payload->'audience_scores') = 'null' OR (payload->'audience_scores')::text = '{}')
+    AND (payload->'geography_codes' IS NULL OR jsonb_typeof(payload->'geography_codes') = 'null' OR jsonb_array_length(payload->'geography_codes') = 0)
+    AND (payload->'industry_codes' IS NULL OR jsonb_typeof(payload->'industry_codes') = 'null' OR jsonb_array_length(payload->'industry_codes') = 0)
+    AND (payload->'topic_codes' IS NULL OR jsonb_typeof(payload->'topic_codes') = 'null' OR jsonb_array_length(payload->'topic_codes') = 0)
+  );
+
+-- Show the affected items
+SELECT id, url, payload->>'title' as title, status_code
+FROM ingestion_queue
+WHERE status_code = 220
+  AND (
+    (payload->'audience_scores' IS NULL OR jsonb_typeof(payload->'audience_scores') = 'null' OR (payload->'audience_scores')::text = '{}')
+    AND (payload->'geography_codes' IS NULL OR jsonb_typeof(payload->'geography_codes') = 'null' OR jsonb_array_length(payload->'geography_codes') = 0)
+    AND (payload->'industry_codes' IS NULL OR jsonb_typeof(payload->'industry_codes') = 'null' OR jsonb_array_length(payload->'industry_codes') = 0)
+    AND (payload->'topic_codes' IS NULL OR jsonb_typeof(payload->'topic_codes') = 'null' OR jsonb_array_length(payload->'topic_codes') = 0)
+  );

--- a/retag-items.sql
+++ b/retag-items.sql
@@ -1,0 +1,19 @@
+-- Move the 3 items in status 300 back to status 220 (to_tag) for re-enrichment
+-- This will trigger the tagger to run with the new dynamic audience schema
+
+UPDATE ingestion_queue
+SET status_code = 220
+WHERE id IN (
+  'df2eab69-f835-488a-9567-90bdfb091cd3',  -- AI Agent Team Automates Development Tasks
+  '3b11a7a1-9ea4-4589-a565-cfdc3469a40d',  -- 9 RAG Architectures Every AI Developer Must Know
+  'e8a8ea11-d789-4cdd-b42a-1946745cb092'   -- Building the 7 Layers of a Production-Grade Agentic AI System
+);
+
+-- Verify the update
+SELECT id, payload->>'title' as title, status_code
+FROM ingestion_queue
+WHERE id IN (
+  'df2eab69-f835-488a-9567-90bdfb091cd3',
+  '3b11a7a1-9ea4-4589-a565-cfdc3469a40d',
+  'e8a8ea11-d789-4cdd-b42a-1946745cb092'
+);


### PR DESCRIPTION
## Problem
When trying to approve a new vendor entity, the system failed with error: **"column 'slug' of relation 'ag_vendor' does not exist"**

## Root Cause
The  RPC function assumed all entity tables have a  column, but:
- ✅  has  (text, unique)
- ✅  has  (text, unique)
- ❌  uses  (no slug)
- ❌  uses  (no slug)

Additionally,  and  used  for their primary keys while other entity tables use .

## Solution
Standardized all entity tables to follow a consistent pattern:
- **id**:  (primary key)
- **slug**:  (unique, stable identifier for lookups/URLs)
- **name**:  (display name)

### Database Changes
1. Added  column to  and 
2. Generated slugs from existing names (lowercase, hyphenated)
3. Renamed  → 
4. Converted  from  → 
5. Converted  from  → 
6. Updated all FK references in  and  tables
7. Updated  RPC to use unified slug pattern

### Frontend Changes
- Updated  to query  consistently across all entity tables

## Benefits
- **Consistency**: All entity tables now follow the same schema pattern
- **Maintainability**: Single code path in RPC functions
- **Stability**: Slugs provide stable identifiers independent of display names
- **Scalability**: UUID primary keys across all tables

## Files Changed
-  - Comprehensive migration
-  - Updated to use slug

## Testing Notes
⚠️ **This migration modifies existing data** - please review carefully before running in production.

The migration uses temporary mapping tables to safely convert bigint IDs to UUIDs while preserving all foreign key relationships.