### PR TITLE
chore: hygiene gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,17 +24,16 @@ pnpm-debug.log*
 .idea/
 .lighthouseci/
 reports/
-dist/
-.astro/
 
 # Test artifacts
 playwright-report/
 test-results/
 .playwright/
 coverage/
-.env
-summaries-review.json
 summaries-review.json
 public/thumbs/
-.vercel
 .env*.local
+
+**/.next/
+**/out/
+.vercel/


### PR DESCRIPTION
#### Why
Prevent accidental commits of local/build artifacts (Next.js build output, Vercel metadata, etc.) and remove duplicate `.gitignore` entries.

#### Change
- Dedupe `.gitignore` entries
- Add ignores for:
  - `**/.next/`
  - `**/out/`
  - `.vercel/`

#### Verification
- `npm run lint -w admin` (0 errors, 0 warnings)
