### PR TITLE
fix: make Vercel build admin-only

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "git": {
     "deploymentEnabled": true
   },
-  "buildCommand": "rm -rf .next && npm run build"
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build:admin"
 }


### PR DESCRIPTION
#### Problem
Vercel was using `vercel.json` to run the repo-root build (`npm run build`), which builds Astro and fails on missing Supabase env vars. Admin deploys should build only the Next.js app.

#### Change
- `vercel.json`
  - `installCommand`: `npm ci`
  - `buildCommand`: `npm run build:admin`

#### Result
Vercel builds the admin surface only (workspaces-safe, single lockfile) and avoids accidental Astro builds.
