### PR TITLE
fix: replace div role=button with native button element (S6819)

### DIFF
--- a/apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx
@@ -10,11 +10,10 @@ interface ModalWrapperProps {
 
 export function ModalWrapper({ onClose, maxWidth = 'max-w-4xl', children }: ModalWrapperProps) {
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       aria-label="Close modal"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 w-full h-full border-none cursor-default"
       onClick={onClose}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
@@ -26,6 +25,6 @@ export function ModalWrapper({ onClose, maxWidth = 'max-w-4xl', children }: Moda
       >
         {children}
       </div>
-    </div>
+    </button>
   );
 }

--- a/docs/architecture/quality/sonar-lessons/use-native-html-elements-instead-of-aria-roles.md
+++ b/docs/architecture/quality/sonar-lessons/use-native-html-elements-instead-of-aria-roles.md
@@ -1,0 +1,75 @@
+# Use native HTML elements instead of ARIA roles
+
+**Rule ID**: typescript:S6819  
+**SonarCloud message**: "Use \<button> instead of the \"button\" role to ensure accessibility across all devices."  
+**Aliases**: div role="button", ARIA role instead of semantic HTML, prefer semantic elements
+
+**Rule**: [Prefer tag over ARIA role](../sonar-rules/prefer-tag-over-aria-role.md)
+
+---
+
+## Why this matters
+
+Semantic HTML elements like `<button>` have built-in accessibility support:
+
+- Keyboard navigation (focus, Enter/Space to activate)
+- Screen reader announcements
+- Universal browser support
+
+ARIA roles are a fallback, not a replacement for semantic HTML.
+
+---
+
+## Pattern to avoid
+
+```tsx
+{
+  /* BAD: Using ARIA role instead of native element */
+}
+<div
+  role="button"
+  tabIndex={0}
+  onClick={handleClick}
+  onKeyDown={(e) => e.key === 'Enter' && handleClick()}
+>
+  Click me
+</div>;
+```
+
+## Fix — Use native element
+
+```tsx
+{
+  /* GOOD: Native button with built-in accessibility */
+}
+<button type="button" onClick={handleClick}>
+  Click me
+</button>;
+```
+
+## Modal backdrop pattern
+
+For modal backdrops that close on click:
+
+```tsx
+{
+  /* GOOD: Button styled as backdrop */
+}
+<button
+  type="button"
+  aria-label="Close modal"
+  className="fixed inset-0 z-50 bg-black/50 w-full h-full border-none cursor-default"
+  onClick={onClose}
+  onKeyDown={(e) => e.key === 'Escape' && onClose()}
+>
+  <div role="dialog" aria-modal="true" onMouseDown={(e) => e.stopPropagation()}>
+    {children}
+  </div>
+</button>;
+```
+
+## Key points
+
+- Always prefer `<button>` over `<div role="button">`
+- Always prefer `<a href>` over `<div role="link">`
+- ARIA roles are for cases where no suitable HTML element exists

--- a/docs/architecture/quality/sonar-rules/prefer-tag-over-aria-role.md
+++ b/docs/architecture/quality/sonar-rules/prefer-tag-over-aria-role.md
@@ -1,0 +1,9 @@
+# Prefer tag over ARIA role
+
+**Rule ID**: typescript:S6819  
+**SonarCloud message**: "Use \<input type=\"button\">, \<input type=\"image\">, \<input type=\"reset\">, \<input type=\"submit\">, or \<button> instead of the \"button\" role to ensure accessibility across all devices."  
+**Aliases**: div role="button", ARIA role instead of semantic HTML, role="button" on div
+
+**Link**: https://rules.sonarsource.com/typescript/RSPEC-6819/
+
+**Lesson**: [Use native HTML elements instead of ARIA roles](../sonar-lessons/use-native-html-elements-instead-of-aria-roles.md)

--- a/docs/architecture/quality/sonarcloud.md
+++ b/docs/architecture/quality/sonarcloud.md
@@ -37,6 +37,7 @@ When you see a SonarCloud issue, extract the Rule ID and find the matching lesso
 | S2301   | [Provide multiple methods instead of boolean selectors](./sonar-lessons/provide-multiple-methods-instead-of-boolean-selector-parameters.md)  |
 | S6848   | [Add role and keyboard handling to interactive divs](./sonar-lessons/add-role-and-keyboard-handling-to-interactive-divs.md)                  |
 | S6842   | [Do not add interactive ARIA roles to non-interactive elements](./sonar-lessons/use-native-interactive-elements-or-add-proper-aria-roles.md) |
+| S6819   | [Use native HTML elements instead of ARIA roles](./sonar-lessons/use-native-html-elements-instead-of-aria-roles.md)                          |
 
 ---
 
@@ -47,6 +48,7 @@ Quick checks before committing. If you're about to write any of these patterns, 
 - [ ] **No nested ternaries** — Extract to helper function with early returns
 - [ ] **No boolean selector parameters** — Use separate methods or union types
 - [ ] **Interactive handlers on interactive elements only** — Use `<button>`, not `<div onClick>`
+- [ ] **Prefer native HTML over ARIA roles** — Use `<button>` not `<div role="button">`
 - [ ] **No code duplication** — Extract shared logic to functions/components
 - [ ] **No overly complex functions** — Keep cyclomatic complexity low
 
@@ -74,6 +76,10 @@ Project-specific patterns derived from fixing real issues. Each entry shows what
 
 ---
 
+## [Use native HTML elements instead of ARIA roles](./sonar-lessons/use-native-html-elements-instead-of-aria-roles.md) (S6819)
+
+---
+
 # Rule Index
 
 Rules we've encountered. Links to authoritative SonarSource documentation.
@@ -91,5 +97,9 @@ Rules we've encountered. Links to authoritative SonarSource documentation.
 ---
 
 ## [Non-interactive DOM elements should not have interactive ARIA roles](./sonar-rules/non-interactive-dom-elements-should-not-have-interactive-aria-roles.md)
+
+---
+
+## [Prefer tag over ARIA role](./sonar-rules/prefer-tag-over-aria-role.md)
 
 ---


### PR DESCRIPTION
## Problem
S6819 violation: `<div role="button">` used instead of native `<button>` element in ModalWrapper.tsx.

## Solution

### Code fix
Changed `<div role="button" tabIndex={0}>` to native `<button type="button">` with appropriate styling.

### Documentation (NEW RULE)
- Created `sonar-rules/prefer-tag-over-aria-role.md`
- Created `sonar-lessons/use-native-html-elements-instead-of-aria-roles.md`
- Updated `sonarcloud.md`:
  - Added S6819 to Quick Lookup table
  - Added prevention checklist item
  - Added Lessons Learned entry
  - Added Rule Index entry

## Files Changed
**Code:**
- `apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx` - div → button

**Documentation:**
- `docs/architecture/quality/sonar-rules/prefer-tag-over-aria-role.md` - NEW
- `docs/architecture/quality/sonar-lessons/use-native-html-elements-instead-of-aria-roles.md` - NEW
- `docs/architecture/quality/sonarcloud.md` - Updated with S6819

## Evidence
- **Lint**: 0 errors, 0 warnings
- **Doc updated**: sonarcloud.md