### PR TITLE
fix: add ESM module sanity job

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -11,6 +11,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  module-sanity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Report Node version
+        continue-on-error: true
+        run: node -p "process.versions.node"
+
+      - name: "ESM sanity: import zod"
+        continue-on-error: true
+        run: node --input-type=module -e "await import('zod'); console.log('zod ok')"
+
+      - name: "ESM sanity: import openai/helpers/zod"
+        continue-on-error: true
+        run: node --input-type=module -e "await import('openai/helpers/zod'); console.log('openai/helpers/zod ok')"
+
   large-file-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  module-sanity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Report Node version
+        continue-on-error: true
+        run: node -p "process.versions.node"
+
+      - name: "ESM sanity: import zod"
+        continue-on-error: true
+        run: node --input-type=module -e "await import('zod'); console.log('zod ok')"
+
+      - name: "ESM sanity: import openai/helpers/zod"
+        continue-on-error: true
+        run: node --input-type=module -e "await import('openai/helpers/zod'); console.log('openai/helpers/zod ok')"
+
   large-file-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem
CI did not have a cheap, ESM-explicit module sanity check to catch dependency/module-resolution drift (e.g., the recent `openai/helpers/zod` → missing `zod` failure).

## Root Cause
Workflows can drift in Node/module execution context and dependency installation layout over time, making it easy for ESM resolution issues to slip in unnoticed until a nightly job fails.

## Solution
Add a non-blocking (log-only) `module-sanity` job to both PR CI and main CI that:
- reports the Node version
- uses ESM-explicit inline execution (`node --input-type=module`)
- verifies that Node can import `zod` and `openai/helpers/zod`

All sanity steps use `continue-on-error: true` so the job surfaces failures without blocking builds initially.

## Files Changed
- `.github/workflows/ci.yml` - add `module-sanity` job (PR CI)
- `.github/workflows/ci-main.yml` - add `module-sanity` job (main CI)

## PR
(autofilled by GitHub)
