### PR TITLE
fix: batch sonar fixes for modal components (S6819, S6847)

### DIFF
--- a/apps/admin/src/app/(dashboard)/agents/components/AgentTableRowParts.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/AgentTableRowParts.tsx
@@ -161,7 +161,11 @@ function ActionsCell(props: {
   readonly onTest: (p: PromptVersion) => void;
 }) {
   return (
-    <div className="flex items-center gap-2" onMouseDown={(e) => e.stopPropagation()}>
+    <div
+      role="presentation"
+      className="flex items-center gap-2"
+      onMouseDown={(e) => e.stopPropagation()}
+    >
       <ActionButtons
         currentPrompt={props.currentPrompt}
         onEdit={props.onEdit}

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-wrapper.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-wrapper.tsx
@@ -7,22 +7,22 @@ interface ModalWrapperProps {
 
 export function ModalWrapper({ onClose, children }: ModalWrapperProps) {
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       aria-label="Close modal"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 w-full h-full border-none cursor-default"
       onClick={onClose}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-6"
-        onMouseDown={(e) => e.stopPropagation()}
-      >
-        {children}
+      <div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-6"
+        >
+          {children}
+        </div>
       </div>
-    </div>
+    </button>
   );
 }

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/test-detail-modal/index.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/test-detail-modal/index.tsx
@@ -15,25 +15,26 @@ function ModalContent({ test, onClose, onUpdate }: TestDetailModalProps) {
   const { updating, updateStatus, promoteWinner } = useTestActions(test, onUpdate);
   const results = test.results as TestResults | undefined;
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="w-full max-w-2xl rounded-lg border border-neutral-800 bg-neutral-900 p-6"
-      onMouseDown={(e) => e.stopPropagation()}
-    >
-      <ModalHeader test={test} />
-      <VariantCards test={test} results={results} />
-      <ProgressBar processed={test.items_processed} total={test.sample_size} />
-      <ActionButtons
-        test={test}
-        updating={updating}
-        updateStatus={updateStatus}
-        promoteWinner={promoteWinner}
-      />
-      <div className="flex justify-end mt-6">
-        <button onClick={onClose} className="px-4 py-2 text-sm text-neutral-400 hover:text-white">
-          Close
-        </button>
+    <div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-2xl rounded-lg border border-neutral-800 bg-neutral-900 p-6"
+      >
+        <ModalHeader test={test} />
+        <VariantCards test={test} results={results} />
+        <ProgressBar processed={test.items_processed} total={test.sample_size} />
+        <ActionButtons
+          test={test}
+          updating={updating}
+          updateStatus={updateStatus}
+          promoteWinner={promoteWinner}
+        />
+        <div className="flex justify-end mt-6">
+          <button onClick={onClose} className="px-4 py-2 text-sm text-neutral-400 hover:text-white">
+            Close
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -41,15 +42,14 @@ function ModalContent({ test, onClose, onUpdate }: TestDetailModalProps) {
 
 export function TestDetailModal({ test, onClose, onUpdate }: TestDetailModalProps) {
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       aria-label="Close modal"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 w-full h-full border-none cursor-default"
       onClick={onClose}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
       <ModalContent test={test} onClose={onClose} onUpdate={onUpdate} />
-    </div>
+    </button>
   );
 }

--- a/apps/admin/src/app/(dashboard)/evals/golden-sets/components/CreateGoldenSetModal.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/golden-sets/components/CreateGoldenSetModal.tsx
@@ -67,15 +67,16 @@ function CreateGoldenSetModalContent({
   onClose: () => void;
 }) {
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="modal-title"
-      className="w-full max-w-2xl max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col"
-      onMouseDown={(e) => e.stopPropagation()}
-    >
-      <CreateGoldenSetModalHeader />
-      <CreateGoldenSetModalForm state={state} handleCreate={handleCreate} onClose={onClose} />
+    <div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+        className="w-full max-w-2xl max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col"
+      >
+        <CreateGoldenSetModalHeader />
+        <CreateGoldenSetModalForm state={state} handleCreate={handleCreate} onClose={onClose} />
+      </div>
     </div>
   );
 }
@@ -90,16 +91,15 @@ function CreateGoldenSetModalWrapper({
   onClose: () => void;
 }) {
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       aria-label="Close modal"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 w-full h-full border-none cursor-default"
       onClick={onClose}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
       <CreateGoldenSetModalContent state={state} handleCreate={handleCreate} onClose={onClose} />
-    </div>
+    </button>
   );
 }
 

--- a/apps/admin/src/app/(dashboard)/evals/golden-sets/components/ViewGoldenSetModal.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/golden-sets/components/ViewGoldenSetModal.tsx
@@ -58,25 +58,25 @@ function ViewGoldenSetFooter({ item, onClose }: { item: EvalGoldenSet; onClose: 
 
 export function ViewGoldenSetModal({ item, onClose }: ViewGoldenSetModalProps) {
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       aria-label="Close modal"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 w-full h-full border-none cursor-default"
       onClick={onClose}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="view-modal-title"
-        className="w-full max-w-3xl max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col"
-        onMouseDown={(e) => e.stopPropagation()}
-      >
-        <ViewGoldenSetHeader item={item} />
-        <ViewGoldenSetContent item={item} />
-        <ViewGoldenSetFooter item={item} onClose={onClose} />
+      <div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="view-modal-title"
+          className="w-full max-w-3xl max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col"
+        >
+          <ViewGoldenSetHeader item={item} />
+          <ViewGoldenSetContent item={item} />
+          <ViewGoldenSetFooter item={item} onClose={onClose} />
+        </div>
       </div>
-    </div>
+    </button>
   );
 }

--- a/apps/admin/src/app/(dashboard)/sources/components/SourceModal.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/SourceModal.tsx
@@ -14,23 +14,23 @@ interface SourceModalProps {
 
 function ModalWrapper({ onClose, children }: { onClose: () => void; children: React.ReactNode }) {
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       aria-label="Close modal"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 w-full h-full border-none cursor-default"
       onClick={onClose}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-6"
-        onMouseDown={(e) => e.stopPropagation()}
-      >
-        {children}
+      <div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="w-full max-w-lg rounded-lg border border-neutral-800 bg-neutral-900 p-6"
+        >
+          {children}
+        </div>
       </div>
-    </div>
+    </button>
   );
 }
 


### PR DESCRIPTION
## Problem
Multiple SonarCloud violations across modal components:
- **S6819**: `<div role="button">` instead of native `<button>`
- **S6847**: `onMouseDown` on non-interactive elements (dialog divs)

## Solution
Applied existing lessons to all affected files:
- S6819: [Use native HTML elements instead of ARIA roles](docs/architecture/quality/sonar-lessons/use-native-html-elements-instead-of-aria-roles.md)
- S6847: [Use role presentation for non-interactive event handlers](docs/architecture/quality/sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md)

## Files Changed

| File | S6819 | S6847 |
|------|-------|-------|
| `AgentTableRowParts.tsx` | - | ✅ Add role="presentation" |
| `modal-wrapper.tsx` (ab-tests) | ✅ div→button | ✅ presentation wrapper |
| `test-detail-modal/index.tsx` | ✅ div→button | ✅ presentation wrapper |
| `CreateGoldenSetModal.tsx` | ✅ div→button | ✅ presentation wrapper |
| `ViewGoldenSetModal.tsx` | ✅ div→button | ✅ presentation wrapper |
| `SourceModal.tsx` | ✅ div→button | ✅ presentation wrapper |

## Evidence
- **Lint**: 0 errors, 0 warnings