### PR TITLE
fix: unify GHA Node version pinning

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -21,8 +21,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -48,7 +49,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Check for large files (>500 lines)
         run: node scripts/check-large-files.cjs || echo "⚠️ Quality Gate violations found - see KB-151 for tracking"
@@ -107,8 +110,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'npm'
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -47,7 +48,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Check for large files (>500 lines)
         run: node scripts/check-large-files.cjs || echo "⚠️ Quality Gate violations found - see KB-151 for tracking"
@@ -67,8 +70,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/nightly-discovery.yml
+++ b/.github/workflows/nightly-discovery.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install root dependencies
         run: npm ci --legacy-peer-deps
@@ -70,8 +71,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install root dependencies
         run: npm ci --legacy-peer-deps

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/update-schema-docs.yml
+++ b/.github/workflows/update-schema-docs.yml
@@ -19,8 +19,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Problem
GitHub Actions workflows were pinning Node versions inconsistently (mix of hardcoded `node-version: 20`, quoted strings, and `.nvmrc` usage). Cache configuration was also inconsistent, which can cause subtle dependency tree drift in a monorepo.

## Root Cause
Over time, workflows were added/edited with slightly different `actions/setup-node` configurations, leading to drift.

## Solution
Standardize all workflows to:
- use `node-version-file: '.nvmrc'` (single source of truth)
- use `cache: npm` with explicit `cache-dependency-path: package-lock.json` where caching is enabled

## Files Changed
- `.github/workflows/ci.yml`
- `.github/workflows/ci-main.yml`
- `.github/workflows/ci-nightly.yml`
- `.github/workflows/nightly-discovery.yml`
- `.github/workflows/sonarcloud.yml`
- `.github/workflows/update-schema-docs.yml`

## PR
(autofilled by GitHub)
