### PR TITLE
fix: resolve 'openai' instead of 'openai/package.json' in nightly workflow

### DIFF
--- a/.github/workflows/nightly-discovery.yml
+++ b/.github/workflows/nightly-discovery.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Debug module resolution (ESM)
         run: |
           npm -w services/agent-api exec -- node -p "process.cwd()"
-          npm -w services/agent-api exec -- node --input-type=module -e "console.log(await import.meta.resolve('openai/package.json'))"
+          npm -w services/agent-api exec -- node --input-type=module -e "console.log(await import.meta.resolve('openai'))"
           npm -w services/agent-api exec -- node --input-type=module -e "console.log(await import.meta.resolve('zod'))"
 
       - name: Run discovery (agent-api)


### PR DESCRIPTION
## Problem
Nightly discovery workflow failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` error because the debug step tried to resolve `openai/package.json`, which is not exported by the openai package.

## Root Cause
The openai package's `exports` field in package.json doesn't allow importing the `./package.json` subpath directly.

## Solution
Changed the debug step to resolve `openai` instead of `openai/package.json`. The debug step only verifies module resolution works - it doesn't need access to the package.json file.

## Files Changed
- `.github/workflows/nightly-discovery.yml` - Fixed module resolution debug command