### PR TITLE
fix: simplify nightly installs

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -25,7 +25,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Debug - Check env vars
         run: |

--- a/.github/workflows/nightly-discovery.yml
+++ b/.github/workflows/nightly-discovery.yml
@@ -25,26 +25,20 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install root dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Install agent-api dependencies
-        run: npm ci --legacy-peer-deps
-        working-directory: services/agent-api
+        run: npm ci
 
       - name: Debug module resolution (ESM)
-        working-directory: services/agent-api
         run: |
-          node -p "process.cwd()"
-          node --input-type=module -e "console.log(await import.meta.resolve('openai/package.json'))"
-          node --input-type=module -e "console.log(await import.meta.resolve('zod'))"
+          npm -w services/agent-api exec -- node -p "process.cwd()"
+          npm -w services/agent-api exec -- node --input-type=module -e "console.log(await import.meta.resolve('openai/package.json'))"
+          npm -w services/agent-api exec -- node --input-type=module -e "console.log(await import.meta.resolve('zod'))"
 
       - name: Run discovery (agent-api)
-        working-directory: services/agent-api
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: node src/cli.js discovery --agentic --premium
+        run: npm -w services/agent-api exec -- node src/cli.js discovery --agentic --premium
 
       - name: Notify on failure
         if: failure()
@@ -76,24 +70,18 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install root dependencies
-        run: npm ci --legacy-peer-deps
-
-      - name: Install agent-api dependencies
-        run: npm ci --legacy-peer-deps
-        working-directory: services/agent-api
+        run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install chromium
-        working-directory: services/agent-api
+        run: npm -w services/agent-api exec -- playwright install chromium
 
       - name: Run enrichment pipeline (limit 20 per night)
-        working-directory: services/agent-api
         env:
           PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: node src/cli.js process-queue --limit=20
+        run: npm -w services/agent-api exec -- node src/cli.js process-queue --limit=20
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Problem
Some workflows used `npm ci --legacy-peer-deps` and performed multiple installs across directories, which can hide peer conflicts and create inconsistent dependency trees in a monorepo.

## Root Cause
Workflow install steps evolved organically (root install + workspace install + peer suppression) rather than enforcing a single strict install strategy.

## Solution
- Make installs strict by default (`npm ci` with no flags).
- In nightly discovery, remove the separate `services/agent-api` install and run agent-api commands via `npm -w services/agent-api exec -- ...` so module resolution stays workspace-scoped.
- Keep Playwright browser install as the explicit exception, but run it through the workspace local binary.

## Files Changed
- `.github/workflows/nightly-discovery.yml` - single root install + workspace exec for agent-api commands; remove legacy-peer-deps
- `.github/workflows/ci-nightly.yml` - remove legacy-peer-deps from install

## PR
(autofilled by GitHub)
