### PR TITLE
fix: Sonar batch 1 (admin add flow)

### DIFF
--- a/apps/admin/src/app/(auth)/layout.tsx
+++ b/apps/admin/src/app/(auth)/layout.tsx
@@ -1,4 +1,6 @@
+import type { ReactNode } from 'react';
+
 // Auth layout - no sidebar, centered content
-export default function AuthLayout({ children }: { children: React.ReactNode }) {
+export default function AuthLayout({ children }: Readonly<{ children: ReactNode }>) {
   return <>{children}</>;
 }

--- a/apps/admin/src/app/(dashboard)/add/handlers/submitArticle.ts
+++ b/apps/admin/src/app/(dashboard)/add/handlers/submitArticle.ts
@@ -23,153 +23,193 @@ interface SubmitArticleParams {
   resetForm: () => void;
 }
 
-export async function submitArticle(params: SubmitArticleParams) {
-  const {
-    inputMode,
-    url,
-    pdfFile,
-    pdfTitle,
-    submitterName,
-    submitterAudience,
-    submitterChannel,
-    submitterUrgency,
-    whyValuable,
-    verbatimComment,
-    suggestedAudiences,
-    existingSource,
-    editingId,
-    supabase,
-    setStatus,
-    setMessage,
-    setUploadProgress,
-    setEditingId,
-    loadMissedItems,
-    resetForm,
-  } = params;
+type SubmitCtx = SubmitArticleParams;
 
-  setStatus('submitting');
-  setMessage('');
+async function uploadPdfAndGetUrl(
+  supabase: SupabaseClient,
+  pdfFile: File,
+  setUploadProgress: (progress: number) => void,
+) {
+  setUploadProgress(0);
+  const fileId = crypto.randomUUID();
+  const filePath = `pdfs/${fileId}.pdf`;
+  const { error: uploadError } = await supabase.storage.from('asset').upload(filePath, pdfFile, {
+    contentType: 'application/pdf',
+    upsert: false,
+  });
+  if (uploadError) throw new Error(`Upload failed: ${uploadError.message}`);
+  setUploadProgress(100);
+
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from('asset').getPublicUrl(filePath);
+  return publicUrl;
+}
+
+function normalizeUrlAndDomain(inputUrl: string) {
+  const urlObj = new URL(inputUrl);
+  const urlNorm = (urlObj.origin + urlObj.pathname).toLowerCase();
+  const domain = urlObj.hostname.replace(/^www\./, '');
+  return { urlNorm, domain };
+}
+
+function getSuggestedAudiencesValue(suggestedAudiences: string[]) {
+  return suggestedAudiences.length > 0 ? suggestedAudiences : null;
+}
+
+function trimOrNull(value: string) {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+async function updateMissedDiscovery(ctx: SubmitCtx) {
+  const { error } = await ctx.supabase
+    .from('missed_discovery')
+    .update({
+      submitter_name: trimOrNull(ctx.submitterName),
+      submitter_audience: ctx.submitterAudience,
+      submitter_channel: ctx.submitterChannel,
+      submitter_urgency: ctx.submitterUrgency,
+      why_valuable: ctx.whyValuable.trim(),
+      verbatim_comment: trimOrNull(ctx.verbatimComment),
+      suggested_audiences: getSuggestedAudiencesValue(ctx.suggestedAudiences),
+    })
+    .eq('id', ctx.editingId);
+  if (error) throw error;
+}
+
+async function insertQueueItem(ctx: SubmitCtx, finalUrl: string) {
+  const isPdf = ctx.inputMode === 'pdf';
+  const { data: queueItem, error: queueError } = await ctx.supabase
+    .from('ingestion_queue')
+    .insert({
+      url: finalUrl,
+      status_code: isPdf ? 230 : 200,
+      entry_type: 'manual',
+      payload: {
+        manual_add: true,
+        title: isPdf ? ctx.pdfTitle.trim() : null,
+        is_pdf: isPdf,
+        submitter: trimOrNull(ctx.submitterName),
+        why_valuable: ctx.whyValuable.trim(),
+        source: ctx.existingSource || null,
+      },
+    })
+    .select('id')
+    .single();
+  if (queueError) throw queueError;
+  return { queueId: queueItem.id, isPdf };
+}
+
+function buildMissedDiscoveryInsert(
+  ctx: SubmitCtx,
+  urlInfo: { finalUrl: string; urlNorm: string; domain: string },
+  queueId: string,
+) {
+  return {
+    url: urlInfo.finalUrl,
+    url_norm: urlInfo.urlNorm,
+    queue_id: queueId,
+    submitter_name: trimOrNull(ctx.submitterName),
+    submitter_type: 'client',
+    submitter_audience: ctx.submitterAudience,
+    submitter_channel: ctx.submitterChannel,
+    submitter_urgency: ctx.submitterUrgency,
+    why_valuable: ctx.whyValuable.trim(),
+    verbatim_comment: trimOrNull(ctx.verbatimComment),
+    suggested_audiences: getSuggestedAudiencesValue(ctx.suggestedAudiences),
+    source_domain: urlInfo.domain,
+    existing_source_slug: ctx.existingSource,
+  };
+}
+
+async function insertMissedDiscovery(
+  ctx: SubmitCtx,
+  urlInfo: { finalUrl: string; urlNorm: string; domain: string },
+  queueId: string,
+) {
+  const { error } = await ctx.supabase.from('missed_discovery').insert({
+    ...buildMissedDiscoveryInsert(ctx, urlInfo, queueId),
+  });
+  return error;
+}
+
+async function triggerManualProcessing(queueId: string) {
+  await fetch('/api/process-manual', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ queueId }),
+  });
+}
+
+async function resolveUrlInfo(ctx: SubmitCtx) {
+  const finalUrlSeed = ctx.url.trim();
+  if (ctx.inputMode === 'pdf' && ctx.pdfFile) {
+    ctx.setStatus('uploading');
+    const finalUrl = await uploadPdfAndGetUrl(ctx.supabase, ctx.pdfFile, ctx.setUploadProgress);
+    ctx.setStatus('submitting');
+    return { finalUrl, domain: 'manual-pdf-upload', urlNorm: finalUrl.toLowerCase() };
+  }
+
+  const normalized = normalizeUrlAndDomain(finalUrlSeed);
+  return { finalUrl: finalUrlSeed, domain: normalized.domain, urlNorm: normalized.urlNorm };
+}
+
+async function ensureUrlNotAlreadyReported(ctx: SubmitCtx, urlNorm: string) {
+  const { data: existing } = await ctx.supabase
+    .from('missed_discovery')
+    .select('id')
+    .eq('url_norm', urlNorm)
+    .maybeSingle();
+  if (existing) throw new Error('This URL has already been reported');
+}
+
+async function submitUpdate(ctx: SubmitCtx) {
+  await updateMissedDiscovery(ctx);
+  ctx.setStatus('success');
+  ctx.setMessage('Article updated successfully!');
+  ctx.setEditingId(null);
+  ctx.loadMissedItems();
+  ctx.resetForm();
+}
+
+function getSuccessMessage(isPdf: boolean) {
+  return isPdf
+    ? 'PDF uploaded! Processing started - check History tab for progress.'
+    : 'Article submitted! Processing started - check History tab for progress.';
+}
+
+async function submitCreate(
+  ctx: SubmitCtx,
+  urlInfo: { finalUrl: string; urlNorm: string; domain: string },
+) {
+  await ensureUrlNotAlreadyReported(ctx, urlInfo.urlNorm);
+
+  const { queueId, isPdf } = await insertQueueItem(ctx, urlInfo.finalUrl);
+  const insertError = await insertMissedDiscovery(ctx, urlInfo, queueId);
+  if (insertError) console.error('Failed to add to missed_discovery:', insertError);
 
   try {
-    let finalUrl = url.trim();
-    let domain = '';
-    let urlNorm = '';
+    await triggerManualProcessing(queueId);
+  } catch (error_) {
+    console.error('Failed to trigger enrichment:', error_);
+  }
 
-    // Handle PDF upload
-    if (inputMode === 'pdf' && pdfFile) {
-      setStatus('uploading');
-      setUploadProgress(0);
-      const fileId = crypto.randomUUID();
-      const filePath = `pdfs/${fileId}.pdf`;
-      const { error: uploadError } = await supabase.storage
-        .from('asset')
-        .upload(filePath, pdfFile, {
-          contentType: 'application/pdf',
-          upsert: false,
-        });
-      if (uploadError) throw new Error(`Upload failed: ${uploadError.message}`);
-      setUploadProgress(100);
-      const {
-        data: { publicUrl },
-      } = supabase.storage.from('asset').getPublicUrl(filePath);
-      finalUrl = publicUrl;
-      domain = 'manual-pdf-upload';
-      urlNorm = publicUrl.toLowerCase();
-      setStatus('submitting');
-    } else {
-      const urlObj = new URL(url);
-      urlNorm = (urlObj.origin + urlObj.pathname).toLowerCase();
-      domain = urlObj.hostname.replace(/^www\./, '');
-    }
+  ctx.setStatus('success');
+  ctx.setMessage(getSuccessMessage(isPdf));
+  ctx.resetForm();
+}
 
-    if (editingId) {
-      const { error } = await supabase
-        .from('missed_discovery')
-        .update({
-          submitter_name: submitterName.trim() || null,
-          submitter_audience: submitterAudience,
-          submitter_channel: submitterChannel,
-          submitter_urgency: submitterUrgency,
-          why_valuable: whyValuable.trim(),
-          verbatim_comment: verbatimComment.trim() || null,
-          suggested_audiences: suggestedAudiences.length > 0 ? suggestedAudiences : null,
-        })
-        .eq('id', editingId);
-      if (error) throw error;
-      setStatus('success');
-      setMessage('Article updated successfully!');
-      setEditingId(null);
-      loadMissedItems();
-    } else {
-      const { data: existing } = await supabase
-        .from('missed_discovery')
-        .select('id')
-        .eq('url_norm', urlNorm)
-        .maybeSingle();
-      if (existing) {
-        setStatus('error');
-        setMessage('This URL has already been reported');
-        return;
-      }
+export async function submitArticle(ctx: SubmitArticleParams) {
+  ctx.setStatus('submitting');
+  ctx.setMessage('');
 
-      const isPdf = inputMode === 'pdf';
-      const { data: queueItem, error: queueError } = await supabase
-        .from('ingestion_queue')
-        .insert({
-          url: finalUrl,
-          status_code: isPdf ? 230 : 200,
-          entry_type: 'manual',
-          payload: {
-            manual_add: true,
-            title: isPdf ? pdfTitle.trim() : null,
-            is_pdf: isPdf,
-            submitter: submitterName.trim() || null,
-            why_valuable: whyValuable.trim(),
-            source: existingSource || null,
-          },
-        })
-        .select('id')
-        .single();
-      if (queueError) throw queueError;
-
-      const { error } = await supabase.from('missed_discovery').insert({
-        url: finalUrl,
-        url_norm: urlNorm,
-        queue_id: queueItem.id,
-        submitter_name: submitterName.trim() || null,
-        submitter_type: 'client',
-        submitter_audience: submitterAudience,
-        submitter_channel: submitterChannel,
-        submitter_urgency: submitterUrgency,
-        why_valuable: whyValuable.trim(),
-        verbatim_comment: verbatimComment.trim() || null,
-        suggested_audiences: suggestedAudiences.length > 0 ? suggestedAudiences : null,
-        source_domain: domain,
-        existing_source_slug: existingSource,
-      });
-      if (error) console.error('Failed to add to missed_discovery:', error);
-
-      try {
-        await fetch('/api/process-manual', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ queueId: queueItem.id }),
-        });
-      } catch (triggerErr) {
-        console.error('Failed to trigger enrichment:', triggerErr);
-      }
-
-      setStatus('success');
-      setMessage(
-        isPdf
-          ? 'PDF uploaded! Processing started - check History tab for progress.'
-          : 'Article submitted! Processing started - check History tab for progress.',
-      );
-    }
-
-    resetForm();
+  try {
+    const urlInfo = await resolveUrlInfo(ctx);
+    if (ctx.editingId) await submitUpdate(ctx);
+    else await submitCreate(ctx, urlInfo);
   } catch (err) {
-    setStatus('error');
-    setMessage(err instanceof Error ? err.message : 'Failed to submit');
+    ctx.setStatus('error');
+    ctx.setMessage(err instanceof Error ? err.message : 'Failed to submit');
   }
 }

--- a/apps/admin/src/app/(dashboard)/add/page.tsx
+++ b/apps/admin/src/app/(dashboard)/add/page.tsx
@@ -1,100 +1,248 @@
 'use client';
 
 import Link from 'next/link';
+import type { FormEventHandler } from 'react';
 import { useAddArticle } from './hooks';
 import { ArticleInput, SubmitterInfo, WhyValuable, MissedItemsList } from './components';
 import { validateForm } from './handlers/validateForm';
 import { submitArticle } from './handlers/submitArticle';
 
+function getSubmitLabel(state: {
+  status: string;
+  editingId: string | null;
+  inputMode: 'url' | 'pdf';
+}) {
+  if (state.status === 'uploading') return 'Uploading PDF...';
+  if (state.status === 'submitting') return 'Submitting...';
+  if (state.editingId) return 'Update Article';
+  if (state.inputMode === 'pdf') return 'Upload PDF';
+  return 'Add Article';
+}
+
+function buildValidationInput(state: ReturnType<typeof useAddArticle>) {
+  return {
+    inputMode: state.inputMode,
+    url: state.url,
+    pdfFile: state.pdfFile,
+    pdfTitle: state.pdfTitle,
+    submitterName: state.submitterName,
+    whyValuable: state.whyValuable,
+    submitterAudience: state.submitterAudience,
+    submitterChannel: state.submitterChannel,
+    submitterUrgency: state.submitterUrgency,
+  };
+}
+
+function isValidOrSetError(state: ReturnType<typeof useAddArticle>) {
+  const validation = validateForm(buildValidationInput(state));
+  if (validation.valid) return true;
+  state.setStatus('error');
+  state.setMessage(validation.error!);
+  return false;
+}
+
+function buildSubmitParams(state: ReturnType<typeof useAddArticle>) {
+  return {
+    inputMode: state.inputMode,
+    url: state.url,
+    pdfFile: state.pdfFile,
+    pdfTitle: state.pdfTitle,
+    submitterName: state.submitterName,
+    submitterAudience: state.submitterAudience,
+    submitterChannel: state.submitterChannel,
+    submitterUrgency: state.submitterUrgency,
+    whyValuable: state.whyValuable,
+    verbatimComment: state.verbatimComment,
+    suggestedAudiences: state.suggestedAudiences,
+    existingSource: state.existingSource,
+    editingId: state.editingId,
+    supabase: state.supabase,
+    setStatus: state.setStatus,
+    setMessage: state.setMessage,
+    setUploadProgress: state.setUploadProgress,
+    setEditingId: state.setEditingId,
+    loadMissedItems: state.loadMissedItems,
+    resetForm: state.resetForm,
+  };
+}
+
+async function runSubmit(state: ReturnType<typeof useAddArticle>) {
+  if (!isValidOrSetError(state)) return;
+  await submitArticle(buildSubmitParams(state));
+}
+
+function StatusBanner(state: { status: string; message: string }) {
+  if (state.status === 'success') {
+    return (
+      <div className="mb-6 rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-4">
+        <p className="text-emerald-300">✅ {state.message}</p>
+      </div>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="mb-6 rounded-lg border border-red-500/20 bg-red-500/10 p-4">
+        <p className="text-red-300">❌ {state.message}</p>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function Tabs(state: {
+  activeTab: string;
+  setActiveTab: (tab: 'add' | 'list') => void;
+  missedItemsLength: number;
+}) {
+  return (
+    <div className="flex gap-6 border-b border-neutral-800">
+      <button
+        onClick={() => state.setActiveTab('add')}
+        className={`pb-3 text-sm font-medium transition-colors border-b-2 -mb-px ${state.activeTab === 'add' ? 'border-sky-500 text-white' : 'border-transparent text-neutral-400 hover:text-white'}`}
+      >
+        ➕ Add Article
+      </button>
+      <button
+        onClick={() => state.setActiveTab('list')}
+        className={`pb-3 text-sm font-medium transition-colors border-b-2 -mb-px ${state.activeTab === 'list' ? 'border-sky-500 text-white' : 'border-transparent text-neutral-400 hover:text-white'}`}
+      >
+        📋 History ({state.missedItemsLength || '...'})
+      </button>
+    </div>
+  );
+}
+
+function EditingBanner(state: { editingId: string | null; cancelEdit: () => void }) {
+  if (!state.editingId) return null;
+  return (
+    <div className="mb-4 flex items-center justify-between rounded-lg border border-sky-500/20 bg-sky-500/10 p-3">
+      <span className="text-sky-300">✏️ Editing article</span>
+      <button
+        type="button"
+        onClick={state.cancelEdit}
+        className="text-sm text-neutral-400 hover:text-white"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+function SubmitActions(state: { status: string; submitLabel: string }) {
+  return (
+    <div className="flex gap-3">
+      <button
+        type="submit"
+        disabled={state.status === 'submitting' || state.status === 'uploading'}
+        className="rounded-lg bg-sky-600 px-6 py-3 font-medium text-white hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {state.submitLabel}
+      </button>
+      <Link
+        href="/items"
+        className="rounded-lg border border-neutral-700 px-6 py-3 font-medium text-neutral-300 hover:bg-neutral-800"
+      >
+        Go to Items Queue
+      </Link>
+    </div>
+  );
+}
+
+function ArticleSection(state: ReturnType<typeof useAddArticle>) {
+  return (
+    <ArticleInput
+      inputMode={state.inputMode}
+      setInputMode={state.setInputMode}
+      url={state.url}
+      setUrl={state.setUrl}
+      pdfFile={state.pdfFile}
+      setPdfFile={state.setPdfFile}
+      pdfTitle={state.pdfTitle}
+      setPdfTitle={state.setPdfTitle}
+      detectedDomain={state.detectedDomain}
+      existingSource={state.existingSource}
+      status={state.status}
+      uploadProgress={state.uploadProgress}
+    />
+  );
+}
+
+function SubmitterSection(state: ReturnType<typeof useAddArticle>) {
+  return (
+    <SubmitterInfo
+      submitterName={state.submitterName}
+      setSubmitterName={state.setSubmitterName}
+      submitterChannel={state.submitterChannel}
+      setSubmitterChannel={state.setSubmitterChannel}
+      submitterAudience={state.submitterAudience}
+      setSubmitterAudience={state.setSubmitterAudience}
+      submitterUrgency={state.submitterUrgency}
+      setSubmitterUrgency={state.setSubmitterUrgency}
+    />
+  );
+}
+
+function WhyValuableSection(state: ReturnType<typeof useAddArticle>) {
+  return (
+    <WhyValuable
+      whyValuable={state.whyValuable}
+      setWhyValuable={state.setWhyValuable}
+      verbatimComment={state.verbatimComment}
+      setVerbatimComment={state.setVerbatimComment}
+      suggestedAudiences={state.suggestedAudiences}
+      toggleAudience={state.toggleAudience}
+    />
+  );
+}
+
+function AddFormFields(state: ReturnType<typeof useAddArticle>) {
+  return (
+    <>
+      <ArticleSection {...state} />
+      <SubmitterSection {...state} />
+      <WhyValuableSection {...state} />
+    </>
+  );
+}
+
+function AddTab(
+  state: ReturnType<typeof useAddArticle> & { onSubmit: FormEventHandler<HTMLFormElement> },
+) {
+  const submitLabel = getSubmitLabel(state);
+  return (
+    <div className="max-w-2xl">
+      <EditingBanner editingId={state.editingId} cancelEdit={state.cancelEdit} />
+      <StatusBanner status={state.status} message={state.message} />
+      <form onSubmit={state.onSubmit} className="space-y-6">
+        <AddFormFields {...state} />
+        <SubmitActions status={state.status} submitLabel={submitLabel} />
+      </form>
+    </div>
+  );
+}
+
+function Content(
+  state: ReturnType<typeof useAddArticle> & { onSubmit: FormEventHandler<HTMLFormElement> },
+) {
+  return state.activeTab === 'add' ? (
+    <AddTab {...state} onSubmit={state.onSubmit} />
+  ) : (
+    <MissedItemsList
+      items={state.missedItems}
+      loading={state.loadingList}
+      onEdit={state.editItem}
+      onDelete={state.deleteItem}
+    />
+  );
+}
+
 export default function AddArticlePage() {
-  const {
-    activeTab,
-    setActiveTab,
-    missedItems,
-    loadingList,
-    loadMissedItems,
-    inputMode,
-    setInputMode,
-    url,
-    setUrl,
-    pdfFile,
-    setPdfFile,
-    pdfTitle,
-    setPdfTitle,
-    uploadProgress,
-    setUploadProgress,
-    submitterName,
-    setSubmitterName,
-    submitterAudience,
-    setSubmitterAudience,
-    submitterChannel,
-    setSubmitterChannel,
-    submitterUrgency,
-    setSubmitterUrgency,
-    whyValuable,
-    setWhyValuable,
-    verbatimComment,
-    setVerbatimComment,
-    suggestedAudiences,
-    toggleAudience,
-    status,
-    setStatus,
-    message,
-    setMessage,
-    detectedDomain,
-    existingSource,
-    editingId,
-    setEditingId,
-    resetForm,
-    editItem,
-    cancelEdit,
-    deleteItem,
-    supabase,
-  } = useAddArticle();
-
-  const handleSubmit = async (e: React.FormEvent) => {
+  const state = useAddArticle();
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-
-    const validation = validateForm({
-      inputMode,
-      url,
-      pdfFile,
-      pdfTitle,
-      submitterName,
-      whyValuable,
-      submitterAudience,
-      submitterChannel,
-      submitterUrgency,
-    });
-
-    if (!validation.valid) {
-      setStatus('error');
-      setMessage(validation.error!);
-      return;
-    }
-
-    await submitArticle({
-      inputMode,
-      url,
-      pdfFile,
-      pdfTitle,
-      submitterName,
-      submitterAudience,
-      submitterChannel,
-      submitterUrgency,
-      whyValuable,
-      verbatimComment,
-      suggestedAudiences,
-      existingSource,
-      editingId,
-      supabase,
-      setStatus,
-      setMessage,
-      setUploadProgress,
-      setEditingId,
-      loadMissedItems,
-      resetForm,
-    });
+    void runSubmit(state);
   };
 
   return (
@@ -106,112 +254,13 @@ export default function AddArticlePage() {
         </p>
       </header>
 
-      <div className="flex gap-6 border-b border-neutral-800">
-        <button
-          onClick={() => setActiveTab('add')}
-          className={`pb-3 text-sm font-medium transition-colors border-b-2 -mb-px ${activeTab === 'add' ? 'border-sky-500 text-white' : 'border-transparent text-neutral-400 hover:text-white'}`}
-        >
-          ➕ Add Article
-        </button>
-        <button
-          onClick={() => setActiveTab('list')}
-          className={`pb-3 text-sm font-medium transition-colors border-b-2 -mb-px ${activeTab === 'list' ? 'border-sky-500 text-white' : 'border-transparent text-neutral-400 hover:text-white'}`}
-        >
-          📋 History ({missedItems.length || '...'})
-        </button>
-      </div>
+      <Tabs
+        activeTab={state.activeTab}
+        setActiveTab={state.setActiveTab}
+        missedItemsLength={state.missedItems.length}
+      />
 
-      {activeTab === 'add' ? (
-        <div className="max-w-2xl">
-          {editingId && (
-            <div className="mb-4 flex items-center justify-between rounded-lg border border-sky-500/20 bg-sky-500/10 p-3">
-              <span className="text-sky-300">✏️ Editing article</span>
-              <button
-                type="button"
-                onClick={cancelEdit}
-                className="text-sm text-neutral-400 hover:text-white"
-              >
-                Cancel
-              </button>
-            </div>
-          )}
-          {status === 'success' && (
-            <div className="mb-6 rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-4">
-              <p className="text-emerald-300">✅ {message}</p>
-            </div>
-          )}
-          {status === 'error' && (
-            <div className="mb-6 rounded-lg border border-red-500/20 bg-red-500/10 p-4">
-              <p className="text-red-300">❌ {message}</p>
-            </div>
-          )}
-
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <ArticleInput
-              inputMode={inputMode}
-              setInputMode={setInputMode}
-              url={url}
-              setUrl={setUrl}
-              pdfFile={pdfFile}
-              setPdfFile={setPdfFile}
-              pdfTitle={pdfTitle}
-              setPdfTitle={setPdfTitle}
-              detectedDomain={detectedDomain}
-              existingSource={existingSource}
-              status={status}
-              uploadProgress={uploadProgress}
-            />
-            <SubmitterInfo
-              submitterName={submitterName}
-              setSubmitterName={setSubmitterName}
-              submitterChannel={submitterChannel}
-              setSubmitterChannel={setSubmitterChannel}
-              submitterAudience={submitterAudience}
-              setSubmitterAudience={setSubmitterAudience}
-              submitterUrgency={submitterUrgency}
-              setSubmitterUrgency={setSubmitterUrgency}
-            />
-            <WhyValuable
-              whyValuable={whyValuable}
-              setWhyValuable={setWhyValuable}
-              verbatimComment={verbatimComment}
-              setVerbatimComment={setVerbatimComment}
-              suggestedAudiences={suggestedAudiences}
-              toggleAudience={toggleAudience}
-            />
-            <div className="flex gap-3">
-              <button
-                type="submit"
-                disabled={status === 'submitting' || status === 'uploading'}
-                className="rounded-lg bg-sky-600 px-6 py-3 font-medium text-white hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {status === 'uploading'
-                  ? 'Uploading PDF...'
-                  : status === 'submitting'
-                    ? 'Submitting...'
-                    : editingId
-                      ? 'Update Article'
-                      : inputMode === 'pdf'
-                        ? 'Upload PDF'
-                        : 'Add Article'}
-              </button>
-              <Link
-                href="/items"
-                className="rounded-lg border border-neutral-700 px-6 py-3 font-medium text-neutral-300 hover:bg-neutral-800"
-              >
-                Go to Items Queue
-              </Link>
-            </div>
-          </form>
-        </div>
-      ) : (
-        <MissedItemsList
-          items={missedItems}
-          loading={loadingList}
-          onEdit={editItem}
-          onDelete={deleteItem}
-        />
-      )}
+      <Content {...state} onSubmit={handleSubmit} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fix Sonar issues in the Admin Add flow (batch 1)
- Keep `npm run lint -w admin` at 0 errors / 0 warnings

## Changes
- `apps/admin/src/app/(dashboard)/add/handlers/submitArticle.ts`
  - Refactor to reduce cognitive complexity
  - Rename catch param to `error_`
- `apps/admin/src/app/(dashboard)/add/page.tsx`
  - Fix promise-returning submit handler where void expected
  - Simplify submit label logic
  - Refactor to satisfy repo Quality Gate (function size / param count)
- `apps/admin/src/app/(auth)/layout.tsx`
  - Mark props as `Readonly`

## Verification
- `npm run lint -w admin`
