### PR TITLE
chore: reset SonarCloud baseline

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.organization=rick-te-molder
 
 # Project metadata
 sonar.projectName=BFSI Insights
-sonar.projectVersion=1.0.0
+sonar.projectVersion=2026.01.03
 
 # Source paths
 sonar.sources=apps/web,apps/admin/src,services/agent-api/src


### PR DESCRIPTION
#### Why
The SonarCloud Quality Gate currently treats a large refactor/move as "New Code", causing the gate to fail on "Coverage on New Code".

We are using the project New Code mode "Previous version" (Reference branch mode is not available in this SonarCloud setup), so bumping `sonar.projectVersion` establishes a fresh baseline.

#### Change
- `sonar.projectVersion`: `1.0.0` -> `2026.01.03`

#### Follow-up
Re-run the SonarCloud Analysis workflow on `main` to confirm the Quality Gate is now evaluated against the new baseline.
