### PR TITLE
fix: update SonarCloud paths after apps/ move

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.projectName=BFSI Insights
 sonar.projectVersion=1.0.0
 
 # Source paths
-sonar.sources=src,services/agent-api/src
+sonar.sources=apps/web,apps/admin/src,services/agent-api/src
 sonar.tests=apps/web/tests,scripts/tests,apps/web/e2e,services/agent-api/src/lib/__tests__
 
 # Exclusions (don't analyze these as source - includes orchestration with high complexity)
@@ -70,9 +70,9 @@ sonar.coverage.exclusions=\
   **/routes/**,\
   **/middleware/**,\
   services/agent-api/src/index.js,\
-  src/pages/**,\
-  src/features/**,\
-  src/lib/admin/**
+  apps/web/pages/**,\
+  apps/web/features/**,\
+  apps/web/lib/admin/**
 
 # TypeScript/JavaScript settings
 sonar.typescript.tsconfigPath=tsconfig.json


### PR DESCRIPTION
#### Problem
SonarCloud scan fails with:
- `Invalid value of sonar.sources ... The folder 'src' does not exist`

#### Change
- Update `sonar.sources` to match the post-move monorepo layout:
  - `apps/web`
  - `apps/admin/src`
  - `services/agent-api/src`
- Update `sonar.coverage.exclusions` entries that still referenced `src/...` to `apps/web/...`.
