### PR TITLE
fix: replace selector parameter with separate methods in submitArticle.ts (S2301)

### DIFF
--- a/apps/admin/src/app/(dashboard)/add/handlers/submitArticle.ts
+++ b/apps/admin/src/app/(dashboard)/add/handlers/submitArticle.ts
@@ -173,10 +173,12 @@ async function submitUpdate(ctx: SubmitCtx) {
   ctx.resetForm();
 }
 
-function getSuccessMessage(isPdf: boolean) {
-  return isPdf
-    ? 'PDF uploaded! Processing started - check History tab for progress.'
-    : 'Article submitted! Processing started - check History tab for progress.';
+function getPdfSuccessMessage() {
+  return 'PDF uploaded! Processing started - check History tab for progress.';
+}
+
+function getArticleSuccessMessage() {
+  return 'Article submitted! Processing started - check History tab for progress.';
 }
 
 async function submitCreate(
@@ -196,7 +198,7 @@ async function submitCreate(
   }
 
   ctx.setStatus('success');
-  ctx.setMessage(getSuccessMessage(isPdf));
+  ctx.setMessage(isPdf ? getPdfSuccessMessage() : getArticleSuccessMessage());
   ctx.resetForm();
 }
 


### PR DESCRIPTION
## Problem
S2301 violation: `getSuccessMessage(isPdf: boolean)` uses a boolean selector parameter.

## Solution
Split into two separate, clearly named methods:
- `getPdfSuccessMessage()`
- `getArticleSuccessMessage()`

## Related Sonar Doc
**Already documented:**
- Rule: `docs/architecture/quality/sonar-rules/methods-should-not-contain-selector-parameters.md`
- Lesson: `docs/architecture/quality/sonar-lessons/provide-multiple-methods-instead-of-boolean-selector-parameters.md`

## Files Changed
- `apps/admin/src/app/(dashboard)/add/handlers/submitArticle.ts` - Split boolean selector function

## Evidence
- **Lint**: 0 errors, 0 warnings