### PR TITLE
fix: associate labels with form controls and refactor large components

### DIFF
--- a/apps/admin/src/app/(dashboard)/agents/components/PromptEditModal.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/PromptEditModal.tsx
@@ -13,141 +13,216 @@ interface PromptEditModalProps {
   onSave: () => void;
 }
 
-export function PromptEditModal({ prompt, mode, onClose, onSave }: PromptEditModalProps) {
+type ModalState = { promptText: string; notes: string; newVersion: string; saving: boolean };
+
+function ModalHeader({ agentName, promptText }: { agentName: string; promptText: string }) {
+  return (
+    <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
+      <div>
+        <h2 className="text-lg font-bold text-white">Edit Prompt</h2>
+        <p className="text-sm text-neutral-400">{agentName}</p>
+      </div>
+      <div className="text-sm text-neutral-400">
+        {promptText.length.toLocaleString()} chars • ~{estimateTokens(promptText).toLocaleString()}{' '}
+        tokens
+      </div>
+    </div>
+  );
+}
+
+function ModeNotice({ mode, version }: { mode: 'edit' | 'create'; version: string }) {
+  if (mode === 'create') {
+    return (
+      <div className="p-3 rounded-lg bg-neutral-800/50 border border-neutral-700">
+        <p className="text-sm text-neutral-300">
+          Creating new version as <span className="text-amber-400 font-medium">DEV</span> draft.
+          Promote to TST → PRD to deploy.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="p-3 rounded-lg bg-sky-800/50 border border-sky-700">
+      <p className="text-sm text-neutral-300">
+        Editing <span className="text-sky-400 font-medium">{version}</span> in-place. No version
+        increment.
+      </p>
+    </div>
+  );
+}
+
+function VersionNameField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label htmlFor="versionName" className="block text-sm text-neutral-400 mb-1">
+        Version Name
+      </label>
+      <input
+        id="versionName"
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="e.g., v2.1"
+        className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+      />
+    </div>
+  );
+}
+
+function NotesField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label htmlFor="notes" className="block text-sm text-neutral-400 mb-1">
+        Notes
+      </label>
+      <input
+        id="notes"
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Describe changes..."
+        className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+      />
+    </div>
+  );
+}
+
+function PromptTextField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex-1">
+      <label htmlFor="promptText" className="block text-sm text-neutral-400 mb-1">
+        Prompt Text
+      </label>
+      <textarea
+        id="promptText"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full h-96 rounded-md border border-neutral-700 bg-neutral-950 px-4 py-3 text-sm text-neutral-300 font-mono resize-none"
+      />
+    </div>
+  );
+}
+
+function ModalFooter({
+  onClose,
+  onSave,
+  saving,
+  mode,
+}: {
+  onClose: () => void;
+  onSave: () => void;
+  saving: boolean;
+  mode: 'edit' | 'create';
+}) {
+  const label = saving ? 'Saving...' : mode === 'create' ? 'Create DEV Version' : 'Save Changes';
+  return (
+    <div className="p-4 border-t border-neutral-800 flex justify-end gap-3">
+      <button
+        onClick={onClose}
+        className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
+      >
+        Cancel
+      </button>
+      <button
+        onClick={onSave}
+        disabled={saving}
+        className="rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
+      >
+        {label}
+      </button>
+    </div>
+  );
+}
+
+async function savePrompt(
+  supabase: ReturnType<typeof createClient>,
+  prompt: PromptVersion,
+  mode: 'edit' | 'create',
+  state: ModalState,
+): Promise<string | null> {
+  if (mode === 'create') {
+    if (!state.newVersion) return 'Please enter a version name';
+    const { error } = await supabase.from('prompt_version').insert({
+      agent_name: prompt.agent_name,
+      version: state.newVersion,
+      prompt_text: state.promptText,
+      notes: state.notes || null,
+      model_id: prompt.model_id,
+      stage: 'DEV',
+    });
+    return error ? 'Failed to create version: ' + error.message : null;
+  }
+  const { error } = await supabase
+    .from('prompt_version')
+    .update({ prompt_text: state.promptText, notes: state.notes || prompt.notes })
+    .eq('id', prompt.id);
+  return error ? 'Failed to update version: ' + error.message : null;
+}
+
+function useEditState(prompt: PromptVersion) {
   const [promptText, setPromptText] = useState(prompt.prompt_text);
   const [notes, setNotes] = useState('');
   const [newVersion, setNewVersion] = useState(suggestNextVersion(prompt.version));
   const [saving, setSaving] = useState(false);
+  return {
+    promptText,
+    setPromptText,
+    notes,
+    setNotes,
+    newVersion,
+    setNewVersion,
+    saving,
+    setSaving,
+  };
+}
 
+function ModalBody({
+  mode,
+  prompt,
+  state,
+}: {
+  mode: 'edit' | 'create';
+  prompt: PromptVersion;
+  state: ReturnType<typeof useEditState>;
+}) {
+  return (
+    <div className="flex-1 overflow-auto p-4 space-y-4">
+      <ModeNotice mode={mode} version={prompt.version} />
+      {mode === 'create' && (
+        <VersionNameField value={state.newVersion} onChange={state.setNewVersion} />
+      )}
+      <NotesField value={state.notes} onChange={state.setNotes} />
+      <PromptTextField value={state.promptText} onChange={state.setPromptText} />
+    </div>
+  );
+}
+
+export function PromptEditModal({ prompt, mode, onClose, onSave }: PromptEditModalProps) {
+  const state = useEditState(prompt);
   const supabase = createClient();
 
   async function handleSave() {
-    setSaving(true);
-
-    if (mode === 'create') {
-      // Create new version
-      if (!newVersion) {
-        alert('Please enter a version name');
-        setSaving(false);
-        return;
-      }
-
-      const { error } = await supabase.from('prompt_version').insert({
-        agent_name: prompt.agent_name,
-        version: newVersion,
-        prompt_text: promptText,
-        notes: notes || null,
-        model_id: prompt.model_id,
-        stage: 'DEV',
-      });
-
-      if (error) {
-        alert('Failed to create version: ' + error.message);
-        setSaving(false);
-        return;
-      }
-    } else {
-      // Edit existing version in-place
-      const { error } = await supabase
-        .from('prompt_version')
-        .update({
-          prompt_text: promptText,
-          notes: notes || prompt.notes,
-        })
-        .eq('id', prompt.id);
-
-      if (error) {
-        alert('Failed to update version: ' + error.message);
-        setSaving(false);
-        return;
-      }
+    state.setSaving(true);
+    const error = await savePrompt(supabase, prompt, mode, {
+      promptText: state.promptText,
+      notes: state.notes,
+      newVersion: state.newVersion,
+      saving: state.saving,
+    });
+    if (error) {
+      alert(error);
+      state.setSaving(false);
+      return;
     }
-
-    setSaving(false);
+    state.setSaving(false);
     onSave();
   }
 
   return (
     <ModalWrapper onClose={onClose}>
-      <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-bold text-white">Edit Prompt</h2>
-          <p className="text-sm text-neutral-400">{prompt.agent_name}</p>
-        </div>
-        <div className="text-sm text-neutral-400">
-          {promptText.length.toLocaleString()} chars • ~
-          {estimateTokens(promptText).toLocaleString()} tokens
-        </div>
-      </div>
-
-      <div className="flex-1 overflow-auto p-4 space-y-4">
-        {mode === 'create' && (
-          <div className="p-3 rounded-lg bg-neutral-800/50 border border-neutral-700">
-            <p className="text-sm text-neutral-300">
-              Creating new version as <span className="text-amber-400 font-medium">DEV</span> draft.
-              Promote to TST → PRD to deploy.
-            </p>
-          </div>
-        )}
-
-        {mode === 'edit' && (
-          <div className="p-3 rounded-lg bg-sky-800/50 border border-sky-700">
-            <p className="text-sm text-neutral-300">
-              Editing <span className="text-sky-400 font-medium">{prompt.version}</span> in-place.
-              No version increment.
-            </p>
-          </div>
-        )}
-
-        {mode === 'create' && (
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Version Name</label>
-            <input
-              type="text"
-              value={newVersion}
-              onChange={(e) => setNewVersion(e.target.value)}
-              placeholder="e.g., v2.1"
-              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-            />
-          </div>
-        )}
-
-        <div>
-          <label className="block text-sm text-neutral-400 mb-1">Notes</label>
-          <input
-            type="text"
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            placeholder="Describe changes..."
-            className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-          />
-        </div>
-
-        <div className="flex-1">
-          <label className="block text-sm text-neutral-400 mb-1">Prompt Text</label>
-          <textarea
-            value={promptText}
-            onChange={(e) => setPromptText(e.target.value)}
-            className="w-full h-96 rounded-md border border-neutral-700 bg-neutral-950 px-4 py-3 text-sm text-neutral-300 font-mono resize-none"
-          />
-        </div>
-      </div>
-
-      <div className="p-4 border-t border-neutral-800 flex justify-end gap-3">
-        <button
-          onClick={onClose}
-          className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
-        >
-          Cancel
-        </button>
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className="rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
-        >
-          {saving ? 'Saving...' : mode === 'create' ? 'Create DEV Version' : 'Save Changes'}
-        </button>
-      </div>
+      <ModalHeader agentName={prompt.agent_name} promptText={state.promptText} />
+      <ModalBody mode={mode} prompt={prompt} state={state} />
+      <ModalFooter onClose={onClose} onSave={handleSave} saving={state.saving} mode={mode} />
     </ModalWrapper>
   );
 }

--- a/apps/admin/src/app/(dashboard)/agents/components/PromptPlayground.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/PromptPlayground.tsx
@@ -10,120 +10,192 @@ interface PromptPlaygroundProps {
   onClose: () => void;
 }
 
-export function PromptPlayground({ prompt, onClose }: PromptPlaygroundProps) {
+function PlaygroundHeader({ prompt }: { prompt: PromptVersion }) {
+  return (
+    <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
+      <div>
+        <h2 className="text-lg font-bold text-white flex items-center gap-2">
+          <span>🧪</span> Test Playground
+        </h2>
+        <p className="text-sm text-neutral-400">
+          {prompt.agent_name} • {prompt.version}
+        </p>
+      </div>
+      <span className="text-xs text-neutral-500">
+        ~{estimateTokens(prompt.prompt_text).toLocaleString()} tokens
+      </span>
+    </div>
+  );
+}
+
+function PromptPreview({ text }: { text: string }) {
+  return (
+    <div>
+      <span className="block text-sm text-neutral-400 mb-1">
+        Prompt ({text.length.toLocaleString()} chars)
+      </span>
+      <pre className="p-3 rounded-md bg-neutral-950 text-xs text-neutral-400 max-h-32 overflow-y-auto whitespace-pre-wrap">
+        {text.slice(0, 500)}
+        {text.length > 500 && '...'}
+      </pre>
+    </div>
+  );
+}
+
+function TestInputField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label htmlFor="testInput" className="block text-sm text-neutral-400 mb-1">
+        Test Input (sample content to classify/process)
+      </label>
+      <textarea
+        id="testInput"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Paste article text, title, or any content you want to test the prompt against..."
+        className="w-full h-40 rounded-md border border-neutral-700 bg-neutral-950 px-4 py-3 text-sm text-neutral-300 resize-none"
+      />
+    </div>
+  );
+}
+
+function RunButton({
+  onClick,
+  disabled,
+  testing,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  testing: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-md bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-500 disabled:opacity-50"
+    >
+      {testing ? 'Running...' : '▶ Run Test'}
+    </button>
+  );
+}
+
+function OutputDisplay({ output }: { output: string }) {
+  return (
+    <div>
+      <span className="block text-sm text-neutral-400 mb-1">Output</span>
+      <pre className="p-4 rounded-md bg-emerald-950/50 border border-emerald-500/20 text-sm text-emerald-300 overflow-auto max-h-64 whitespace-pre-wrap">
+        {output}
+      </pre>
+    </div>
+  );
+}
+
+function PlaygroundFooter({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="p-4 border-t border-neutral-800 flex justify-between items-center">
+      <p className="text-xs text-neutral-500">
+        Note: This runs the prompt against the test input using the configured model
+      </p>
+      <button
+        onClick={onClose}
+        className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
+      >
+        Close
+      </button>
+    </div>
+  );
+}
+
+async function executeTest(
+  prompt: PromptVersion,
+  testInput: string,
+): Promise<{ output?: string; error?: string }> {
+  try {
+    const response = await fetch('/api/test-prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentName: prompt.agent_name,
+        promptText: prompt.prompt_text,
+        testInput,
+      }),
+    });
+    const data = await response.json();
+    return response.ok
+      ? { output: JSON.stringify(data.result, null, 2) }
+      : { error: data.error || 'Test failed' };
+  } catch (err) {
+    return {
+      error: 'Failed to run test: ' + (err instanceof Error ? err.message : 'Unknown error'),
+    };
+  }
+}
+
+function usePlaygroundState() {
   const [testInput, setTestInput] = useState('');
   const [testOutput, setTestOutput] = useState<string | null>(null);
   const [testing, setTesting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  return {
+    testInput,
+    setTestInput,
+    testOutput,
+    setTestOutput,
+    testing,
+    setTesting,
+    error,
+    setError,
+  };
+}
+
+function PlaygroundBody({
+  prompt,
+  state,
+  onRun,
+}: {
+  prompt: PromptVersion;
+  state: ReturnType<typeof usePlaygroundState>;
+  onRun: () => void;
+}) {
+  return (
+    <div className="flex-1 overflow-auto p-4 space-y-4">
+      <PromptPreview text={prompt.prompt_text} />
+      <TestInputField value={state.testInput} onChange={state.setTestInput} />
+      <div className="flex items-center gap-3">
+        <RunButton
+          onClick={onRun}
+          disabled={state.testing || !state.testInput.trim()}
+          testing={state.testing}
+        />
+        {state.error && <span className="text-sm text-red-400">{state.error}</span>}
+      </div>
+      {state.testOutput && <OutputDisplay output={state.testOutput} />}
+    </div>
+  );
+}
+
+export function PromptPlayground({ prompt, onClose }: PromptPlaygroundProps) {
+  const state = usePlaygroundState();
 
   async function runTest() {
-    if (!testInput.trim()) {
-      setError('Please enter some test content');
+    if (!state.testInput.trim()) {
+      state.setError('Please enter some test content');
       return;
     }
-
-    setTesting(true);
-    setError(null);
-    setTestOutput(null);
-
-    try {
-      const response = await fetch('/api/test-prompt', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          agentName: prompt.agent_name,
-          promptText: prompt.prompt_text,
-          testInput: testInput,
-        }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        setError(data.error || 'Test failed');
-      } else {
-        setTestOutput(JSON.stringify(data.result, null, 2));
-      }
-    } catch (err) {
-      setError('Failed to run test: ' + (err instanceof Error ? err.message : 'Unknown error'));
-    } finally {
-      setTesting(false);
-    }
+    state.setTesting(true);
+    state.setError(null);
+    state.setTestOutput(null);
+    const result = await executeTest(prompt, state.testInput);
+    if (result.error) state.setError(result.error);
+    else state.setTestOutput(result.output || null);
+    state.setTesting(false);
   }
 
   return (
     <ModalWrapper onClose={onClose}>
-      <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-bold text-white flex items-center gap-2">
-            <span>🧪</span> Test Playground
-          </h2>
-          <p className="text-sm text-neutral-400">
-            {prompt.agent_name} • {prompt.version}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-neutral-500">
-            ~{estimateTokens(prompt.prompt_text).toLocaleString()} tokens
-          </span>
-        </div>
-      </div>
-
-      <div className="flex-1 overflow-auto p-4 space-y-4">
-        <div>
-          <label className="block text-sm text-neutral-400 mb-1">
-            Prompt ({prompt.prompt_text.length.toLocaleString()} chars)
-          </label>
-          <pre className="p-3 rounded-md bg-neutral-950 text-xs text-neutral-400 max-h-32 overflow-y-auto whitespace-pre-wrap">
-            {prompt.prompt_text.slice(0, 500)}
-            {prompt.prompt_text.length > 500 && '...'}
-          </pre>
-        </div>
-
-        <div>
-          <label className="block text-sm text-neutral-400 mb-1">
-            Test Input (sample content to classify/process)
-          </label>
-          <textarea
-            value={testInput}
-            onChange={(e) => setTestInput(e.target.value)}
-            placeholder="Paste article text, title, or any content you want to test the prompt against..."
-            className="w-full h-40 rounded-md border border-neutral-700 bg-neutral-950 px-4 py-3 text-sm text-neutral-300 resize-none"
-          />
-        </div>
-
-        <div className="flex items-center gap-3">
-          <button
-            onClick={runTest}
-            disabled={testing || !testInput.trim()}
-            className="rounded-md bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-500 disabled:opacity-50"
-          >
-            {testing ? 'Running...' : '▶ Run Test'}
-          </button>
-          {error && <span className="text-sm text-red-400">{error}</span>}
-        </div>
-
-        {testOutput && (
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Output</label>
-            <pre className="p-4 rounded-md bg-emerald-950/50 border border-emerald-500/20 text-sm text-emerald-300 overflow-auto max-h-64 whitespace-pre-wrap">
-              {testOutput}
-            </pre>
-          </div>
-        )}
-      </div>
-
-      <div className="p-4 border-t border-neutral-800 flex justify-between items-center">
-        <p className="text-xs text-neutral-500">
-          Note: This runs the prompt against the test input using the configured model
-        </p>
-        <button
-          onClick={onClose}
-          className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
-        >
-          Close
-        </button>
-      </div>
+      <PlaygroundHeader prompt={prompt} />
+      <PlaygroundBody prompt={prompt} state={state} onRun={runTest} />
+      <PlaygroundFooter onClose={onClose} />
     </ModalWrapper>
   );
 }

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/components/form-fields.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/components/form-fields.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import type { PromptVersion } from '@/types/database';
+
+const inputClass =
+  'w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white';
+const labelClass = 'block text-sm text-neutral-400 mb-1';
+
+export function TestNameField({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="testName" className={labelClass}>
+        Test Name (optional)
+      </label>
+      <input
+        id="testName"
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="e.g., Tagger mutual exclusivity test"
+        className={inputClass}
+      />
+    </div>
+  );
+}
+
+export function AgentSelect({
+  agents,
+  value,
+  onChange,
+}: {
+  agents: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="agentSelect" className={labelClass}>
+        Agent
+      </label>
+      <select
+        id="agentSelect"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={inputClass}
+      >
+        {agents.map((agent) => (
+          <option key={agent} value={agent}>
+            {agent}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function VariantOptions({ prompts }: { prompts: PromptVersion[] }) {
+  return (
+    <>
+      <option value="">Select version</option>
+      {prompts.map((p) => (
+        <option key={p.version} value={p.version}>
+          {p.version} {p.stage === 'PRD' ? '(live)' : ''}
+        </option>
+      ))}
+    </>
+  );
+}
+
+interface VariantSelectProps {
+  id: string;
+  label: string;
+  color: string;
+  value: string;
+  onChange: (v: string) => void;
+  prompts: PromptVersion[];
+}
+
+export function VariantSelect({ id, label, color, value, onChange, prompts }: VariantSelectProps) {
+  return (
+    <div>
+      <label htmlFor={id} className={labelClass}>
+        {label} <span className={color}></span>
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={inputClass}
+      >
+        <VariantOptions prompts={prompts} />
+      </select>
+    </div>
+  );
+}
+
+export function TrafficSplitField({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="trafficSplit" className={labelClass}>
+        Traffic Split (Variant B %)
+      </label>
+      <input
+        id="trafficSplit"
+        type="range"
+        min="10"
+        max="90"
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full"
+      />
+      <div className="flex justify-between text-xs text-neutral-500 mt-1">
+        <span>A: {100 - value}%</span>
+        <span>B: {value}%</span>
+      </div>
+    </div>
+  );
+}
+
+export function SampleSizeField({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="sampleSize" className={labelClass}>
+        Sample Size
+      </label>
+      <input
+        id="sampleSize"
+        type="number"
+        min="10"
+        max="10000"
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className={inputClass}
+      />
+    </div>
+  );
+}
+
+export function ModalFooter({
+  onClose,
+  onCreate,
+  saving,
+}: {
+  onClose: () => void;
+  onCreate: () => void;
+  saving: boolean;
+}) {
+  return (
+    <div className="flex justify-end gap-2 mt-6">
+      <button onClick={onClose} className="px-4 py-2 text-sm text-neutral-400 hover:text-white">
+        Cancel
+      </button>
+      <button
+        onClick={onCreate}
+        disabled={saving}
+        className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
+      >
+        {saving ? 'Creating...' : 'Create Test'}
+      </button>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-content.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-content.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import type { PromptVersion } from '@/types/database';
+import {
+  TestNameField,
+  AgentSelect,
+  VariantSelect,
+  TrafficSplitField,
+  SampleSizeField,
+  ModalFooter,
+} from './form-fields';
+
+interface ModalContentProps {
+  name: string;
+  setName: (v: string) => void;
+  agents: string[];
+  agentName: string;
+  setAgentName: (v: string) => void;
+  agentPrompts: PromptVersion[];
+  variantA: string;
+  setVariantA: (v: string) => void;
+  variantB: string;
+  setVariantB: (v: string) => void;
+  trafficSplit: number;
+  setTrafficSplit: (v: number) => void;
+  sampleSize: number;
+  setSampleSize: (v: number) => void;
+  onClose: () => void;
+  onCreate: () => void;
+  saving: boolean;
+}
+
+interface VariantSelectsProps {
+  agentPrompts: PromptVersion[];
+  variantA: string;
+  setVariantA: (v: string) => void;
+  variantB: string;
+  setVariantB: (v: string) => void;
+}
+
+function VariantSelects({
+  agentPrompts,
+  variantA,
+  setVariantA,
+  variantB,
+  setVariantB,
+}: VariantSelectsProps) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <VariantSelect
+        id="variantA"
+        label="Variant A"
+        color="text-emerald-400"
+        value={variantA}
+        onChange={setVariantA}
+        prompts={agentPrompts}
+      />
+      <VariantSelect
+        id="variantB"
+        label="Variant B"
+        color="text-amber-400"
+        value={variantB}
+        onChange={setVariantB}
+        prompts={agentPrompts}
+      />
+    </div>
+  );
+}
+
+function SplitSizeFields({
+  trafficSplit,
+  setTrafficSplit,
+  sampleSize,
+  setSampleSize,
+}: {
+  trafficSplit: number;
+  setTrafficSplit: (v: number) => void;
+  sampleSize: number;
+  setSampleSize: (v: number) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <TrafficSplitField value={trafficSplit} onChange={setTrafficSplit} />
+      <SampleSizeField value={sampleSize} onChange={setSampleSize} />
+    </div>
+  );
+}
+
+export function ModalContent(props: ModalContentProps) {
+  return (
+    <>
+      <h2 className="text-lg font-bold text-white mb-4">Create A/B Test</h2>
+      <div className="space-y-4">
+        <TestNameField value={props.name} onChange={props.setName} />
+        <AgentSelect agents={props.agents} value={props.agentName} onChange={props.setAgentName} />
+        <VariantSelects
+          agentPrompts={props.agentPrompts}
+          variantA={props.variantA}
+          setVariantA={props.setVariantA}
+          variantB={props.variantB}
+          setVariantB={props.setVariantB}
+        />
+        <SplitSizeFields
+          trafficSplit={props.trafficSplit}
+          setTrafficSplit={props.setTrafficSplit}
+          sampleSize={props.sampleSize}
+          setSampleSize={props.setSampleSize}
+        />
+      </div>
+      <ModalFooter onClose={props.onClose} onCreate={props.onCreate} saving={props.saving} />
+    </>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-wrapper.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-wrapper.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+interface ModalWrapperProps {
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export function ModalWrapper({ onClose, children }: ModalWrapperProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/create-test-modal.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/create-test-modal.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import type { PromptVersion } from '@/types/database';
+import { ModalContent } from './components/modal-content';
+import { ModalWrapper } from './components/modal-wrapper';
 
 interface CreateTestModalProps {
   agents: string[];
@@ -11,177 +13,79 @@ interface CreateTestModalProps {
   onCreated: () => void;
 }
 
-export function CreateTestModal({ agents, prompts, onClose, onCreated }: CreateTestModalProps) {
+function useTestFormState(agents: string[], prompts: PromptVersion[]) {
   const [agentName, setAgentName] = useState(agents[0] || '');
   const [variantA, setVariantA] = useState('');
   const [variantB, setVariantB] = useState('');
   const [trafficSplit, setTrafficSplit] = useState(50);
   const [sampleSize, setSampleSize] = useState(100);
   const [name, setName] = useState('');
-  const [saving, setSaving] = useState(false);
-
-  const supabase = createClient();
-
   const agentPrompts = prompts.filter((p) => p.agent_name === agentName);
   const currentPrompt = agentPrompts.find((p) => p.stage === 'PRD');
-
   useEffect(() => {
-    if (currentPrompt) {
-      setVariantA(currentPrompt.version);
-    }
+    if (currentPrompt) setVariantA(currentPrompt.version);
   }, [agentName, currentPrompt]);
+  return {
+    agentName,
+    setAgentName,
+    variantA,
+    setVariantA,
+    variantB,
+    setVariantB,
+    trafficSplit,
+    setTrafficSplit,
+    sampleSize,
+    setSampleSize,
+    name,
+    setName,
+    agentPrompts,
+  };
+}
+
+function useCreateHandler(state: ReturnType<typeof useTestFormState>, onCreated: () => void) {
+  const [saving, setSaving] = useState(false);
+  const supabase = createClient();
 
   async function handleCreate() {
-    if (!variantA || !variantB) {
+    if (!state.variantA || !state.variantB) {
       alert('Please select both variants');
       return;
     }
-    if (variantA === variantB) {
+    if (state.variantA === state.variantB) {
       alert('Variants must be different');
       return;
     }
-
     setSaving(true);
-
     const { error } = await supabase.from('prompt_ab_test').insert({
-      agent_name: agentName,
-      variant_a_version: variantA,
-      variant_b_version: variantB,
-      traffic_split: trafficSplit / 100,
-      sample_size: sampleSize,
-      name: name || null,
+      agent_name: state.agentName,
+      variant_a_version: state.variantA,
+      variant_b_version: state.variantB,
+      traffic_split: state.trafficSplit / 100,
+      sample_size: state.sampleSize,
+      name: state.name || null,
       status: 'draft',
     });
-
     setSaving(false);
-
-    if (error) {
-      alert('Failed to create test: ' + error.message);
-    } else {
-      onCreated();
-    }
+    if (error) alert('Failed to create test: ' + error.message);
+    else onCreated();
   }
 
+  return { saving, handleCreate };
+}
+
+export function CreateTestModal({ agents, prompts, onClose, onCreated }: CreateTestModalProps) {
+  const state = useTestFormState(agents, prompts);
+  const { saving, handleCreate } = useCreateHandler(state, onCreated);
+
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
-    >
-      <div
-        className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-6"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h2 className="text-lg font-bold text-white mb-4">Create A/B Test</h2>
-
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Test Name (optional)</label>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g., Tagger mutual exclusivity test"
-              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Agent</label>
-            <select
-              value={agentName}
-              onChange={(e) => setAgentName(e.target.value)}
-              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-            >
-              {agents.map((agent) => (
-                <option key={agent} value={agent}>
-                  {agent}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm text-neutral-400 mb-1">
-                Variant A <span className="text-emerald-400">(Control)</span>
-              </label>
-              <select
-                value={variantA}
-                onChange={(e) => setVariantA(e.target.value)}
-                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-              >
-                <option value="">Select version</option>
-                {agentPrompts.map((p) => (
-                  <option key={p.version} value={p.version}>
-                    {p.version} {p.stage === 'PRD' ? '(live)' : ''}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm text-neutral-400 mb-1">
-                Variant B <span className="text-amber-400">(Challenger)</span>
-              </label>
-              <select
-                value={variantB}
-                onChange={(e) => setVariantB(e.target.value)}
-                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-              >
-                <option value="">Select version</option>
-                {agentPrompts.map((p) => (
-                  <option key={p.version} value={p.version}>
-                    {p.version} {p.stage === 'PRD' ? '(live)' : ''}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm text-neutral-400 mb-1">
-                Traffic Split (Variant B %)
-              </label>
-              <input
-                type="range"
-                min="10"
-                max="90"
-                value={trafficSplit}
-                onChange={(e) => setTrafficSplit(Number(e.target.value))}
-                className="w-full"
-              />
-              <div className="flex justify-between text-xs text-neutral-500 mt-1">
-                <span>A: {100 - trafficSplit}%</span>
-                <span>B: {trafficSplit}%</span>
-              </div>
-            </div>
-            <div>
-              <label className="block text-sm text-neutral-400 mb-1">Sample Size</label>
-              <input
-                type="number"
-                min="10"
-                max="10000"
-                value={sampleSize}
-                onChange={(e) => setSampleSize(Number(e.target.value))}
-                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-              />
-            </div>
-          </div>
-        </div>
-
-        <div className="flex justify-end gap-2 mt-6">
-          <button onClick={onClose} className="px-4 py-2 text-sm text-neutral-400 hover:text-white">
-            Cancel
-          </button>
-          <button
-            onClick={handleCreate}
-            disabled={saving}
-            className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
-          >
-            {saving ? 'Creating...' : 'Create Test'}
-          </button>
-        </div>
-      </div>
-    </div>
+    <ModalWrapper onClose={onClose}>
+      <ModalContent
+        {...state}
+        agents={agents}
+        onClose={onClose}
+        onCreate={handleCreate}
+        saving={saving}
+      />
+    </ModalWrapper>
   );
 }

--- a/apps/admin/src/app/(dashboard)/evals/components/agent-version-select.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/components/agent-version-select.tsx
@@ -19,6 +19,87 @@ interface AgentVersionSelectProps {
   showStage?: boolean;
 }
 
+function AgentDropdown({
+  agents,
+  value,
+  onChange,
+}: {
+  agents: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="agentSelect" className="block text-sm text-neutral-400 mb-1">
+        Agent
+      </label>
+      <select
+        id="agentSelect"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+      >
+        <option value="">Select agent...</option>
+        {agents.map((agent) => (
+          <option key={agent} value={agent}>
+            {agent}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function VersionOption({ p, showStage }: { p: PromptVersion; showStage: boolean }) {
+  const stageText = showStage && p.stage ? ` (${p.stage})` : '';
+  const currentMark = p.is_current ? ' ★' : '';
+  return (
+    <option value={p.id}>
+      {p.version}
+      {stageText}
+      {currentMark}
+    </option>
+  );
+}
+
+interface VersionDropdownProps {
+  prompts: PromptVersion[];
+  value: string;
+  onChange: (v: string) => void;
+  label: string;
+  disabled: boolean;
+  showStage: boolean;
+}
+
+function VersionDropdown({
+  prompts,
+  value,
+  onChange,
+  label,
+  disabled,
+  showStage,
+}: VersionDropdownProps) {
+  return (
+    <div>
+      <label htmlFor="versionSelect" className="block text-sm text-neutral-400 mb-1">
+        {label}
+      </label>
+      <select
+        id="versionSelect"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white disabled:opacity-50"
+      >
+        <option value="">Select version...</option>
+        {prompts.map((p) => (
+          <VersionOption key={p.id} p={p} showStage={showStage} />
+        ))}
+      </select>
+    </div>
+  );
+}
+
 export function AgentVersionSelect({
   agents,
   prompts,
@@ -30,45 +111,21 @@ export function AgentVersionSelect({
   showStage = false,
 }: AgentVersionSelectProps) {
   const agentPrompts = prompts.filter((p) => p.agent_name === selectedAgent);
-
+  const handleAgentChange = (v: string) => {
+    onAgentChange(v);
+    onVersionChange('');
+  };
   return (
     <>
-      <div>
-        <label className="block text-sm text-neutral-400 mb-1">Agent</label>
-        <select
-          value={selectedAgent}
-          onChange={(e) => {
-            onAgentChange(e.target.value);
-            onVersionChange('');
-          }}
-          className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-        >
-          <option value="">Select agent...</option>
-          {agents.map((agent) => (
-            <option key={agent} value={agent}>
-              {agent}
-            </option>
-          ))}
-        </select>
-      </div>
-      <div>
-        <label className="block text-sm text-neutral-400 mb-1">{versionLabel}</label>
-        <select
-          value={selectedVersion}
-          onChange={(e) => onVersionChange(e.target.value)}
-          disabled={!selectedAgent}
-          className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white disabled:opacity-50"
-        >
-          <option value="">Select version...</option>
-          {agentPrompts.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.version}
-              {showStage && p.stage ? ` (${p.stage})` : ''}
-              {p.is_current ? ' ★' : ''}
-            </option>
-          ))}
-        </select>
-      </div>
+      <AgentDropdown agents={agents} value={selectedAgent} onChange={handleAgentChange} />
+      <VersionDropdown
+        prompts={agentPrompts}
+        value={selectedVersion}
+        onChange={onVersionChange}
+        label={versionLabel}
+        disabled={!selectedAgent}
+        showStage={showStage}
+      />
     </>
   );
 }

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/components/HeadToHeadForm.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/components/HeadToHeadForm.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { ComparisonForm } from './comparison-form';
+import type { ComparisonState } from '../hooks/useComparisonState';
+
+interface StatusItem {
+  code: number;
+  name: string;
+}
+
+interface HeadToHeadFormProps {
+  agents: string[];
+  agentPrompts: { id: string; version: string; stage: string; agent_name: string }[];
+  statuses: StatusItem[];
+  filteredItems: { id: string }[];
+  state: ComparisonState;
+  onRun: () => void;
+  running: boolean;
+}
+
+/** Maps ComparisonState to the props expected by ComparisonForm */
+function buildFormProps(props: HeadToHeadFormProps) {
+  const { agents, agentPrompts, statuses, filteredItems, state, onRun, running } = props;
+  return {
+    agents,
+    selectedAgent: state.selectedAgent,
+    onAgentChange: state.handleAgentChange,
+    agentPrompts,
+    versionA: state.versionA,
+    setVersionA: state.setVersionA,
+    versionB: state.versionB,
+    setVersionB: state.setVersionB,
+    statuses,
+    statusFilter: state.statusFilter,
+    setStatusFilter: state.setStatusFilter,
+    searchQuery: state.searchQuery,
+    setSearchQuery: state.setSearchQuery,
+    selectedItem: state.selectedItem,
+    setSelectedItem: state.setSelectedItem,
+    filteredItems,
+    useLLMJudge: state.useLLMJudge,
+    setUseLLMJudge: state.setUseLLMJudge,
+    onRun,
+    running,
+  };
+}
+
+/**
+ * Wrapper component that connects ComparisonState to ComparisonForm.
+ * Reduces prop drilling in the main page component.
+ */
+export function HeadToHeadForm(props: HeadToHeadFormProps) {
+  return <ComparisonForm {...buildFormProps(props)} />;
+}

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/components/comparison-form.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/components/comparison-form.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { AgentSelect, VersionSelect } from './selects';
+import { ItemSelector } from './item-selector';
+import { ComparisonControls } from './controls';
+
+interface PromptItem {
+  id: string;
+  version: string;
+  stage: string;
+  agent_name: string;
+}
+
+interface StatusItem {
+  code: number;
+  name: string;
+}
+
+interface ComparisonFormProps {
+  agents: string[];
+  selectedAgent: string;
+  onAgentChange: (v: string) => void;
+  agentPrompts: PromptItem[];
+  versionA: string;
+  setVersionA: (v: string) => void;
+  versionB: string;
+  setVersionB: (v: string) => void;
+  statuses: StatusItem[];
+  statusFilter: string;
+  setStatusFilter: (v: string) => void;
+  searchQuery: string;
+  setSearchQuery: (v: string) => void;
+  selectedItem: string;
+  setSelectedItem: (v: string) => void;
+  filteredItems: { id: string }[];
+  useLLMJudge: boolean;
+  setUseLLMJudge: (v: boolean) => void;
+  onRun: () => void;
+  running: boolean;
+}
+
+function FormHeader() {
+  return <h2 className="text-lg font-semibold text-white mb-4">New Comparison</h2>;
+}
+
+function VersionSelectA({
+  agentPrompts,
+  versionA,
+  setVersionA,
+  disabled,
+}: {
+  agentPrompts: PromptItem[];
+  versionA: string;
+  setVersionA: (v: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <VersionSelect
+      id="h2hVersionA"
+      label="Version A (Control)"
+      value={versionA}
+      onChange={setVersionA}
+      disabled={disabled}
+      prompts={agentPrompts}
+    />
+  );
+}
+
+function VersionSelectB({
+  agentPrompts,
+  versionB,
+  setVersionB,
+  disabled,
+}: {
+  agentPrompts: PromptItem[];
+  versionB: string;
+  setVersionB: (v: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <VersionSelect
+      id="h2hVersionB"
+      label="Version B (Treatment)"
+      value={versionB}
+      onChange={setVersionB}
+      disabled={disabled}
+      prompts={agentPrompts}
+    />
+  );
+}
+
+function VersionSelects(props: ComparisonFormProps) {
+  const disabled = !props.selectedAgent;
+  return (
+    <>
+      <VersionSelectA
+        agentPrompts={props.agentPrompts}
+        versionA={props.versionA}
+        setVersionA={props.setVersionA}
+        disabled={disabled}
+      />
+      <VersionSelectB
+        agentPrompts={props.agentPrompts}
+        versionB={props.versionB}
+        setVersionB={props.setVersionB}
+        disabled={disabled}
+      />
+    </>
+  );
+}
+
+function FormGrid(props: ComparisonFormProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+      <AgentSelect
+        agents={props.agents}
+        value={props.selectedAgent}
+        onChange={props.onAgentChange}
+      />
+      <VersionSelects {...props} />
+      <ItemSelector
+        statuses={props.statuses}
+        statusFilter={props.statusFilter}
+        setStatusFilter={props.setStatusFilter}
+        searchQuery={props.searchQuery}
+        setSearchQuery={props.setSearchQuery}
+        selectedItem={props.selectedItem}
+        setSelectedItem={props.setSelectedItem}
+        filteredItems={props.filteredItems}
+      />
+    </div>
+  );
+}
+
+export function ComparisonForm(props: ComparisonFormProps) {
+  const runDisabled = props.running || !props.versionA || !props.versionB || !props.selectedItem;
+  return (
+    <div className="mb-8 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+      <FormHeader />
+      <FormGrid {...props} />
+      <ComparisonControls
+        useLLMJudge={props.useLLMJudge}
+        setUseLLMJudge={props.setUseLLMJudge}
+        onRun={props.onRun}
+        running={props.running}
+        disabled={runDisabled}
+      />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/components/controls.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/components/controls.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+function LLMJudgeCheckbox({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm text-neutral-400">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="rounded border-neutral-700 bg-neutral-800"
+      />
+      Use LLM Judge (experimental)
+    </label>
+  );
+}
+
+function RunButton({
+  onClick,
+  disabled,
+  running,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  running: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {running ? 'Running...' : 'Run Comparison'}
+    </button>
+  );
+}
+
+export function ComparisonControls({
+  useLLMJudge,
+  setUseLLMJudge,
+  onRun,
+  running,
+  disabled,
+}: {
+  useLLMJudge: boolean;
+  setUseLLMJudge: (v: boolean) => void;
+  onRun: () => void;
+  running: boolean;
+  disabled: boolean;
+}) {
+  return (
+    <div className="mt-4 flex items-center justify-between">
+      <LLMJudgeCheckbox checked={useLLMJudge} onChange={setUseLLMJudge} />
+      <RunButton onClick={onRun} disabled={disabled} running={running} />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/components/index.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/components/index.tsx
@@ -1,0 +1,7 @@
+export { AgentSelect, VersionSelect } from './selects';
+export * from './selects';
+export * from './item-selector';
+export * from './controls';
+export * from './results';
+export * from './comparison-form';
+export * from './HeadToHeadForm';

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/components/item-selector.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/components/item-selector.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { getItemLabel } from '../utils';
+
+interface StatusItem {
+  code: number;
+  name: string;
+}
+
+export function StatusFilterSelect({
+  value,
+  onChange,
+  statuses,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  statuses: StatusItem[];
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-32 rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white text-sm"
+    >
+      <option value="">All statuses</option>
+      {statuses.map((s) => (
+        <option key={s.code} value={s.code}>
+          {s.code} {s.name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+export function SearchInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="Search items..."
+      className="flex-1 rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white placeholder:text-neutral-500"
+    />
+  );
+}
+
+export function ItemList({
+  items,
+  selectedItem,
+  setSelectedItem,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  items: any[];
+  selectedItem: string;
+  setSelectedItem: (v: string) => void;
+}) {
+  const handleClick = (e: React.MouseEvent<HTMLSelectElement>) => {
+    const t = e.target as HTMLOptionElement;
+    if (t.value) setSelectedItem(t.value);
+  };
+
+  return (
+    <select
+      value={selectedItem}
+      onChange={(e) => setSelectedItem(e.target.value)}
+      onClick={handleClick}
+      className="w-full mt-2 rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white cursor-pointer"
+      size={5}
+    >
+      <ItemOptions items={items} />
+    </select>
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ItemOptions({ items }: { items: any[] }) {
+  if (items.length === 0) {
+    return (
+      <option value="" disabled>
+        No items match filters
+      </option>
+    );
+  }
+
+  return (
+    <>
+      {items.map((item) => {
+        const label = getItemLabel(item);
+        const displayLabel = label.length > 100 ? label.substring(0, 100) + '...' : label;
+        return (
+          <option key={item.id} value={item.id} title={label}>
+            {displayLabel}
+          </option>
+        );
+      })}
+    </>
+  );
+}
+
+interface ItemSelectorProps {
+  statuses: StatusItem[];
+  statusFilter: string;
+  setStatusFilter: (v: string) => void;
+  searchQuery: string;
+  setSearchQuery: (v: string) => void;
+  selectedItem: string;
+  setSelectedItem: (v: string) => void;
+  filteredItems: { id: string }[];
+}
+
+function FilterRow({
+  statuses,
+  statusFilter,
+  setStatusFilter,
+  setSelectedItem,
+  searchQuery,
+  setSearchQuery,
+}: ItemSelectorProps) {
+  const handleStatusChange = (v: string) => {
+    setStatusFilter(v);
+    setSelectedItem('');
+  };
+  return (
+    <div className="flex gap-2">
+      <StatusFilterSelect value={statusFilter} onChange={handleStatusChange} statuses={statuses} />
+      <SearchInput value={searchQuery} onChange={setSearchQuery} />
+    </div>
+  );
+}
+
+export function ItemSelector(props: ItemSelectorProps) {
+  return (
+    <div className="lg:col-span-2">
+      <span className="block text-sm text-neutral-400 mb-1">Test Item</span>
+      <FilterRow {...props} />
+      <ItemList
+        items={props.filteredItems}
+        selectedItem={props.selectedItem}
+        setSelectedItem={props.setSelectedItem}
+      />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/components/results.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/components/results.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { OutputDisplay } from '../output-display';
+
+export interface ComparisonResult {
+  itemId: string;
+  title: string;
+  versionA: string;
+  versionB: string;
+  outputA: Record<string, unknown>;
+  outputB: Record<string, unknown>;
+  winner?: 'A' | 'B' | 'tie';
+  reasoning?: string;
+}
+
+function ResultHeader({ result }: { result: ComparisonResult }) {
+  return (
+    <div className="mb-4">
+      <h3 className="text-sm font-medium text-neutral-300">{result.title}</h3>
+      <ResultMeta result={result} />
+    </div>
+  );
+}
+
+function ResultMeta({ result }: { result: ComparisonResult }) {
+  return (
+    <div className="flex gap-4 mt-2 text-xs text-neutral-500">
+      <span>Version A: {result.versionA}</span>
+      <span>Version B: {result.versionB}</span>
+      {result.winner && <span className="text-emerald-400">Winner: {result.winner}</span>}
+    </div>
+  );
+}
+
+function OutputColumn({ label, output }: { label: string; output: Record<string, unknown> }) {
+  return (
+    <div>
+      <h4 className="text-xs font-medium text-neutral-400 mb-2">{label}</h4>
+      <OutputDisplay output={output} />
+    </div>
+  );
+}
+
+function ResultOutputs({ result }: { result: ComparisonResult }) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <OutputColumn label="Output A" output={result.outputA} />
+      <OutputColumn label="Output B" output={result.outputB} />
+    </div>
+  );
+}
+
+function ResultReasoning({ reasoning }: { reasoning: string }) {
+  return (
+    <div className="mt-4 pt-4 border-t border-neutral-800">
+      <h4 className="text-xs font-medium text-neutral-400 mb-1">LLM Judge Reasoning</h4>
+      <p className="text-sm text-neutral-300">{reasoning}</p>
+    </div>
+  );
+}
+
+export function ResultCard({ result }: { result: ComparisonResult }) {
+  return (
+    <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+      <ResultHeader result={result} />
+      <ResultOutputs result={result} />
+      {result.reasoning && <ResultReasoning reasoning={result.reasoning} />}
+    </div>
+  );
+}
+
+export function ResultsList({ results }: { results: ComparisonResult[] }) {
+  if (results.length === 0) return null;
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold text-white">Results</h2>
+      {results.map((result, idx) => (
+        <ResultCard key={idx} result={result} />
+      ))}
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/components/selects.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/components/selects.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+interface PromptItem {
+  id: string;
+  version: string;
+  stage: string;
+}
+
+export function AgentSelect({
+  agents,
+  value,
+  onChange,
+}: {
+  agents: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="h2hAgent" className="block text-sm text-neutral-400 mb-1">
+        Agent
+      </label>
+      <select
+        id="h2hAgent"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+      >
+        <option value="">Select agent...</option>
+        {agents.map((agent) => (
+          <option key={agent} value={agent}>
+            {agent}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function VersionSelect({
+  id,
+  label,
+  value,
+  onChange,
+  disabled,
+  prompts,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  disabled: boolean;
+  prompts: PromptItem[];
+}) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm text-neutral-400 mb-1">
+        {label}
+      </label>
+      <VersionOptions
+        id={id}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        prompts={prompts}
+      />
+    </div>
+  );
+}
+
+function VersionOptions({
+  id,
+  value,
+  onChange,
+  disabled,
+  prompts,
+}: {
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  disabled: boolean;
+  prompts: PromptItem[];
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white disabled:opacity-50"
+    >
+      <option value="">Select version...</option>
+      {prompts.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.version} ({p.stage}) {p.stage === 'PRD' ? '★' : ''}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/hooks/useComparisonState.ts
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/hooks/useComparisonState.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import type { ComparisonResult } from '../components/index';
+
+/** Manages comparison results */
+function useResults() {
+  const [results, setResults] = useState<ComparisonResult[]>([]);
+  return { results, setResults };
+}
+
+/** Manages agent and version selection with reset on agent change */
+function useAgentVersionSelection() {
+  const [selectedAgent, setSelectedAgent] = useState('');
+  const [versionA, setVersionA] = useState('');
+  const [versionB, setVersionB] = useState('');
+
+  const handleAgentChange = (v: string) => {
+    setSelectedAgent(v);
+    setVersionA('');
+    setVersionB('');
+  };
+
+  return { selectedAgent, handleAgentChange, versionA, setVersionA, versionB, setVersionB };
+}
+
+/** Manages item selection and filtering */
+function useItemSelection(initialItemId: string) {
+  const [selectedItem, setSelectedItem] = useState(initialItemId);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  return {
+    selectedItem,
+    setSelectedItem,
+    statusFilter,
+    setStatusFilter,
+    searchQuery,
+    setSearchQuery,
+  };
+}
+
+/** Manages LLM judge toggle */
+function useLLMJudgeToggle() {
+  const [useLLMJudge, setUseLLMJudge] = useState(false);
+  return { useLLMJudge, setUseLLMJudge };
+}
+
+/**
+ * Combines all comparison form state into a single hook.
+ */
+export function useComparisonState(initialItemId: string) {
+  const resultsState = useResults();
+  const agentState = useAgentVersionSelection();
+  const itemState = useItemSelection(initialItemId);
+  const judgeState = useLLMJudgeToggle();
+
+  return {
+    ...resultsState,
+    ...agentState,
+    ...itemState,
+    ...judgeState,
+  };
+}
+
+export type ComparisonState = ReturnType<typeof useComparisonState>;

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/hooks/useDerivedData.ts
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/hooks/useDerivedData.ts
@@ -1,0 +1,30 @@
+import { filterItems } from '../utils';
+import type { ComparisonState } from './useComparisonState';
+
+interface PromptItem {
+  id: string;
+  agent_name: string;
+  version: string;
+  stage: string;
+}
+
+/**
+ * Derives computed data from prompts, items, and comparison state.
+ * Returns filtered/sorted lists for the comparison form.
+ */
+export function useDerivedData(
+  prompts: PromptItem[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  items: any[],
+  state: ComparisonState,
+) {
+  const agents = [...new Set(prompts.map((p) => p.agent_name))];
+
+  const agentPrompts = prompts
+    .filter((p) => p.agent_name === state.selectedAgent)
+    .sort((a, b) => a.version.localeCompare(b.version));
+
+  const filteredItems = filterItems(items, state.statusFilter, state.searchQuery);
+
+  return { agents, agentPrompts, filteredItems };
+}

--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/page.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/page.tsx
@@ -1,61 +1,38 @@
 'use client';
 
-import { Suspense, useState } from 'react';
+import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { PageHeader, LoadingState } from '../components';
-import { OutputDisplay } from './output-display';
 import { useHeadToHeadData } from './hooks/useHeadToHeadData';
 import { useComparison } from './hooks/useComparison';
-import { filterItems, getItemLabel } from './utils';
+import { useComparisonState } from './hooks/useComparisonState';
+import { useDerivedData } from './hooks/useDerivedData';
+import { ResultsList, HeadToHeadForm } from './components/index';
 
-interface ComparisonResult {
-  itemId: string;
-  title: string;
-  versionA: string;
-  versionB: string;
-  outputA: Record<string, unknown>;
-  outputB: Record<string, unknown>;
-  winner?: 'A' | 'B' | 'tie';
-  reasoning?: string;
+function useRunHandler(
+  state: ReturnType<typeof useComparisonState>,
+  runComparison: ReturnType<typeof useComparison>['runComparison'],
+) {
+  return () =>
+    runComparison({
+      selectedAgent: state.selectedAgent,
+      versionA: state.versionA,
+      versionB: state.versionB,
+      selectedItem: state.selectedItem,
+      useLLMJudge: state.useLLMJudge,
+      setResults: state.setResults,
+    });
 }
 
 function HeadToHeadContent() {
   const searchParams = useSearchParams();
-  const initialItemId = searchParams.get('item') || '';
-
   const { prompts, items, statuses, loading } = useHeadToHeadData();
   const { running, runComparison } = useComparison();
+  const state = useComparisonState(searchParams.get('item') || '');
+  const { agents, agentPrompts, filteredItems } = useDerivedData(prompts, items, state);
+  const handleRun = useRunHandler(state, runComparison);
 
-  const [results, setResults] = useState<ComparisonResult[]>([]);
-  const [selectedAgent, setSelectedAgent] = useState<string>('');
-  const [versionA, setVersionA] = useState<string>('');
-  const [versionB, setVersionB] = useState<string>('');
-  const [selectedItem, setSelectedItem] = useState<string>(initialItemId);
-  const [useLLMJudge, setUseLLMJudge] = useState(false);
-  const [statusFilter, setStatusFilter] = useState<string>('');
-  const [searchQuery, setSearchQuery] = useState<string>('');
-
-  const agents = [...new Set(prompts.map((p) => p.agent_name))];
-  const agentPrompts = prompts
-    .filter((p) => p.agent_name === selectedAgent)
-    .sort((a, b) => a.version.localeCompare(b.version));
-
-  const filteredItems = filterItems(items, statusFilter, searchQuery);
-
-  const handleRunComparison = () => {
-    runComparison({
-      selectedAgent,
-      versionA,
-      versionB,
-      selectedItem,
-      useLLMJudge,
-      setResults,
-    });
-  };
-
-  if (loading) {
-    return <LoadingState />;
-  }
+  if (loading) return <LoadingState />;
 
   return (
     <div>
@@ -63,170 +40,16 @@ function HeadToHeadContent() {
         title="Head-to-Head Comparison"
         description="Run the same input through two prompt versions and compare outputs side-by-side"
       />
-
-      <div className="mb-8 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
-        <h2 className="text-lg font-semibold text-white mb-4">New Comparison</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Agent</label>
-            <select
-              value={selectedAgent}
-              onChange={(e) => {
-                setSelectedAgent(e.target.value);
-                setVersionA('');
-                setVersionB('');
-              }}
-              className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-            >
-              <option value="">Select agent...</option>
-              {agents.map((agent) => (
-                <option key={agent} value={agent}>
-                  {agent}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Version A (Control)</label>
-            <select
-              value={versionA}
-              onChange={(e) => setVersionA(e.target.value)}
-              disabled={!selectedAgent}
-              className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white disabled:opacity-50"
-            >
-              <option value="">Select version...</option>
-              {agentPrompts.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.version} ({p.stage}) {p.stage === 'PRD' ? '★' : ''}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Version B (Treatment)</label>
-            <select
-              value={versionB}
-              onChange={(e) => setVersionB(e.target.value)}
-              disabled={!selectedAgent}
-              className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white disabled:opacity-50"
-            >
-              <option value="">Select version...</option>
-              {agentPrompts.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.version} ({p.stage}) {p.stage === 'PRD' ? '★' : ''}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="lg:col-span-2">
-            <label className="block text-sm text-neutral-400 mb-1">Test Item</label>
-            <div className="flex gap-2">
-              <select
-                value={statusFilter}
-                onChange={(e) => {
-                  setStatusFilter(e.target.value);
-                  setSelectedItem('');
-                }}
-                className="w-32 rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white text-sm"
-              >
-                <option value="">All statuses</option>
-                {statuses.map((s) => (
-                  <option key={s.code} value={s.code}>
-                    {s.code} {s.name}
-                  </option>
-                ))}
-              </select>
-              <input
-                type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search items..."
-                className="flex-1 rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white placeholder:text-neutral-500"
-              />
-            </div>
-            <select
-              value={selectedItem}
-              onChange={(e) => setSelectedItem(e.target.value)}
-              onClick={(e) => {
-                const target = e.target as HTMLOptionElement;
-                if (target.value) setSelectedItem(target.value);
-              }}
-              className="w-full mt-2 rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white cursor-pointer"
-              size={5}
-            >
-              {filteredItems.length === 0 ? (
-                <option value="" disabled>
-                  No items match filters
-                </option>
-              ) : (
-                filteredItems.map((item) => {
-                  const label = getItemLabel(item);
-                  return (
-                    <option key={item.id} value={item.id} title={label}>
-                      {label.length > 100 ? label.substring(0, 100) + '...' : label}
-                    </option>
-                  );
-                })
-              )}
-            </select>
-          </div>
-        </div>
-
-        <div className="mt-4 flex items-center justify-between">
-          <label className="flex items-center gap-2 text-sm text-neutral-400">
-            <input
-              type="checkbox"
-              checked={useLLMJudge}
-              onChange={(e) => setUseLLMJudge(e.target.checked)}
-              className="rounded border-neutral-700 bg-neutral-800"
-            />
-            Use LLM Judge (experimental)
-          </label>
-          <button
-            onClick={handleRunComparison}
-            disabled={running || !versionA || !versionB || !selectedItem}
-            className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {running ? 'Running...' : 'Run Comparison'}
-          </button>
-        </div>
-      </div>
-
-      {results.length > 0 && (
-        <div className="space-y-6">
-          <h2 className="text-lg font-semibold text-white">Results</h2>
-          {results.map((result, idx) => (
-            <div key={idx} className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
-              <div className="mb-4">
-                <h3 className="text-sm font-medium text-neutral-300">{result.title}</h3>
-                <div className="flex gap-4 mt-2 text-xs text-neutral-500">
-                  <span>Version A: {result.versionA}</span>
-                  <span>Version B: {result.versionB}</span>
-                  {result.winner && (
-                    <span className="text-emerald-400">Winner: {result.winner}</span>
-                  )}
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <h4 className="text-xs font-medium text-neutral-400 mb-2">Output A</h4>
-                  <OutputDisplay output={result.outputA} />
-                </div>
-                <div>
-                  <h4 className="text-xs font-medium text-neutral-400 mb-2">Output B</h4>
-                  <OutputDisplay output={result.outputB} />
-                </div>
-              </div>
-              {result.reasoning && (
-                <div className="mt-4 pt-4 border-t border-neutral-800">
-                  <h4 className="text-xs font-medium text-neutral-400 mb-1">LLM Judge Reasoning</h4>
-                  <p className="text-sm text-neutral-300">{result.reasoning}</p>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
+      <HeadToHeadForm
+        agents={agents}
+        agentPrompts={agentPrompts}
+        statuses={statuses}
+        filteredItems={filteredItems}
+        state={state}
+        onRun={handleRun}
+        running={running}
+      />
+      <ResultsList results={state.results} />
     </div>
   );
 }

--- a/apps/admin/src/app/(dashboard)/evals/llm-judge/components/index.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/llm-judge/components/index.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+interface PromptVersion {
+  id: string;
+  agent_name: string;
+  version: string;
+  stage: string;
+}
+
+export function PageHeader() {
+  return (
+    <header className="mb-6">
+      <h1 className="text-2xl font-bold text-white">LLM-as-Judge</h1>
+      <p className="text-neutral-400 mt-1">
+        Use a second LLM to evaluate agent output quality against criteria
+      </p>
+    </header>
+  );
+}
+
+export function AgentSelect({
+  agents,
+  value,
+  onChange,
+}: {
+  agents: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="judgeAgent" className="block text-sm text-neutral-400 mb-1">
+        Agent
+      </label>
+      <select
+        id="judgeAgent"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+      >
+        <option value="">Select agent...</option>
+        {agents.map((agent) => (
+          <option key={agent} value={agent}>
+            {agent}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+interface PromptSelectProps {
+  prompts: PromptVersion[];
+  value: string;
+  onChange: (v: string) => void;
+  disabled: boolean;
+}
+
+function PromptOptions({ prompts }: { prompts: PromptVersion[] }) {
+  return (
+    <>
+      <option value="">Select version...</option>
+      {prompts.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.version} {p.stage === 'PRD' ? '(live)' : ''}
+        </option>
+      ))}
+    </>
+  );
+}
+
+export function PromptSelect({ prompts, value, onChange, disabled }: PromptSelectProps) {
+  return (
+    <div>
+      <label htmlFor="judgePrompt" className="block text-sm text-neutral-400 mb-1">
+        Prompt Version
+      </label>
+      <select
+        id="judgePrompt"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white disabled:opacity-50"
+      >
+        <PromptOptions prompts={prompts} />
+      </select>
+    </div>
+  );
+}
+
+export function CriteriaInput({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="judgeCriteria" className="block text-sm text-neutral-400 mb-1">
+        Criteria
+      </label>
+      <input
+        id="judgeCriteria"
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
+        placeholder="quality, accuracy, completeness"
+      />
+    </div>
+  );
+}
+
+export function RunButton({
+  onClick,
+  disabled,
+  running,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  running: boolean;
+}) {
+  return (
+    <div className="flex items-end">
+      <button
+        onClick={onClick}
+        disabled={disabled}
+        className="w-full rounded-lg bg-sky-600 px-4 py-2 text-white hover:bg-sky-500 disabled:opacity-50"
+      >
+        {running ? 'Running...' : 'Run Eval'}
+      </button>
+    </div>
+  );
+}
+
+export { type PromptVersion };

--- a/apps/admin/src/app/(dashboard)/evals/llm-judge/components/runs-table.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/llm-judge/components/runs-table.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+interface EvalRun {
+  id: string;
+  agent_name: string;
+  prompt_version: string;
+  eval_type: string;
+  total_examples: number;
+  passed: number | null;
+  failed: number | null;
+  score: number | null;
+  status: string;
+  created_at: string;
+  finished_at: string | null;
+}
+
+function ScoreCell({ score }: { score: number | null }) {
+  if (score === null) return <span className="text-neutral-500">—</span>;
+  const cls = score >= 0.8 ? 'text-emerald-400' : score >= 0.5 ? 'text-yellow-400' : 'text-red-400';
+  return <span className={cls}>{(score * 100).toFixed(1)}%</span>;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const cls =
+    status === 'completed'
+      ? 'bg-emerald-500/20 text-emerald-400'
+      : status === 'running'
+        ? 'bg-sky-500/20 text-sky-400'
+        : 'bg-red-500/20 text-red-400';
+  return <span className={`rounded-full px-2 py-0.5 text-xs ${cls}`}>{status}</span>;
+}
+
+function TableHeader() {
+  return (
+    <thead>
+      <tr className="border-b border-neutral-800 text-left text-sm text-neutral-400">
+        <th className="px-4 py-3">Agent</th>
+        <th className="px-4 py-3">Version</th>
+        <th className="px-4 py-3">Examples</th>
+        <th className="px-4 py-3">Score</th>
+        <th className="px-4 py-3">Status</th>
+        <th className="px-4 py-3">Date</th>
+      </tr>
+    </thead>
+  );
+}
+
+function RunRow({ run }: { run: EvalRun }) {
+  return (
+    <tr className="border-b border-neutral-800/50 hover:bg-neutral-800/30">
+      <td className="px-4 py-3 text-white">{run.agent_name}</td>
+      <td className="px-4 py-3 text-neutral-300">{run.prompt_version}</td>
+      <td className="px-4 py-3 text-neutral-300">{run.total_examples}</td>
+      <td className="px-4 py-3">
+        <ScoreCell score={run.score} />
+      </td>
+      <td className="px-4 py-3">
+        <StatusBadge status={run.status} />
+      </td>
+      <td className="px-4 py-3 text-neutral-500 text-sm">
+        {new Date(run.created_at).toLocaleDateString()}
+      </td>
+    </tr>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="p-8 text-center text-neutral-500">
+      No LLM-as-Judge evaluations yet. Run one above!
+    </div>
+  );
+}
+
+export function RunsTable({ runs }: { runs: EvalRun[] }) {
+  if (runs.length === 0) return <EmptyState />;
+  return (
+    <table className="w-full">
+      <TableHeader />
+      <tbody>
+        {runs.map((run) => (
+          <RunRow key={run.id} run={run} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export { type EvalRun };

--- a/apps/admin/src/app/(dashboard)/evals/llm-judge/hooks/useLLMJudgeData.ts
+++ b/apps/admin/src/app/(dashboard)/evals/llm-judge/hooks/useLLMJudgeData.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState, useCallback } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { EvalRun } from '../components/runs-table';
+import type { PromptVersion } from '../components/index';
+
+export function useLLMJudgeData() {
+  const [runs, setRuns] = useState<EvalRun[]>([]);
+  const [prompts, setPrompts] = useState<PromptVersion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const supabase = createClient();
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    const [runsRes, promptsRes] = await Promise.all([
+      supabase
+        .from('eval_run')
+        .select('*')
+        .eq('eval_type', 'llm_judge')
+        .order('created_at', { ascending: false })
+        .limit(50),
+      supabase.from('prompt_version').select('id, agent_name, version, stage').order('agent_name'),
+    ]);
+    if (!runsRes.error) setRuns(runsRes.data || []);
+    if (!promptsRes.error) setPrompts(promptsRes.data || []);
+    setLoading(false);
+  }, [supabase]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  return { runs, prompts, loading, loadData };
+}

--- a/apps/admin/src/app/(dashboard)/evals/llm-judge/page.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/llm-judge/page.tsx
@@ -1,238 +1,159 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import { createClient } from '@/lib/supabase/client';
+import { useState } from 'react';
+import {
+  PageHeader,
+  AgentSelect,
+  PromptSelect,
+  CriteriaInput,
+  RunButton,
+} from './components/index';
+import { RunsTable } from './components/runs-table';
+import { useLLMJudgeData } from './hooks/useLLMJudgeData';
 
-interface EvalRun {
-  id: string;
-  agent_name: string;
-  prompt_version: string;
-  eval_type: string;
-  total_examples: number;
-  passed: number | null;
-  failed: number | null;
-  score: number | null;
-  status: string;
-  created_at: string;
-  finished_at: string | null;
+interface EvalFormProps {
+  agents: string[];
+  agentPrompts: { id: string; version: string; stage: string; agent_name: string }[];
+  selectedAgent: string;
+  onAgentChange: (v: string) => void;
+  selectedPrompt: string;
+  onPromptChange: (v: string) => void;
+  criteria: string;
+  onCriteriaChange: (v: string) => void;
+  onRun: () => void;
+  running: boolean;
 }
 
-interface PromptVersion {
-  id: string;
-  agent_name: string;
-  version: string;
-  stage: string;
+function EvalFormGrid(props: EvalFormProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <AgentSelect
+        agents={props.agents}
+        value={props.selectedAgent}
+        onChange={props.onAgentChange}
+      />
+      <PromptSelect
+        prompts={props.agentPrompts}
+        value={props.selectedPrompt}
+        onChange={props.onPromptChange}
+        disabled={!props.selectedAgent}
+      />
+      <CriteriaInput value={props.criteria} onChange={props.onCriteriaChange} />
+      <RunButton
+        onClick={props.onRun}
+        disabled={props.running || !props.selectedPrompt}
+        running={props.running}
+      />
+    </div>
+  );
+}
+
+function EvalForm(props: EvalFormProps) {
+  return (
+    <div className="mb-8 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+      <h2 className="text-lg font-semibold text-white mb-4">Run New Evaluation</h2>
+      <EvalFormGrid {...props} />
+    </div>
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function RunsSection({ runs }: { runs: any[] }) {
+  return (
+    <div className="rounded-lg border border-neutral-800 bg-neutral-900">
+      <div className="border-b border-neutral-800 px-4 py-3">
+        <h2 className="text-lg font-semibold text-white">Previous Runs</h2>
+      </div>
+      <RunsTable runs={runs} />
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <div className="text-neutral-400">Loading...</div>
+    </div>
+  );
+}
+
+function useLLMJudgeState(prompts: { agent_name: string }[]) {
+  const [running, setRunning] = useState(false);
+  const [selectedAgent, setSelectedAgent] = useState('');
+  const [selectedPrompt, setSelectedPrompt] = useState('');
+  const [criteria, setCriteria] = useState('quality, accuracy, and completeness');
+  const agents = [...new Set(prompts.map((p) => p.agent_name))];
+  const handleAgentChange = (v: string) => {
+    setSelectedAgent(v);
+    setSelectedPrompt('');
+  };
+  return {
+    running,
+    setRunning,
+    selectedAgent,
+    selectedPrompt,
+    setSelectedPrompt,
+    criteria,
+    setCriteria,
+    agents,
+    handleAgentChange,
+  };
+}
+
+async function runEvaluation(
+  selectedPrompt: string,
+  criteria: string,
+  setRunning: (v: boolean) => void,
+  loadData: () => void,
+) {
+  if (!selectedPrompt) {
+    alert('Please select a prompt version');
+    return;
+  }
+  setRunning(true);
+  try {
+    const res = await fetch('/api/evals/llm-judge', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ promptVersionId: selectedPrompt, criteria }),
+    });
+    if (res.ok) loadData();
+    else {
+      const data = await res.json();
+      alert('Failed to run eval: ' + data.error);
+    }
+  } catch {
+    alert('Network error');
+  } finally {
+    setRunning(false);
+  }
 }
 
 export default function LLMJudgePage() {
-  const [runs, setRuns] = useState<EvalRun[]>([]);
-  const [prompts, setPrompts] = useState<PromptVersion[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [running, setRunning] = useState(false);
-  const [selectedAgent, setSelectedAgent] = useState<string>('');
-  const [selectedPrompt, setSelectedPrompt] = useState<string>('');
-  const [criteria, setCriteria] = useState('quality, accuracy, and completeness');
+  const { runs, prompts, loading, loadData } = useLLMJudgeData();
+  const state = useLLMJudgeState(prompts);
+  const agentPrompts = prompts.filter((p) => p.agent_name === state.selectedAgent);
+  const handleRunEval = () =>
+    runEvaluation(state.selectedPrompt, state.criteria, state.setRunning, loadData);
 
-  const supabase = createClient();
-
-  const loadData = useCallback(async () => {
-    setLoading(true);
-
-    const [runsRes, promptsRes] = await Promise.all([
-      supabase
-        .from('eval_run')
-        .select('*')
-        .eq('eval_type', 'llm_judge')
-        .order('created_at', { ascending: false })
-        .limit(50),
-      supabase.from('prompt_version').select('id, agent_name, version, stage').order('agent_name'),
-    ]);
-
-    if (!runsRes.error) setRuns(runsRes.data || []);
-    if (!promptsRes.error) setPrompts(promptsRes.data || []);
-    setLoading(false);
-  }, [supabase]);
-
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
-
-  const agents = [...new Set(prompts.map((p) => p.agent_name))];
-  const agentPrompts = prompts.filter((p) => p.agent_name === selectedAgent);
-
-  async function handleRunEval() {
-    if (!selectedPrompt) {
-      alert('Please select a prompt version');
-      return;
-    }
-
-    setRunning(true);
-    try {
-      const res = await fetch('/api/evals/llm-judge', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          promptVersionId: selectedPrompt,
-          criteria,
-        }),
-      });
-
-      if (res.ok) {
-        loadData();
-      } else {
-        const data = await res.json();
-        alert('Failed to run eval: ' + data.error);
-      }
-    } catch {
-      alert('Network error');
-    } finally {
-      setRunning(false);
-    }
-  }
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-neutral-400">Loading...</div>
-      </div>
-    );
-  }
+  if (loading) return <LoadingState />;
 
   return (
     <div>
-      <header className="mb-6">
-        <h1 className="text-2xl font-bold text-white">LLM-as-Judge</h1>
-        <p className="text-neutral-400 mt-1">
-          Use a second LLM to evaluate agent output quality against criteria
-        </p>
-      </header>
-
-      {/* Run New Eval */}
-      <div className="mb-8 rounded-lg border border-neutral-800 bg-neutral-900 p-4">
-        <h2 className="text-lg font-semibold text-white mb-4">Run New Evaluation</h2>
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Agent</label>
-            <select
-              value={selectedAgent}
-              onChange={(e) => {
-                setSelectedAgent(e.target.value);
-                setSelectedPrompt('');
-              }}
-              className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-            >
-              <option value="">Select agent...</option>
-              {agents.map((agent) => (
-                <option key={agent} value={agent}>
-                  {agent}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Prompt Version</label>
-            <select
-              value={selectedPrompt}
-              onChange={(e) => setSelectedPrompt(e.target.value)}
-              disabled={!selectedAgent}
-              className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white disabled:opacity-50"
-            >
-              <option value="">Select version...</option>
-              {agentPrompts.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.version} {p.stage === 'PRD' ? '(live)' : ''}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Criteria</label>
-            <input
-              type="text"
-              value={criteria}
-              onChange={(e) => setCriteria(e.target.value)}
-              className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-              placeholder="quality, accuracy, completeness"
-            />
-          </div>
-          <div className="flex items-end">
-            <button
-              onClick={handleRunEval}
-              disabled={running || !selectedPrompt}
-              className="w-full rounded-lg bg-sky-600 px-4 py-2 text-white hover:bg-sky-500 disabled:opacity-50"
-            >
-              {running ? 'Running...' : 'Run Eval'}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Previous Runs */}
-      <div className="rounded-lg border border-neutral-800 bg-neutral-900">
-        <div className="border-b border-neutral-800 px-4 py-3">
-          <h2 className="text-lg font-semibold text-white">Previous Runs</h2>
-        </div>
-        {runs.length === 0 ? (
-          <div className="p-8 text-center text-neutral-500">
-            No LLM-as-Judge evaluations yet. Run one above!
-          </div>
-        ) : (
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-neutral-800 text-left text-sm text-neutral-400">
-                <th className="px-4 py-3">Agent</th>
-                <th className="px-4 py-3">Version</th>
-                <th className="px-4 py-3">Examples</th>
-                <th className="px-4 py-3">Score</th>
-                <th className="px-4 py-3">Status</th>
-                <th className="px-4 py-3">Date</th>
-              </tr>
-            </thead>
-            <tbody>
-              {runs.map((run) => (
-                <tr key={run.id} className="border-b border-neutral-800/50 hover:bg-neutral-800/30">
-                  <td className="px-4 py-3 text-white">{run.agent_name}</td>
-                  <td className="px-4 py-3 text-neutral-300">{run.prompt_version}</td>
-                  <td className="px-4 py-3 text-neutral-300">{run.total_examples}</td>
-                  <td className="px-4 py-3">
-                    {run.score !== null ? (
-                      <span
-                        className={
-                          run.score >= 0.8
-                            ? 'text-emerald-400'
-                            : run.score >= 0.5
-                              ? 'text-yellow-400'
-                              : 'text-red-400'
-                        }
-                      >
-                        {(run.score * 100).toFixed(1)}%
-                      </span>
-                    ) : (
-                      <span className="text-neutral-500">—</span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`rounded-full px-2 py-0.5 text-xs ${
-                        run.status === 'completed'
-                          ? 'bg-emerald-500/20 text-emerald-400'
-                          : run.status === 'running'
-                            ? 'bg-sky-500/20 text-sky-400'
-                            : 'bg-red-500/20 text-red-400'
-                      }`}
-                    >
-                      {run.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-neutral-500 text-sm">
-                    {new Date(run.created_at).toLocaleDateString()}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
+      <PageHeader />
+      <EvalForm
+        agents={state.agents}
+        agentPrompts={agentPrompts}
+        selectedAgent={state.selectedAgent}
+        onAgentChange={state.handleAgentChange}
+        selectedPrompt={state.selectedPrompt}
+        onPromptChange={state.setSelectedPrompt}
+        criteria={state.criteria}
+        onCriteriaChange={state.setCriteria}
+        onRun={handleRunEval}
+        running={state.running}
+      />
+      <RunsSection runs={runs} />
     </div>
   );
 }

--- a/apps/admin/src/app/(dashboard)/missed/components/missed-form/ClassificationSection.parts.tsx
+++ b/apps/admin/src/app/(dashboard)/missed/components/missed-form/ClassificationSection.parts.tsx
@@ -16,10 +16,10 @@ export function AudienceChips({
   toggleAudience: (audience: string) => void;
 }) {
   return (
-    <div>
-      <label className="block text-sm font-medium text-neutral-300 mb-2">
+    <fieldset>
+      <legend className="block text-sm font-medium text-neutral-300 mb-2">
         Who should see this?
-      </label>
+      </legend>
       <div className="flex flex-wrap gap-2">
         {audiences.map((aud) => (
           <button
@@ -32,6 +32,6 @@ export function AudienceChips({
           </button>
         ))}
       </div>
-    </div>
+    </fieldset>
   );
 }

--- a/apps/admin/src/app/(dashboard)/missed/components/missed-form/SubmitterBasics.parts.tsx
+++ b/apps/admin/src/app/(dashboard)/missed/components/missed-form/SubmitterBasics.parts.tsx
@@ -7,8 +7,11 @@ export function SubmitterNameField({
 }) {
   return (
     <div>
-      <label className="block text-sm font-medium text-neutral-300 mb-2">Name / Company</label>
+      <label htmlFor="submitterName" className="block text-sm font-medium text-neutral-300 mb-2">
+        Name / Company
+      </label>
       <input
+        id="submitterName"
         type="text"
         value={submitterName}
         onChange={(e) => setSubmitterName(e.target.value)}
@@ -30,8 +33,11 @@ export function SubmitterChannelSelect({
 }) {
   return (
     <div>
-      <label className="block text-sm font-medium text-neutral-300 mb-2">Channel</label>
+      <label htmlFor="submitterChannel" className="block text-sm font-medium text-neutral-300 mb-2">
+        Channel
+      </label>
       <select
+        id="submitterChannel"
         value={submitterChannel}
         onChange={(e) => setSubmitterChannel(e.target.value)}
         className="w-full rounded-lg border border-neutral-700 bg-neutral-800 px-4 py-2 text-white focus:border-sky-500 focus:outline-none"

--- a/apps/admin/src/app/(dashboard)/missed/components/missed-form/SubmitterSection.parts.tsx
+++ b/apps/admin/src/app/(dashboard)/missed/components/missed-form/SubmitterSection.parts.tsx
@@ -35,10 +35,10 @@ export function SubmitterAudience({
   audiences: Array<{ value: string; label: string; description: string }>;
 }) {
   return (
-    <div>
-      <label className="block text-sm font-medium text-neutral-300 mb-2">
+    <fieldset>
+      <legend className="block text-sm font-medium text-neutral-300 mb-2">
         Their Role / Audience <span className="text-red-400">*</span>
-      </label>
+      </legend>
       <div className="grid grid-cols-2 gap-2">
         {audiences.map((aud) => (
           <button
@@ -52,7 +52,7 @@ export function SubmitterAudience({
           </button>
         ))}
       </div>
-    </div>
+    </fieldset>
   );
 }
 
@@ -66,8 +66,8 @@ export function SubmitterUrgency({
   urgencyOptions: Array<{ value: string; label: string; color: string }>;
 }) {
   return (
-    <div>
-      <label className="block text-sm font-medium text-neutral-300 mb-2">Urgency</label>
+    <fieldset>
+      <legend className="block text-sm font-medium text-neutral-300 mb-2">Urgency</legend>
       <div className="flex gap-2">
         {urgencyOptions.map((opt) => (
           <button
@@ -80,6 +80,6 @@ export function SubmitterUrgency({
           </button>
         ))}
       </div>
-    </div>
+    </fieldset>
   );
 }

--- a/apps/admin/src/app/(dashboard)/missed/components/missed-form/WhySection.parts.tsx
+++ b/apps/admin/src/app/(dashboard)/missed/components/missed-form/WhySection.parts.tsx
@@ -45,10 +45,11 @@ export function VerbatimField({
 }) {
   return (
     <div>
-      <label className="block text-sm font-medium text-neutral-300 mb-2">
+      <label htmlFor="verbatim" className="block text-sm font-medium text-neutral-300 mb-2">
         Their exact words (optional)
       </label>
       <input
+        id="verbatim"
         type="text"
         value={verbatimComment}
         onChange={(e) => setVerbatimComment(e.target.value)}

--- a/apps/admin/src/app/(dashboard)/sources/components/FilterBar.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/FilterBar.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { CategoryFilter, TierFilter, StatusFilter, HealthFilter } from './FilterComponents';
+import type { FilterCategory, FilterTier, FilterEnabled, FilterHealth } from '../types';
+
+interface FilterBarProps {
+  filterCategory: FilterCategory;
+  setFilterCategory: (v: FilterCategory) => void;
+  filterTier: FilterTier;
+  setFilterTier: (v: FilterTier) => void;
+  filterEnabled: FilterEnabled;
+  setFilterEnabled: (v: FilterEnabled) => void;
+  filterHealth: FilterHealth;
+  setFilterHealth: (v: FilterHealth) => void;
+  categories: string[];
+}
+
+export function FilterBar({
+  filterCategory,
+  setFilterCategory,
+  filterTier,
+  setFilterTier,
+  filterEnabled,
+  setFilterEnabled,
+  filterHealth,
+  setFilterHealth,
+  categories,
+}: FilterBarProps) {
+  return (
+    <div className="mb-6 flex flex-wrap gap-4 rounded-lg border border-neutral-800 bg-neutral-900/60 p-4">
+      <CategoryFilter value={filterCategory} onChange={setFilterCategory} categories={categories} />
+      <TierFilter value={filterTier} onChange={setFilterTier} />
+      <StatusFilter value={filterEnabled} onChange={setFilterEnabled} />
+      <HealthFilter value={filterHealth} onChange={setFilterHealth} />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/sources/components/FilterComponents.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/FilterComponents.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import type { FilterTier, FilterEnabled, FilterHealth } from '../types';
+
+export function PageHeader({ onAdd }: { onAdd: () => void }) {
+  return (
+    <header className="mb-6 flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-bold text-white">Sources</h1>
+        <p className="mt-1 text-sm text-neutral-400">Configure discovery sources and priorities</p>
+      </div>
+      <button
+        onClick={onAdd}
+        className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500"
+      >
+        + Add Source
+      </button>
+    </header>
+  );
+}
+
+export function StatsBadges({
+  stats,
+}: {
+  stats: { total: number; enabled: number; premium: number; withRss: number; withScraper: number };
+}) {
+  return (
+    <div className="mb-6 flex flex-wrap gap-3 text-sm">
+      <span className="rounded-full bg-neutral-800 px-3 py-1">{stats.total} total</span>
+      <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-3 py-1">
+        {stats.enabled} enabled
+      </span>
+      <span className="rounded-full bg-amber-500/20 text-amber-300 px-3 py-1">
+        {stats.premium} premium
+      </span>
+      <span className="rounded-full bg-sky-500/20 text-sky-300 px-3 py-1">{stats.withRss} RSS</span>
+      <span className="rounded-full bg-purple-500/20 text-purple-300 px-3 py-1">
+        {stats.withScraper} scrapers
+      </span>
+    </div>
+  );
+}
+
+export function Legend() {
+  return (
+    <div className="mb-6 flex flex-wrap items-center gap-6 text-xs text-neutral-500">
+      <span className="font-medium">Discovery:</span>
+      <span title="RSS Feed">📡 RSS</span>
+      <span title="Sitemap">🗺️ Sitemap</span>
+      <span title="Custom scraper">🤖 Scraper</span>
+      <span className="ml-4 font-medium">Health:</span>
+      <span className="text-emerald-400">🟢 Healthy</span>
+      <span className="text-amber-400">🟡 Warning (low yield or minor errors)</span>
+      <span className="text-red-400">🔴 Errors (&gt;30% fail rate)</span>
+      <span className="text-neutral-500">⚪ Inactive (&gt;7d since last run)</span>
+    </div>
+  );
+}
+
+export function CategoryFilter({
+  value,
+  onChange,
+  categories,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  categories: string[];
+}) {
+  return (
+    <div>
+      <label htmlFor="filterCategory" className="block text-xs text-neutral-400 mb-1">
+        Category
+      </label>
+      <select
+        id="filterCategory"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-white"
+      >
+        <option value="all">All categories</option>
+        {categories.map((cat) => (
+          <option key={cat} value={cat}>
+            {cat}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function TierFilter({
+  value,
+  onChange,
+}: {
+  value: FilterTier;
+  onChange: (v: FilterTier) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="filterTier" className="block text-xs text-neutral-400 mb-1">
+        Tier
+      </label>
+      <select
+        id="filterTier"
+        value={value}
+        onChange={(e) => onChange(e.target.value as FilterTier)}
+        className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-white"
+      >
+        <option value="all">All tiers</option>
+        <option value="standard">Standard</option>
+        <option value="premium">Premium</option>
+      </select>
+    </div>
+  );
+}
+
+export function StatusFilter({
+  value,
+  onChange,
+}: {
+  value: FilterEnabled;
+  onChange: (v: FilterEnabled) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="filterStatus" className="block text-xs text-neutral-400 mb-1">
+        Status
+      </label>
+      <select
+        id="filterStatus"
+        value={value}
+        onChange={(e) => onChange(e.target.value as FilterEnabled)}
+        className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-white"
+      >
+        <option value="all">All</option>
+        <option value="true">Enabled</option>
+        <option value="false">Disabled</option>
+      </select>
+    </div>
+  );
+}
+
+export function HealthFilter({
+  value,
+  onChange,
+}: {
+  value: FilterHealth;
+  onChange: (v: FilterHealth) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="filterHealth" className="block text-xs text-neutral-400 mb-1">
+        Health
+      </label>
+      <select
+        id="filterHealth"
+        value={value}
+        onChange={(e) => onChange(e.target.value as FilterHealth)}
+        className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-1.5 text-sm text-white"
+      >
+        <option value="all">All health</option>
+        <option value="healthy">🟢 Healthy</option>
+        <option value="warning">🟡 Warning</option>
+        <option value="error">🔴 Errors</option>
+        <option value="inactive">⚪ Inactive</option>
+      </select>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/sources/components/SourceForm.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/SourceForm.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import {
+  NameSlugFields,
+  DomainField,
+  CategoryTierFields,
+  UrlFields,
+  PriorityField,
+  CheckboxFields,
+  FormFooter,
+  type FormData,
+  type SetFormData,
+} from './source-form-fields';
+
+interface SourceFormProps {
+  formData: FormData;
+  setFormData: SetFormData;
+  isEdit: boolean;
+  onSubmit: (e: React.FormEvent) => void;
+  onClose: () => void;
+  saving: boolean;
+}
+
+export function SourceForm({
+  formData,
+  setFormData,
+  isEdit,
+  onSubmit,
+  onClose,
+  saving,
+}: SourceFormProps) {
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <NameSlugFields formData={formData} setFormData={setFormData} isEdit={isEdit} />
+      <DomainField formData={formData} setFormData={setFormData} />
+      <CategoryTierFields formData={formData} setFormData={setFormData} />
+      <UrlFields formData={formData} setFormData={setFormData} />
+      <PriorityField formData={formData} setFormData={setFormData} />
+      <CheckboxFields formData={formData} setFormData={setFormData} />
+      <FormFooter onClose={onClose} saving={saving} />
+    </form>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/sources/components/SourceModal.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/SourceModal.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState } from 'react';
-import { createClient } from '@/lib/supabase/client';
 import type { Source } from '@/types/database';
+import { defaultFormData, type FormData } from './source-form-fields';
+import { SourceForm } from './SourceForm';
+import { useSourceModalSubmit } from '../hooks/useSourceModalSubmit';
 
 interface SourceModalProps {
   source: Source | null;
@@ -10,58 +12,7 @@ interface SourceModalProps {
   onSave: () => void;
 }
 
-export function SourceModal({ source, onClose, onSave }: SourceModalProps) {
-  const [formData, setFormData] = useState<Partial<Source>>(
-    source || {
-      name: '',
-      slug: '',
-      domain: '',
-      category: 'vendor',
-      tier: 'standard',
-      enabled: true,
-      sort_order: 500,
-      rss_feed: '',
-      sitemap_url: '',
-      description: '',
-      show_on_external_page: false,
-    },
-  );
-  const [saving, setSaving] = useState(false);
-
-  const supabase = createClient();
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setSaving(true);
-
-    const dataToSave = {
-      ...formData,
-      rss_feed: formData.rss_feed || null,
-      sitemap_url: formData.sitemap_url || null,
-      description: formData.description || null,
-    };
-
-    let error;
-    if (source) {
-      const { error: updateError } = await supabase
-        .from('kb_source')
-        .update(dataToSave)
-        .eq('slug', source.slug);
-      error = updateError;
-    } else {
-      const { error: insertError } = await supabase.from('kb_source').insert(dataToSave);
-      error = insertError;
-    }
-
-    setSaving(false);
-
-    if (error) {
-      alert('Failed to save: ' + error.message);
-    } else {
-      onSave();
-    }
-  }
-
+function ModalWrapper({ onClose, children }: { onClose: () => void; children: React.ReactNode }) {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
@@ -71,153 +22,27 @@ export function SourceModal({ source, onClose, onSave }: SourceModalProps) {
         className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-6"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="text-lg font-bold text-white mb-4">
-          {source ? 'Edit Source' : 'Add Source'}
-        </h2>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm text-neutral-400 mb-1">Name</label>
-              <input
-                type="text"
-                value={formData.name || ''}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-                required
-              />
-            </div>
-            <div>
-              <label className="block text-sm text-neutral-400 mb-1">Slug</label>
-              <input
-                type="text"
-                value={formData.slug || ''}
-                onChange={(e) => setFormData({ ...formData, slug: e.target.value })}
-                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-                required
-                disabled={!!source}
-              />
-            </div>
-          </div>
-
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Domain</label>
-            <input
-              type="text"
-              value={formData.domain || ''}
-              onChange={(e) => setFormData({ ...formData, domain: e.target.value })}
-              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-              placeholder="example.com"
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm text-neutral-400 mb-1">Category</label>
-              <select
-                value={formData.category || ''}
-                onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-              >
-                <option value="regulator">Regulator</option>
-                <option value="central_bank">Central Bank</option>
-                <option value="vendor">Vendor</option>
-                <option value="research">Research</option>
-                <option value="consulting">Consulting</option>
-                <option value="media_outlet">Media Outlet</option>
-                <option value="standards_body">Standards Body</option>
-                <option value="academic">Academic</option>
-                <option value="government_body">Government Body</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm text-neutral-400 mb-1">Tier</label>
-              <select
-                value={formData.tier || 'standard'}
-                onChange={(e) =>
-                  setFormData({ ...formData, tier: e.target.value as 'standard' | 'premium' })
-                }
-                className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-              >
-                <option value="standard">Standard</option>
-                <option value="premium">Premium</option>
-              </select>
-            </div>
-          </div>
-
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">RSS Feed URL</label>
-            <input
-              type="text"
-              value={formData.rss_feed || ''}
-              onChange={(e) => setFormData({ ...formData, rss_feed: e.target.value })}
-              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-              placeholder="https://..."
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Sitemap URL</label>
-            <input
-              type="text"
-              value={formData.sitemap_url || ''}
-              onChange={(e) => setFormData({ ...formData, sitemap_url: e.target.value })}
-              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-              placeholder="https://..."
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm text-neutral-400 mb-1">Priority (sort order)</label>
-            <input
-              type="number"
-              value={formData.sort_order || 500}
-              onChange={(e) => setFormData({ ...formData, sort_order: parseInt(e.target.value) })}
-              className="w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white"
-            />
-          </div>
-
-          <div className="flex items-center gap-4">
-            <label className="flex items-center gap-2 text-sm text-neutral-400">
-              <input
-                type="checkbox"
-                checked={formData.enabled || false}
-                onChange={(e) => setFormData({ ...formData, enabled: e.target.checked })}
-                className="rounded border-neutral-700 bg-neutral-800"
-              />
-              Enabled
-            </label>
-            <label className="flex items-center gap-2 text-sm text-neutral-400">
-              <input
-                type="checkbox"
-                checked={formData.show_on_external_page || false}
-                onChange={(e) =>
-                  setFormData({ ...formData, show_on_external_page: e.target.checked })
-                }
-                className="rounded border-neutral-700 bg-neutral-800"
-              />
-              Show on external page
-            </label>
-          </div>
-
-          <div className="flex justify-end gap-3 pt-4 border-t border-neutral-800">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={saving}
-              className="rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
-            >
-              {saving ? 'Saving...' : 'Save'}
-            </button>
-          </div>
-        </form>
+        {children}
       </div>
     </div>
+  );
+}
+
+export function SourceModal({ source, onClose, onSave }: SourceModalProps) {
+  const [formData, setFormData] = useState<FormData>(source || defaultFormData);
+  const { saving, handleSubmit } = useSourceModalSubmit(source, formData, onSave);
+
+  return (
+    <ModalWrapper onClose={onClose}>
+      <h2 className="text-lg font-bold text-white mb-4">{source ? 'Edit Source' : 'Add Source'}</h2>
+      <SourceForm
+        formData={formData}
+        setFormData={setFormData}
+        isEdit={!!source}
+        onSubmit={handleSubmit}
+        onClose={onClose}
+        saving={saving}
+      />
+    </ModalWrapper>
   );
 }

--- a/apps/admin/src/app/(dashboard)/sources/components/SourcesContent.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/SourcesContent.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import type { Source } from '@/types/database';
+import { SourceModal } from './SourceModal';
+import { SourceTable } from './SourceTable';
+import { PageHeader, StatsBadges, Legend } from './FilterComponents';
+import { FilterBar } from './FilterBar';
+import { getDiscoveryInfo, getHealthBadge, getCategoryColor, calculateStats } from '../utils';
+import { filterSources, useSourceFilters } from '../hooks';
+
+interface SourcesContentProps {
+  sources: Source[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  healthData: Map<string, any>;
+  toggleEnabled: (s: Source) => void;
+  filters: ReturnType<typeof useSourceFilters>;
+  modal: {
+    editingSource: Source | null;
+    showModal: boolean;
+    openAdd: () => void;
+    openEdit: (s: Source) => void;
+    closeModal: () => void;
+    handleSave: () => void;
+  };
+  formatTimeAgo: (d: string | null) => string;
+}
+
+function HeaderSection({
+  modal,
+  stats,
+}: {
+  modal: SourcesContentProps['modal'];
+  stats: ReturnType<typeof calculateStats>;
+}) {
+  return (
+    <>
+      <PageHeader onAdd={modal.openAdd} />
+      <StatsBadges stats={stats} />
+      <Legend />
+    </>
+  );
+}
+
+function TableSection({
+  filteredSources,
+  healthData,
+  toggleEnabled,
+  modal,
+  formatTimeAgo,
+}: {
+  filteredSources: Source[];
+  healthData: SourcesContentProps['healthData'];
+  toggleEnabled: SourcesContentProps['toggleEnabled'];
+  modal: SourcesContentProps['modal'];
+  formatTimeAgo: SourcesContentProps['formatTimeAgo'];
+}) {
+  return (
+    <SourceTable
+      sources={filteredSources}
+      healthData={healthData}
+      onToggleEnabled={toggleEnabled}
+      onEdit={modal.openEdit}
+      formatTimeAgo={formatTimeAgo}
+      getHealthBadge={getHealthBadge}
+      getDiscoveryInfo={getDiscoveryInfo}
+      getCategoryColor={getCategoryColor}
+    />
+  );
+}
+
+function ModalSection({ modal }: { modal: SourcesContentProps['modal'] }) {
+  if (!modal.showModal) return null;
+  return (
+    <SourceModal
+      source={modal.editingSource}
+      onClose={modal.closeModal}
+      onSave={modal.handleSave}
+    />
+  );
+}
+
+export function SourcesContent({
+  sources,
+  healthData,
+  toggleEnabled,
+  filters,
+  modal,
+  formatTimeAgo,
+}: SourcesContentProps) {
+  const filteredSources = filterSources({ sources, healthData, ...filters });
+  const categories = [...new Set(sources.map((s) => s.category).filter(Boolean))];
+  return (
+    <div>
+      <HeaderSection modal={modal} stats={calculateStats(sources)} />
+      <FilterBar {...filters} categories={categories} />
+      <TableSection
+        filteredSources={filteredSources}
+        healthData={healthData}
+        toggleEnabled={toggleEnabled}
+        modal={modal}
+        formatTimeAgo={formatTimeAgo}
+      />
+      <ModalSection modal={modal} />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/sources/components/source-form-fields.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/source-form-fields.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import type { Source } from '@/types/database';
+
+type FormData = Partial<Source>;
+type SetFormData = React.Dispatch<React.SetStateAction<FormData>>;
+
+const inputClass =
+  'w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white';
+const labelClass = 'block text-sm text-neutral-400 mb-1';
+
+function NameField({ formData, setFormData }: { formData: FormData; setFormData: SetFormData }) {
+  return (
+    <div>
+      <label htmlFor="sourceName" className={labelClass}>
+        Name
+      </label>
+      <input
+        id="sourceName"
+        type="text"
+        value={formData.name || ''}
+        onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+        className={inputClass}
+        required
+      />
+    </div>
+  );
+}
+
+function SlugField({
+  formData,
+  setFormData,
+  disabled,
+}: {
+  formData: FormData;
+  setFormData: SetFormData;
+  disabled: boolean;
+}) {
+  return (
+    <div>
+      <label htmlFor="sourceSlug" className={labelClass}>
+        Slug
+      </label>
+      <input
+        id="sourceSlug"
+        type="text"
+        value={formData.slug || ''}
+        onChange={(e) => setFormData({ ...formData, slug: e.target.value })}
+        className={inputClass}
+        required
+        disabled={disabled}
+      />
+    </div>
+  );
+}
+
+export function NameSlugFields({
+  formData,
+  setFormData,
+  isEdit,
+}: {
+  formData: FormData;
+  setFormData: SetFormData;
+  isEdit: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <NameField formData={formData} setFormData={setFormData} />
+      <SlugField formData={formData} setFormData={setFormData} disabled={isEdit} />
+    </div>
+  );
+}
+
+export function DomainField({
+  formData,
+  setFormData,
+}: {
+  formData: FormData;
+  setFormData: SetFormData;
+}) {
+  return (
+    <div>
+      <label htmlFor="sourceDomain" className={labelClass}>
+        Domain
+      </label>
+      <input
+        id="sourceDomain"
+        type="text"
+        value={formData.domain || ''}
+        onChange={(e) => setFormData({ ...formData, domain: e.target.value })}
+        className={inputClass}
+        placeholder="example.com"
+      />
+    </div>
+  );
+}
+
+export { CategoryTierFields } from './source-form-selects';
+
+function RssField({ formData, setFormData }: { formData: FormData; setFormData: SetFormData }) {
+  return (
+    <div>
+      <label htmlFor="sourceRss" className={labelClass}>
+        RSS Feed URL
+      </label>
+      <input
+        id="sourceRss"
+        type="text"
+        value={formData.rss_feed || ''}
+        onChange={(e) => setFormData({ ...formData, rss_feed: e.target.value })}
+        className={inputClass}
+        placeholder="https://..."
+      />
+    </div>
+  );
+}
+
+function SitemapField({ formData, setFormData }: { formData: FormData; setFormData: SetFormData }) {
+  return (
+    <div>
+      <label htmlFor="sourceSitemap" className={labelClass}>
+        Sitemap URL
+      </label>
+      <input
+        id="sourceSitemap"
+        type="text"
+        value={formData.sitemap_url || ''}
+        onChange={(e) => setFormData({ ...formData, sitemap_url: e.target.value })}
+        className={inputClass}
+        placeholder="https://..."
+      />
+    </div>
+  );
+}
+
+export function UrlFields({
+  formData,
+  setFormData,
+}: {
+  formData: FormData;
+  setFormData: SetFormData;
+}) {
+  return (
+    <>
+      <RssField formData={formData} setFormData={setFormData} />
+      <SitemapField formData={formData} setFormData={setFormData} />
+    </>
+  );
+}
+
+export function PriorityField({
+  formData,
+  setFormData,
+}: {
+  formData: FormData;
+  setFormData: SetFormData;
+}) {
+  return (
+    <div>
+      <label htmlFor="sourcePriority" className={labelClass}>
+        Priority (sort order)
+      </label>
+      <input
+        id="sourcePriority"
+        type="number"
+        value={formData.sort_order || 500}
+        onChange={(e) => setFormData({ ...formData, sort_order: parseInt(e.target.value) })}
+        className={inputClass}
+      />
+    </div>
+  );
+}
+
+export function CheckboxFields({
+  formData,
+  setFormData,
+}: {
+  formData: FormData;
+  setFormData: SetFormData;
+}) {
+  return (
+    <div className="flex items-center gap-4">
+      <label className="flex items-center gap-2 text-sm text-neutral-400">
+        <input
+          type="checkbox"
+          checked={formData.enabled || false}
+          onChange={(e) => setFormData({ ...formData, enabled: e.target.checked })}
+          className="rounded border-neutral-700 bg-neutral-800"
+        />
+        Enabled
+      </label>
+      <label className="flex items-center gap-2 text-sm text-neutral-400">
+        <input
+          type="checkbox"
+          checked={formData.show_on_external_page || false}
+          onChange={(e) => setFormData({ ...formData, show_on_external_page: e.target.checked })}
+          className="rounded border-neutral-700 bg-neutral-800"
+        />
+        Show on external page
+      </label>
+    </div>
+  );
+}
+
+export function FormFooter({ onClose, saving }: { onClose: () => void; saving: boolean }) {
+  return (
+    <div className="flex justify-end gap-3 pt-4 border-t border-neutral-800">
+      <button
+        type="button"
+        onClick={onClose}
+        className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        disabled={saving}
+        className="rounded-md bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
+      >
+        {saving ? 'Saving...' : 'Save'}
+      </button>
+    </div>
+  );
+}
+
+export const defaultFormData: FormData = {
+  name: '',
+  slug: '',
+  domain: '',
+  category: 'vendor',
+  tier: 'standard',
+  enabled: true,
+  sort_order: 500,
+  rss_feed: '',
+  sitemap_url: '',
+  description: '',
+  show_on_external_page: false,
+};
+
+export type { FormData, SetFormData };

--- a/apps/admin/src/app/(dashboard)/sources/components/source-form-selects.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/source-form-selects.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import type { Source } from '@/types/database';
+
+type FormData = Partial<Source>;
+type SetFormData = React.Dispatch<React.SetStateAction<FormData>>;
+
+const inputClass =
+  'w-full rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-white';
+const labelClass = 'block text-sm text-neutral-400 mb-1';
+
+const CATEGORIES = [
+  { value: 'regulator', label: 'Regulator' },
+  { value: 'central_bank', label: 'Central Bank' },
+  { value: 'vendor', label: 'Vendor' },
+  { value: 'research', label: 'Research' },
+  { value: 'consulting', label: 'Consulting' },
+  { value: 'media_outlet', label: 'Media Outlet' },
+  { value: 'standards_body', label: 'Standards Body' },
+  { value: 'academic', label: 'Academic' },
+  { value: 'government_body', label: 'Government Body' },
+];
+
+function CategorySelect({
+  formData,
+  setFormData,
+}: {
+  formData: FormData;
+  setFormData: SetFormData;
+}) {
+  return (
+    <div>
+      <label htmlFor="sourceCategory" className={labelClass}>
+        Category
+      </label>
+      <select
+        id="sourceCategory"
+        value={formData.category || ''}
+        onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+        className={inputClass}
+      >
+        {CATEGORIES.map((c) => (
+          <option key={c.value} value={c.value}>
+            {c.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function TierSelect({ formData, setFormData }: { formData: FormData; setFormData: SetFormData }) {
+  return (
+    <div>
+      <label htmlFor="sourceTier" className={labelClass}>
+        Tier
+      </label>
+      <select
+        id="sourceTier"
+        value={formData.tier || 'standard'}
+        onChange={(e) =>
+          setFormData({ ...formData, tier: e.target.value as 'standard' | 'premium' })
+        }
+        className={inputClass}
+      >
+        <option value="standard">Standard</option>
+        <option value="premium">Premium</option>
+      </select>
+    </div>
+  );
+}
+
+export function CategoryTierFields({
+  formData,
+  setFormData,
+}: {
+  formData: FormData;
+  setFormData: SetFormData;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <CategorySelect formData={formData} setFormData={setFormData} />
+      <TierSelect formData={formData} setFormData={setFormData} />
+    </div>
+  );
+}
+
+export type { FormData, SetFormData };

--- a/apps/admin/src/app/(dashboard)/sources/hooks/index.ts
+++ b/apps/admin/src/app/(dashboard)/sources/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useSourceData } from './useSourceData';
+export { useFormatTimeAgo } from './useFormatTimeAgo';
+export { useSourceFilters, filterSources } from './useSourceFilters';

--- a/apps/admin/src/app/(dashboard)/sources/hooks/useFormatTimeAgo.ts
+++ b/apps/admin/src/app/(dashboard)/sources/hooks/useFormatTimeAgo.ts
@@ -1,0 +1,17 @@
+import { useRef, useCallback } from 'react';
+
+export function useFormatTimeAgo() {
+  const nowRef = useRef<number | null>(null);
+  // eslint-disable-next-line react-hooks/purity -- Date.now() computed once on mount for relative time display
+  if (nowRef.current === null) nowRef.current = Date.now();
+
+  return useCallback((date: string | null) => {
+    if (!date) return 'Never';
+    const diff = nowRef.current! - new Date(date).getTime();
+    const hours = Math.floor(diff / (60 * 60 * 1000));
+    if (hours < 1) return 'Just now';
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return days === 1 ? '1 day ago' : `${days} days ago`;
+  }, []);
+}

--- a/apps/admin/src/app/(dashboard)/sources/hooks/useSourceData.ts
+++ b/apps/admin/src/app/(dashboard)/sources/hooks/useSourceData.ts
@@ -1,0 +1,66 @@
+import { useState, useCallback, useEffect } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { Source } from '@/types/database';
+import type { SourceHealth } from '../types';
+
+function useSourceLoader(supabase: ReturnType<typeof createClient>) {
+  const [sources, setSources] = useState<Source[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadSources = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('kb_source')
+      .select('*')
+      .order('sort_order', { ascending: true });
+    if (error) console.error('Error loading sources:', error);
+    else setSources(data || []);
+    setLoading(false);
+  }, [supabase]);
+
+  return { sources, loading, loadSources };
+}
+
+function useHealthLoader() {
+  const [healthData, setHealthData] = useState<Map<string, SourceHealth>>(new Map());
+
+  const loadHealth = useCallback(async () => {
+    try {
+      const res = await fetch('/api/source-health');
+      if (!res.ok) return;
+      const data = await res.json();
+      const healthMap = new Map<string, SourceHealth>();
+      for (const h of data.health || []) healthMap.set(h.source_slug, h);
+      setHealthData(healthMap);
+    } catch (error) {
+      console.error('Error loading health:', error);
+    }
+  }, []);
+
+  return { healthData, loadHealth };
+}
+
+export function useSourceData() {
+  const supabase = createClient();
+  const { sources, loading, loadSources } = useSourceLoader(supabase);
+  const { healthData, loadHealth } = useHealthLoader();
+
+  useEffect(() => {
+    loadSources();
+    loadHealth();
+  }, [loadSources, loadHealth]);
+
+  const toggleEnabled = useCallback(
+    async (source: Source) => {
+      const { error } = await supabase
+        .from('kb_source')
+        .update({ enabled: !source.enabled })
+        .eq('slug', source.slug);
+      if (error) alert('Failed to update: ' + error.message);
+      else loadSources();
+    },
+    [supabase, loadSources],
+  );
+
+  return { sources, healthData, loading, loadSources, toggleEnabled };
+}

--- a/apps/admin/src/app/(dashboard)/sources/hooks/useSourceFilters.ts
+++ b/apps/admin/src/app/(dashboard)/sources/hooks/useSourceFilters.ts
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import type { Source } from '@/types/database';
+import type {
+  FilterCategory,
+  FilterTier,
+  FilterEnabled,
+  FilterHealth,
+  SourceHealth,
+} from '../types';
+
+export function useSourceFilters() {
+  const [filterCategory, setFilterCategory] = useState<FilterCategory>('all');
+  const [filterTier, setFilterTier] = useState<FilterTier>('all');
+  const [filterEnabled, setFilterEnabled] = useState<FilterEnabled>('all');
+  const [filterHealth, setFilterHealth] = useState<FilterHealth>('all');
+
+  return {
+    filterCategory,
+    setFilterCategory,
+    filterTier,
+    setFilterTier,
+    filterEnabled,
+    setFilterEnabled,
+    filterHealth,
+    setFilterHealth,
+  };
+}
+
+interface FilterOptions {
+  sources: Source[];
+  healthData: Map<string, SourceHealth>;
+  filterCategory: FilterCategory;
+  filterTier: FilterTier;
+  filterEnabled: FilterEnabled;
+  filterHealth: FilterHealth;
+}
+
+export function filterSources(opts: FilterOptions): Source[] {
+  const { sources, healthData, filterCategory, filterTier, filterEnabled, filterHealth } = opts;
+  return sources.filter((s) => {
+    if (filterCategory !== 'all' && s.category !== filterCategory) return false;
+    if (filterTier !== 'all' && s.tier !== filterTier) return false;
+    if (filterEnabled !== 'all' && String(s.enabled) !== filterEnabled) return false;
+    if (filterHealth !== 'all') {
+      const h = healthData.get(s.slug);
+      if ((h?.health_status || 'inactive') !== filterHealth) return false;
+    }
+    return true;
+  });
+}

--- a/apps/admin/src/app/(dashboard)/sources/hooks/useSourceModalSubmit.ts
+++ b/apps/admin/src/app/(dashboard)/sources/hooks/useSourceModalSubmit.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { Source } from '@/types/database';
+import type { FormData } from '../components/source-form-fields';
+
+function prepareDataToSave(formData: FormData) {
+  return {
+    ...formData,
+    rss_feed: formData.rss_feed || null,
+    sitemap_url: formData.sitemap_url || null,
+    description: formData.description || null,
+  };
+}
+
+/**
+ * Handles the submit logic for the source modal form.
+ */
+export function useSourceModalSubmit(
+  source: Source | null,
+  formData: FormData,
+  onSave: () => void,
+) {
+  const [saving, setSaving] = useState(false);
+  const supabase = createClient();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    const dataToSave = prepareDataToSave(formData);
+    const { error } = source
+      ? await supabase.from('kb_source').update(dataToSave).eq('slug', source.slug)
+      : await supabase.from('kb_source').insert(dataToSave);
+    setSaving(false);
+    if (error) alert('Failed to save: ' + error.message);
+    else onSave();
+  }
+
+  return { saving, handleSubmit };
+}


### PR DESCRIPTION
## Problem
SonarCloud flagged accessibility issues where form labels were not properly associated with their controls. Additionally, multiple files had functions exceeding the 30-line limit enforced by the Husky pre-commit hook.

## Root Cause
- Form elements missing `htmlFor`/`id` associations for accessibility
- Large monolithic components and hooks that grew organically without proper decomposition

## Solution
1. **Accessibility fixes**: Added proper `htmlFor`/`id` associations to all form labels across 12+ files
2. **Structural refactoring**: Extracted components and hooks into separate files with clear single responsibilities:
   - `sources/`: Extracted `FilterBar`, `SourceForm`, `SourcesContent`, hooks (`useSourceData`, `useSourceFilters`, `useSourceModalSubmit`)
   - `evals/head-to-head/`: Extracted `ComparisonForm`, `HeadToHeadForm`, `ItemSelector`, hooks (`useComparisonState`, `useDerivedData`)
   - `evals/llm-judge/`: Extracted `RunsTable`, `useLLMJudgeData` hook
   - `evals/ab-tests/`: Extracted `ModalContent`, `ModalWrapper`, form field components
   - `agents/`: Refactored `PromptEditModal` and `PromptPlayground` with smaller helper hooks

## Files Changed
- 38 files changed, 2894 insertions(+), 1288 deletions(-)
- Created new component and hook files for better code organization
- All functions now under 30 lines with meaningful abstractions