### PR TITLE
fix: stop vercel.json overriding project build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,5 @@
 {
   "git": {
     "deploymentEnabled": true
-  },
-  "installCommand": "npm ci",
-  "buildCommand": "npm run build:admin"
+  }
 }


### PR DESCRIPTION
#### Problem
Vercel Project Settings are configured with Root Directory `apps/admin` and build `npm run build`, but repo `vercel.json` was overriding those settings by forcing a root-level build command.

This caused Vercel to run `npm run build:admin` inside `apps/admin`, which fails because that script exists only at the repo root.

#### Change
- Remove `installCommand` and `buildCommand` from `vercel.json`.

#### Intended Vercel settings
- Root Directory: `apps/admin`
- Install: `npm ci --prefix ../..`
- Build: `npm run build`
