### PR TITLE
ci: make SonarCloud quality gate non-blocking

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -54,5 +54,6 @@ jobs:
       - name: SonarCloud Quality Gate
         uses: SonarSource/sonarqube-quality-gate-action@v1
         timeout-minutes: 5
+        continue-on-error: true
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
#### Why
SonarCloud Quality Gate is currently failing due to New Code definition / coverage baseline drift. We still want SonarCloud analysis results, but we don't want it to block CI while we tune the project configuration.

#### Change
- Make the "SonarCloud Quality Gate" step non-blocking by adding `continue-on-error: true`.

#### CI impact
- This affects **Slow CI only** (workflow runs on `push` to `main` and manual dispatch).
- The scan still runs and the gate status is still visible in logs, but the workflow will not fail solely due to the gate.
