### PR TITLE
fix: return 404 for missing publication slug

### DIFF
--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -24,12 +24,12 @@ export async function getStaticPaths() {
 // ------------------------------------------------------------
 const { slug } = Astro.params;
 if (!slug) {
-  throw new Error('Missing slug param');
+  return new Response(null, { status: 404 });
 }
 
 const item = await getPublicationBySlug(slug);
 if (!item) {
-  throw new Error(`Publication not found for slug: ${slug}`);
+  return new Response(null, { status: 404 });
 }
 
 const title = item.title;


### PR DESCRIPTION
## Problem\nAstro static build can fail when a publication slug disappears between getStaticPaths() and render, causing a thrown error during prerender and aborting the build.\n\n## Root Cause\n throws when slug is missing or publication lookup returns null, which turns a missing page into a build-stopping exception.\n\n## Solution\nReturn a 404 Response when slug is missing or the publication is not found, so prerender continues and the site builds successfully.\n\n## Files Changed\n-  - return 404 instead of throwing for missing slug/publication\n\nCloses https://linear.app/knowledge-base/issue/KB-151\n