### PR TITLE
fix: sonar tests paths

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.projectVersion=1.0.0
 
 # Source paths
 sonar.sources=src,services/agent-api/src
-sonar.tests=tests,e2e,services/agent-api/src/lib/__tests__
+sonar.tests=site/tests,scripts/tests,site/e2e,services/agent-api/src/lib/__tests__
 
 # Exclusions (don't analyze these as source - includes orchestration with high complexity)
 sonar.exclusions=\


### PR DESCRIPTION
## Problem
SonarCloud scan fails because `sonar.tests` references directories that no longer exist after the test/e2e folder move.

## Change
- Update `sonar.tests` to point at:
  - `site/tests`
  - `scripts/tests`
  - `site/e2e`

## Notes
- Config-only change.

Closes https://linear.app/knowledge-base/issue/KB-XXX
