### PR TITLE
fix: make Vercel admin build explicit

### DIFF
--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -17,6 +17,11 @@ This repository is a monorepo containing:
 | Admin dashboard | `apps/admin/`         | Next.js | `npm run dev -w admin`            |
 | Agent API       | `services/agent-api/` | Node.js | `npm start -w services/agent-api` |
 
+Deployment roots:
+
+- Vercel: `apps/admin/`
+- Cloudflare Pages: `apps/web/`
+
 ## Where "truth" lives
 
 | Concern                 | Source of truth        |

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   ],
   "scripts": {
     "dev": "astro dev",
+    "dev:admin": "npm run dev -w apps/admin",
     "build": "astro build",
+    "build:admin": "npm run build -w apps/admin",
+    "build:web": "astro build",
     "preview": "astro preview",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
#### Why
Vercel was triggering the repo-root `build` script (Astro), causing admin deploys to accidentally build the web surface.

#### Changes
- Root scripts:
  - `build:admin`: `npm run build -w apps/admin`
  - `dev:admin`: `npm run dev -w apps/admin`
  - `build:web`: `astro build`
- Docs: note deployment roots
  - Vercel: `apps/admin/`
  - Cloudflare Pages: `apps/web/`

#### How to use (Vercel)
- Root Directory: `.`
- Install: `npm ci`
- Build: `npm run build:admin`
