### PR TITLE
refactor: lazy supabase client init

### DIFF
--- a/services/agent-api/src/lib/state-machine.mermaid.js
+++ b/services/agent-api/src/lib/state-machine.mermaid.js
@@ -1,0 +1,49 @@
+export function buildMermaidDiagram({ statusCodes, normalTransitions, manualTransitions }) {
+  const getStatusName = createGetStatusName(statusCodes);
+  let diagram = 'stateDiagram-v2\n';
+
+  diagram = appendNormalTransitions(diagram, normalTransitions, getStatusName);
+  diagram = appendManualTransitions(diagram, manualTransitions, getStatusName);
+
+  return diagram;
+}
+
+function createGetStatusName(statusCodes) {
+  const keys = Object.keys(statusCodes);
+
+  return (code) => {
+    const name = keys.find((k) => statusCodes[k] === code);
+    return name ? name.toLowerCase() : `status_${code}`;
+  };
+}
+
+function appendNormalTransitions(diagram, normalTransitions, getStatusName) {
+  for (const [from, toStates] of Object.entries(normalTransitions)) {
+    const fromCode = Number.parseInt(from, 10);
+    const fromName = getStatusName(fromCode);
+
+    if (toStates.length === 0) {
+      diagram += `    ${fromName} --> [*]\n`;
+      continue;
+    }
+
+    for (const toCode of toStates) {
+      diagram += `    ${fromName} --> ${getStatusName(toCode)}\n`;
+    }
+  }
+
+  return diagram;
+}
+
+function appendManualTransitions(diagram, manualTransitions, getStatusName) {
+  for (const [from, toStates] of Object.entries(manualTransitions)) {
+    const fromCode = Number.parseInt(from, 10);
+    const fromName = getStatusName(fromCode);
+
+    for (const toCode of toStates) {
+      diagram += `    ${fromName} -.-> ${getStatusName(toCode)} : manual\n`;
+    }
+  }
+
+  return diagram;
+}

--- a/services/agent-api/src/lib/status-codes.js
+++ b/services/agent-api/src/lib/status-codes.js
@@ -6,7 +6,13 @@
 import process from 'node:process';
 import { createClient } from '@supabase/supabase-js';
 
-const supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+let supabaseClient = null;
+
+function getSupabaseClient() {
+  if (supabaseClient) return supabaseClient;
+  supabaseClient = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  return supabaseClient;
+}
 
 // Cached status codes (loaded once at startup)
 let statusCache = null;
@@ -19,6 +25,7 @@ let statusCache = null;
 export async function loadStatusCodes() {
   if (statusCache) return statusCache;
 
+  const supabase = getSupabaseClient();
   const { data, error } = await supabase.from('status_lookup').select('code, name').order('code');
 
   if (error) {


### PR DESCRIPTION
Moves Supabase client creation out of module scope to avoid import-time side effects.

- `services/agent-api/src/lib/status-codes.js`: create client lazily on first use
- `services/agent-api/src/lib/state-machine.js`: create client lazily on first use; Mermaid helpers extracted to keep file under 300 lines

Verification:
- `npm run lint -w services/agent-api`
- `npm run test:coverage -w services/agent-api` (grep proof available for state-machine.js/status-codes.js)
