### PR TITLE
improve: document web test ownership

### DIFF
--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -17,6 +17,12 @@ This repository is a monorepo containing:
 | Admin dashboard | `apps/admin/`         | Next.js | `npm run dev -w admin`            |
 | Agent API       | `services/agent-api/` | Node.js | `npm start -w services/agent-api` |
 
+Test ownership:
+
+- Web unit tests: `apps/web/tests/`
+- Web E2E tests: `apps/web/e2e/`
+- Web public assets: `apps/web/public/`
+
 Deployment roots:
 
 - Vercel: `apps/admin/`


### PR DESCRIPTION
#### Goal
Make test ownership explicit: the web surface owns its unit tests, E2E tests, and public assets.

#### Note
The directory moves (`apps/web/tests`, `apps/web/e2e`, `apps/web/public`) already exist in `main`. This PR adds the "quality signal" in docs.

#### Verification
- `npm run lint -w admin` (0 errors, 0 warnings)
