### PR TITLE
fix: raise agent-api new code coverage for Sonar

### DIFF
--- a/services/agent-api/src/lib/queue-update.js
+++ b/services/agent-api/src/lib/queue-update.js
@@ -33,7 +33,7 @@ function getSupabaseClient() {
 export async function transitionItemStatus(queueId, newStatusCode, options = {}) {
   const { changedBy = 'system:auto', changes = null, isManual = false } = options;
 
-  if (!queueId || typeof newStatusCode !== 'number') {
+  if (!queueId || typeof newStatusCode !== 'number' || Number.isNaN(newStatusCode)) {
     throw new Error('transitionItemStatus: queueId and newStatusCode are required');
   }
 

--- a/services/agent-api/tests/lib/queue-update.spec.js
+++ b/services/agent-api/tests/lib/queue-update.spec.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockCreateClient, mockRpc } = vi.hoisted(() => ({
+  mockRpc: vi.fn(),
+  mockCreateClient: vi.fn(() => ({
+    rpc: mockRpc,
+  })),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: mockCreateClient,
+}));
+
+describe('lib/queue-update', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.PUBLIC_SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_KEY;
+
+    mockRpc.mockReset();
+    mockCreateClient.mockClear();
+    vi.resetModules();
+  });
+
+  it('throws if required args are missing', async () => {
+    process.env.PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+    const { transitionItemStatus } = await import('../../src/lib/queue-update.js');
+
+    await expect(transitionItemStatus('', 123)).rejects.toThrow(
+      'queueId and newStatusCode are required',
+    );
+    await expect(transitionItemStatus('id', Number.NaN)).rejects.toThrow(
+      'queueId and newStatusCode are required',
+    );
+  });
+
+  it('throws if Supabase env vars are missing', async () => {
+    const { transitionItemStatus } = await import('../../src/lib/queue-update.js');
+
+    await expect(transitionItemStatus('id', 123)).rejects.toThrow(
+      'Missing Supabase environment variables',
+    );
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('calls transition_status RPC with expected payload', async () => {
+    process.env.PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+    mockRpc.mockResolvedValue({ error: null });
+
+    const { transitionItemStatus } = await import('../../src/lib/queue-update.js');
+
+    await transitionItemStatus('queue-1', 200, {
+      changedBy: 'agent:test',
+      changes: { payload: { hello: 'world' } },
+      isManual: true,
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    expect(mockRpc).toHaveBeenCalledWith('transition_status', {
+      p_queue_id: 'queue-1',
+      p_new_status: 200,
+      p_changed_by: 'agent:test',
+      p_changes: { payload: { hello: 'world' } },
+      p_is_manual: true,
+    });
+  });
+
+  it('wraps RPC errors with queueId and status', async () => {
+    process.env.PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+    mockRpc.mockResolvedValue({ error: { message: 'boom' } });
+
+    const { transitionItemStatus } = await import('../../src/lib/queue-update.js');
+
+    await expect(transitionItemStatus('queue-1', 200)).rejects.toThrow(
+      'transition_status failed for item queue-1 → 200: boom',
+    );
+  });
+
+  it('transitionByAgent infers changedBy from agentName', async () => {
+    process.env.PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+    mockRpc.mockResolvedValue({ error: null });
+
+    const { transitionByAgent } = await import('../../src/lib/queue-update.js');
+
+    await transitionByAgent('queue-1', 200, 'summarizer', { changes: { ok: true } });
+
+    expect(mockRpc).toHaveBeenCalledWith('transition_status', {
+      p_queue_id: 'queue-1',
+      p_new_status: 200,
+      p_changed_by: 'agent:summarizer',
+      p_changes: { ok: true },
+      p_is_manual: false,
+    });
+  });
+
+  it('transitionByUser marks the transition as manual', async () => {
+    process.env.PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+    mockRpc.mockResolvedValue({ error: null });
+
+    const { transitionByUser } = await import('../../src/lib/queue-update.js');
+
+    await transitionByUser('queue-1', 200, 'rick');
+
+    expect(mockRpc).toHaveBeenCalledWith('transition_status', {
+      p_queue_id: 'queue-1',
+      p_new_status: 200,
+      p_changed_by: 'user:rick',
+      p_changes: null,
+      p_is_manual: true,
+    });
+  });
+});

--- a/services/agent-api/tests/lib/random.spec.js
+++ b/services/agent-api/tests/lib/random.spec.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const { mockCryptoRandomInt } = vi.hoisted(() => ({
+  mockCryptoRandomInt: vi.fn(),
+}));
+
+vi.mock('node:crypto', () => ({
+  randomInt: mockCryptoRandomInt,
+}));
+
+import { randomInt } from '../../src/lib/random.js';
+
+describe('lib/random', () => {
+  it('delegates to node:crypto randomInt', () => {
+    mockCryptoRandomInt.mockReturnValue(7);
+
+    const result = randomInt(1, 10);
+
+    expect(result).toBe(7);
+    expect(mockCryptoRandomInt).toHaveBeenCalledWith(1, 10);
+  });
+});

--- a/services/agent-api/tests/lib/supabase.spec.js
+++ b/services/agent-api/tests/lib/supabase.spec.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockCreateClient } = vi.hoisted(() => ({
+  mockCreateClient: vi.fn(() => ({ mocked: true })),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: mockCreateClient,
+}));
+
+import { getSupabase, resetSupabaseForTests } from '../../src/lib/supabase.js';
+
+describe('lib/supabase', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    resetSupabaseForTests();
+    mockCreateClient.mockClear();
+  });
+
+  it('throws if PUBLIC_SUPABASE_URL is missing', () => {
+    delete process.env.PUBLIC_SUPABASE_URL;
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+    expect(() => getSupabase()).toThrow('CRITICAL: Supabase env vars missing');
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('throws if no key is available', () => {
+    process.env.PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    delete process.env.SUPABASE_SERVICE_KEY;
+    delete process.env.PUBLIC_SUPABASE_ANON_KEY;
+
+    expect(() => getSupabase()).toThrow('CRITICAL: Supabase env vars missing');
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('creates and caches a client (prefers service key, falls back to anon)', () => {
+    process.env.PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.PUBLIC_SUPABASE_ANON_KEY = 'anon-key';
+
+    const first = getSupabase();
+    const second = getSupabase();
+
+    expect(first).toBe(second);
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    expect(mockCreateClient).toHaveBeenCalledWith('https://example.supabase.co', 'anon-key');
+  });
+
+  it('resetSupabaseForTests clears cached client', () => {
+    process.env.PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
+
+    const first = getSupabase();
+    resetSupabaseForTests();
+    const second = getSupabase();
+
+    expect(first).not.toBe(second);
+    expect(mockCreateClient).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem\nSonarQube Quality Gate fails on main because new-code coverage is below the required threshold (0%-covered new agent-api modules).\n\n## Root Cause\nRecently-added/refactored agent-api modules (e.g. Supabase helper + queue transition helper) were not exercised by unit tests, so Sonar counted them as uncovered new code.\n\n## Solution\nAdd focused Vitest unit tests for the new modules using mocks (no network / no real Supabase credentials), and tighten input validation to reject NaN status codes early.\n\n## Files Changed\n-  - tests for lazy Supabase helper\n-  - tests for transition_status wrapper + helpers\n-  - tests for crypto random wrapper\n-  - treat NaN status codes as invalid input\n\n## PR\n(autofilled by GitHub)