### PR TITLE
fix: use role=presentation for non-interactive event handlers (S6847)

### DIFF
--- a/apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx
@@ -17,13 +17,14 @@ export function ModalWrapper({ onClose, maxWidth = 'max-w-4xl', children }: Moda
       onClick={onClose}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        className={`w-full ${maxWidth} max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col`}
-        onMouseDown={(e) => e.stopPropagation()}
-      >
-        {children}
+      <div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          className={`w-full ${maxWidth} max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col`}
+        >
+          {children}
+        </div>
       </div>
     </button>
   );

--- a/docs/architecture/quality/sonar-lessons/extract-nested-ternary-operations-into-helper-functions.md
+++ b/docs/architecture/quality/sonar-lessons/extract-nested-ternary-operations-into-helper-functions.md
@@ -1,7 +1,10 @@
 # Extract Nested Ternary Operations into Helper Functions
 
-**Rule**:
-[Ternary operators should not be nested](../sonar-rules/ternary-operators-should-not-be-nested.md)
+**Rule ID**: typescript:S3358  
+**SonarCloud message**: "Ternary operators should not be nested."  
+**Aliases**: nested ternary, chained ternary, multiple ? : operators
+
+**Rule**: [Ternary operators should not be nested](../sonar-rules/ternary-operators-should-not-be-nested.md)
 
 **Pattern to avoid**:
 

--- a/docs/architecture/quality/sonar-lessons/provide-multiple-methods-instead-of-boolean-selector-parameters.md
+++ b/docs/architecture/quality/sonar-lessons/provide-multiple-methods-instead-of-boolean-selector-parameters.md
@@ -1,7 +1,10 @@
 # Provide multiple methods instead of boolean selector parameters
 
-**Rule**:
-[Methods should not contain selector parameters](../sonar-rules/methods-should-not-contain-selector-parameters.md)
+**Rule ID**: typescript:S2301  
+**SonarCloud message**: "Provide multiple methods instead of using \"isPdf\" to determine which action to take."  
+**Aliases**: boolean parameter, isPdf parameter, isX parameter, selector argument
+
+**Rule**: [Methods should not contain selector parameters](../sonar-rules/methods-should-not-contain-selector-parameters.md)
 
 **Pattern to avoid**:
 

--- a/docs/architecture/quality/sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md
+++ b/docs/architecture/quality/sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md
@@ -1,0 +1,84 @@
+# Use role presentation for non-interactive event handlers
+
+**Rule ID**: typescript:S6847  
+**SonarCloud message**: "Non-interactive elements should not be assigned mouse or keyboard event listeners."  
+**Aliases**: onMouseDown on div, onClick on span, event handler on non-interactive element
+
+**Rule**: [Non-interactive elements shouldn't have event handlers](../sonar-rules/non-interactive-elements-shouldnt-have-event-handlers.md)
+
+---
+
+## Why this matters
+
+Non-interactive HTML elements (`<div>`, `<span>`) are not designed for event handlers. Adding them can cause accessibility issues:
+
+- Screen readers may not announce the element correctly
+- Keyboard users may not be able to interact with it
+- Focus management may be broken
+
+---
+
+## Pattern to avoid
+
+```tsx
+{
+  /* BAD: Event handler on dialog div */
+}
+<div role="dialog" aria-modal="true" onMouseDown={(e) => e.stopPropagation()}>
+  {children}
+</div>;
+```
+
+## Fix — Use role="presentation" wrapper
+
+When you need event handlers for layout purposes (like preventing event propagation), wrap in a presentation div:
+
+```tsx
+{
+  /* GOOD: Presentation wrapper handles the event */
+}
+<div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
+  <div role="dialog" aria-modal="true">
+    {children}
+  </div>
+</div>;
+```
+
+## Modal pattern
+
+For modals that need to prevent backdrop clicks from closing when clicking inside:
+
+```tsx
+<button type="button" onClick={onClose} aria-label="Close modal">
+  <div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
+    <div role="dialog" aria-modal="true">
+      {children}
+    </div>
+  </div>
+</button>
+```
+
+## Other compliant patterns
+
+```tsx
+{
+  /* Interactive element - no role needed */
+}
+<button onClick={handleClick}>Click me</button>;
+
+{
+  /* Presentation role - for layout event handling */
+}
+<div role="presentation" onClick={() => void 0} />;
+
+{
+  /* aria-hidden - hidden from screen readers */
+}
+<div onClick={() => void 0} aria-hidden />;
+```
+
+## Key points
+
+- `role="presentation"` indicates the element is purely for presentation/layout
+- Use it when you need event handlers for non-interactive purposes (like stopPropagation)
+- Keep semantic roles (`dialog`, `button`) on elements without event handlers when possible

--- a/docs/architecture/quality/sonar-rules/non-interactive-elements-shouldnt-have-event-handlers.md
+++ b/docs/architecture/quality/sonar-rules/non-interactive-elements-shouldnt-have-event-handlers.md
@@ -1,0 +1,9 @@
+# Non-interactive elements shouldn't have event handlers
+
+**Rule ID**: typescript:S6847  
+**SonarCloud message**: "Non-interactive elements should not be assigned mouse or keyboard event listeners."  
+**Aliases**: div with onMouseDown, onClick on non-interactive element, event handler on span/div
+
+**Link**: https://rules.sonarsource.com/typescript/RSPEC-6847/
+
+**Lesson**: [Use role presentation for non-interactive event handlers](../sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md)

--- a/docs/architecture/quality/sonarcloud.md
+++ b/docs/architecture/quality/sonarcloud.md
@@ -38,6 +38,7 @@ When you see a SonarCloud issue, extract the Rule ID and find the matching lesso
 | S6848   | [Add role and keyboard handling to interactive divs](./sonar-lessons/add-role-and-keyboard-handling-to-interactive-divs.md)                  |
 | S6842   | [Do not add interactive ARIA roles to non-interactive elements](./sonar-lessons/use-native-interactive-elements-or-add-proper-aria-roles.md) |
 | S6819   | [Use native HTML elements instead of ARIA roles](./sonar-lessons/use-native-html-elements-instead-of-aria-roles.md)                          |
+| S6847   | [Use role presentation for non-interactive event handlers](./sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md)      |
 
 ---
 
@@ -49,6 +50,7 @@ Quick checks before committing. If you're about to write any of these patterns, 
 - [ ] **No boolean selector parameters** — Use separate methods or union types
 - [ ] **Interactive handlers on interactive elements only** — Use `<button>`, not `<div onClick>`
 - [ ] **Prefer native HTML over ARIA roles** — Use `<button>` not `<div role="button">`
+- [ ] **Use role="presentation" for layout event handlers** — When divs need stopPropagation
 - [ ] **No code duplication** — Extract shared logic to functions/components
 - [ ] **No overly complex functions** — Keep cyclomatic complexity low
 
@@ -60,11 +62,11 @@ Project-specific patterns derived from fixing real issues. Each entry shows what
 
 ---
 
-## [Extract nested ternary operations into helper functions](./sonar-lessons/extract-nested-ternary-operations-into-helper-functions.md)
+## [Extract nested ternary operations into helper functions](./sonar-lessons/extract-nested-ternary-operations-into-helper-functions.md) (S3358)
 
 ---
 
-## [Provide multiple methods instead of boolean selector parameters](./sonar-lessons/provide-multiple-methods-instead-of-boolean-selector-parameters.md)
+## [Provide multiple methods instead of boolean selector parameters](./sonar-lessons/provide-multiple-methods-instead-of-boolean-selector-parameters.md) (S2301)
 
 ---
 
@@ -77,6 +79,10 @@ Project-specific patterns derived from fixing real issues. Each entry shows what
 ---
 
 ## [Use native HTML elements instead of ARIA roles](./sonar-lessons/use-native-html-elements-instead-of-aria-roles.md) (S6819)
+
+---
+
+## [Use role presentation for non-interactive event handlers](./sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md) (S6847)
 
 ---
 
@@ -101,5 +107,9 @@ Rules we've encountered. Links to authoritative SonarSource documentation.
 ---
 
 ## [Prefer tag over ARIA role](./sonar-rules/prefer-tag-over-aria-role.md)
+
+---
+
+## [Non-interactive elements shouldn't have event handlers](./sonar-rules/non-interactive-elements-shouldnt-have-event-handlers.md)
 
 ---


### PR DESCRIPTION
## Problem
S6847 violation: `onMouseDown` handler on `<div role="dialog">` - non-interactive elements shouldn't have event handlers.

## Solution

### Code fix
Wrapped dialog in a `<div role="presentation">` that handles stopPropagation, keeping the dialog div clean.

### Documentation (NEW RULE)
- Created `sonar-rules/non-interactive-elements-shouldnt-have-event-handlers.md`
- Created `sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md`
- Updated `sonarcloud.md`:
  - Added S6847 to Quick Lookup table
  - Added prevention checklist item
  - Added Lessons Learned entry
  - Added Rule Index entry
  - Added rule IDs (S3358, S2301) to existing lessons in Lessons Learned section

### Existing lesson updates
- `extract-nested-ternary-operations-into-helper-functions.md` - Added Rule ID, message, aliases
- `provide-multiple-methods-instead-of-boolean-selector-parameters.md` - Added Rule ID, message, aliases

## Files Changed
**Code:**
- `apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx` - Added presentation wrapper

**Documentation (NEW):**
- `docs/architecture/quality/sonar-rules/non-interactive-elements-shouldnt-have-event-handlers.md`
- `docs/architecture/quality/sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md`

**Documentation (UPDATED):**
- `docs/architecture/quality/sonarcloud.md` - Added S6847 + rule IDs to existing entries
- `docs/architecture/quality/sonar-lessons/extract-nested-ternary-operations-into-helper-functions.md` - Added rule ID
- `docs/architecture/quality/sonar-lessons/provide-multiple-methods-instead-of-boolean-selector-parameters.md` - Added rule ID

## Evidence
- **Lint**: 0 errors, 0 warnings
- **Doc updated**: sonarcloud.md