### PR TITLE
fix: add workflow ESM guardrail

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: "Guardrail: workflow inline Node mode"
+        continue-on-error: true
+        run: node scripts/utilities/check-workflow-node-inline-esm.mjs
+
       - name: Report Node version
         continue-on-error: true
         run: node -p "process.versions.node"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: "Guardrail: workflow inline Node mode"
+        continue-on-error: true
+        run: node scripts/utilities/check-workflow-node-inline-esm.mjs
+
       - name: Report Node version
         continue-on-error: true
         run: node -p "process.versions.node"

--- a/scripts/utilities/check-workflow-node-inline-esm.mjs
+++ b/scripts/utilities/check-workflow-node-inline-esm.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const WORKFLOWS_DIR = path.resolve(process.cwd(), '.github', 'workflows');
+
+function listWorkflowFiles() {
+  if (!fs.existsSync(WORKFLOWS_DIR)) return [];
+
+  return fs
+    .readdirSync(WORKFLOWS_DIR)
+    .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+    .map((name) => path.join(WORKFLOWS_DIR, name));
+}
+
+function findNonExplicitNodeE(workflowPath) {
+  const content = fs.readFileSync(workflowPath, 'utf8');
+  const lines = content.split(/\r?\n/);
+
+  const findings = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.includes('node')) continue;
+    if (!line.includes(' -e ')) continue;
+
+    if (line.includes('--input-type=module')) continue;
+
+    findings.push({
+      lineNumber: i + 1,
+      line: line.trim(),
+    });
+  }
+
+  return findings;
+}
+
+function main() {
+  const workflows = listWorkflowFiles();
+  if (workflows.length === 0) {
+    console.log('No workflow files found.');
+    return;
+  }
+
+  let total = 0;
+
+  for (const workflowPath of workflows) {
+    const findings = findNonExplicitNodeE(workflowPath);
+    if (findings.length === 0) continue;
+
+    for (const finding of findings) {
+      total += 1;
+      console.log(
+        `WARN: Non-ESM-explicit inline node usage in workflow: ${path.basename(
+          workflowPath,
+        )}:${finding.lineNumber}: ${finding.line}`,
+      );
+    }
+  }
+
+  if (total === 0) {
+    console.log('OK: No non-ESM-explicit inline node -e usage found in workflows.');
+  } else {
+    console.log(`Found ${total} potential non-ESM-explicit node -e usage(s).`);
+    console.log(
+      'Recommendation: use `node --input-type=module -e "..."` for ESM snippets or move the script into a committed .mjs file.',
+    );
+  }
+}
+
+main();


### PR DESCRIPTION
## Problem
Workflows can silently drift back to non-explicit inline Node execution (e.g. `node -e ...`), which can change module mode semantics (CJS vs ESM) and reintroduce module resolution issues.

## Root Cause
Inline Node snippets in YAML are easy to add ad-hoc, and `node -e` defaults are not explicit about ESM mode.

## Solution
Add a warn-only guardrail that scans `.github/workflows/*.yml` for inline `node -e` usage that does not include `--input-type=module`.

The guardrail:
- prints WARN lines with file + line number
- is wired into PR CI and main CI as `continue-on-error: true` so it surfaces drift without blocking builds

## Files Changed
- `scripts/utilities/check-workflow-node-inline-esm.mjs` - new workflow guardrail scanner
- `.github/workflows/ci.yml` - run guardrail in `module-sanity` job (non-blocking)
- `.github/workflows/ci-main.yml` - run guardrail in `module-sanity` job (non-blocking)

## PR
(autofilled by GitHub)
