### PR TITLE
fix: enforce ESM resolution in nightly discovery

### DIFF
--- a/.github/workflows/nightly-discovery.yml
+++ b/.github/workflows/nightly-discovery.yml
@@ -30,12 +30,20 @@ jobs:
         run: npm ci --legacy-peer-deps
         working-directory: services/agent-api
 
+      - name: Debug module resolution (ESM)
+        working-directory: services/agent-api
+        run: |
+          node -p "process.cwd()"
+          node --input-type=module -e "console.log(await import.meta.resolve('openai/package.json'))"
+          node --input-type=module -e "console.log(await import.meta.resolve('zod'))"
+
       - name: Run discovery (agent-api)
+        working-directory: services/agent-api
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: node services/agent-api/src/cli.js discovery --agentic --premium
+        run: node src/cli.js discovery --agentic --premium
 
       - name: Notify on failure
         if: failure()
@@ -77,12 +85,13 @@ jobs:
         working-directory: services/agent-api
 
       - name: Run enrichment pipeline (limit 20 per night)
+        working-directory: services/agent-api
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: node services/agent-api/src/cli.js process-queue --limit=20
+        run: node src/cli.js process-queue --limit=20
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Problem
Nightly discovery workflow can fail early with ESM module resolution errors (e.g., OpenAI helper importing `zod` but Node cannot resolve `zod`).

## Root Cause
The workflow executes the agent-api CLI from the repo root, which can cause Node to resolve dependencies from an unintended `node_modules` location. Additionally, we lacked an evidence-first, ESM-native diagnostic step to show actual module resolution paths.

## Solution
- Run discovery/enrichment from `services/agent-api` to keep dependency resolution workspace-scoped.
- Add an ESM-only debug step using `import.meta.resolve()` to print resolution paths for `openai` and `zod` right before the discovery run.

## Files Changed
- `.github/workflows/nightly-discovery.yml` - add ESM debug step and set `working-directory: services/agent-api` for agent-api CLI steps
