### PR TITLE
fix: remove role=presentation, use target check for modal backdrop (S6819)

### DIFF
--- a/apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx
@@ -14,17 +14,15 @@ export function ModalWrapper({ onClose, maxWidth = 'max-w-4xl', children }: Moda
       type="button"
       aria-label="Close modal"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 w-full h-full border-none cursor-default"
-      onClick={onClose}
+      onClick={(e) => e.target === e.currentTarget && onClose()}
       onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
-      <div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
-        <div
-          role="dialog"
-          aria-modal="true"
-          className={`w-full ${maxWidth} max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col`}
-        >
-          {children}
-        </div>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={`w-full ${maxWidth} max-h-[90vh] rounded-lg border border-neutral-800 bg-neutral-900 overflow-hidden flex flex-col`}
+      >
+        {children}
       </div>
     </button>
   );

--- a/docs/architecture/quality/sonar-lessons/use-native-html-elements-instead-of-aria-roles.md
+++ b/docs/architecture/quality/sonar-lessons/use-native-html-elements-instead-of-aria-roles.md
@@ -1,8 +1,11 @@
 # Use native HTML elements instead of ARIA roles
 
 **Rule ID**: typescript:S6819  
-**SonarCloud message**: "Use \<button> instead of the \"button\" role to ensure accessibility across all devices."  
-**Aliases**: div role="button", ARIA role instead of semantic HTML, prefer semantic elements
+**SonarCloud messages**:
+
+- "Use \<button> instead of the \"button\" role to ensure accessibility across all devices."
+- "Use \<img alt=...> instead of the \"presentation\" role to ensure accessibility across all devices."  
+  **Aliases**: div role="button", role="presentation", ARIA role instead of semantic HTML
 
 **Rule**: [Prefer tag over ARIA role](../sonar-rules/prefer-tag-over-aria-role.md)
 
@@ -49,22 +52,42 @@ ARIA roles are a fallback, not a replacement for semantic HTML.
 
 ## Modal backdrop pattern
 
-For modal backdrops that close on click:
+For modal backdrops that close on click, use target check instead of stopPropagation:
 
 ```tsx
 {
-  /* GOOD: Button styled as backdrop */
+  /* GOOD: Check if click is on backdrop (not dialog) */
 }
 <button
   type="button"
   aria-label="Close modal"
   className="fixed inset-0 z-50 bg-black/50 w-full h-full border-none cursor-default"
-  onClick={onClose}
+  onClick={(e) => e.target === e.currentTarget && onClose()}
   onKeyDown={(e) => e.key === 'Escape' && onClose()}
 >
-  <div role="dialog" aria-modal="true" onMouseDown={(e) => e.stopPropagation()}>
+  <div role="dialog" aria-modal="true">
     {children}
   </div>
+</button>;
+```
+
+This eliminates the need for `role="presentation"` wrappers with stopPropagation.
+
+## Avoid role="presentation" for event handling
+
+```tsx
+{
+  /* BAD: Using presentation role for stopPropagation */
+}
+<div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
+  <div role="dialog">{children}</div>
+</div>;
+
+{
+  /* GOOD: Use target check instead */
+}
+<button onClick={(e) => e.target === e.currentTarget && onClose()}>
+  <div role="dialog">{children}</div>
 </button>;
 ```
 

--- a/docs/architecture/quality/sonar-rules/prefer-tag-over-aria-role.md
+++ b/docs/architecture/quality/sonar-rules/prefer-tag-over-aria-role.md
@@ -1,8 +1,11 @@
 # Prefer tag over ARIA role
 
 **Rule ID**: typescript:S6819  
-**SonarCloud message**: "Use \<input type=\"button\">, \<input type=\"image\">, \<input type=\"reset\">, \<input type=\"submit\">, or \<button> instead of the \"button\" role to ensure accessibility across all devices."  
-**Aliases**: div role="button", ARIA role instead of semantic HTML, role="button" on div
+**SonarCloud messages**:
+
+- "Use \<button> instead of the \"button\" role to ensure accessibility across all devices."
+- "Use \<img alt=...> instead of the \"presentation\" role to ensure accessibility across all devices."  
+  **Aliases**: div role="button", role="presentation", ARIA role instead of semantic HTML
 
 **Link**: https://rules.sonarsource.com/typescript/RSPEC-6819/
 

--- a/docs/architecture/quality/sonarcloud.md
+++ b/docs/architecture/quality/sonarcloud.md
@@ -50,7 +50,7 @@ Quick checks before committing. If you're about to write any of these patterns, 
 - [ ] **No boolean selector parameters** — Use separate methods or union types
 - [ ] **Interactive handlers on interactive elements only** — Use `<button>`, not `<div onClick>`
 - [ ] **Prefer native HTML over ARIA roles** — Use `<button>` not `<div role="button">`
-- [ ] **Use role="presentation" for layout event handlers** — When divs need stopPropagation
+- [ ] **Use target check for modal backdrops** — `e.target === e.currentTarget` instead of stopPropagation
 - [ ] **No code duplication** — Extract shared logic to functions/components
 - [ ] **No overly complex functions** — Keep cyclomatic complexity low
 


### PR DESCRIPTION
## Problem
S6819 violation: `role="presentation"` on wrapper div triggers "Use \<img alt=...> instead of the 'presentation' role".

## Solution
Remove the presentation wrapper entirely and use target check to determine if click was on backdrop vs dialog:

```tsx
// Before: stopPropagation on presentation wrapper
<button onClick={onClose}>
  <div role="presentation" onMouseDown={(e) => e.stopPropagation()}>
    <div role="dialog">{children}</div>
  </div>
</button>

// After: target check on backdrop button
<button onClick={(e) => e.target === e.currentTarget && onClose()}>
  <div role="dialog">{children}</div>
</button>
```

## Files Changed
**Code:**
- `apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx` - Remove presentation wrapper, use target check

**Documentation (UPDATED):**
- `docs/architecture/quality/sonar-rules/prefer-tag-over-aria-role.md` - Added presentation role message
- `docs/architecture/quality/sonar-lessons/use-native-html-elements-instead-of-aria-roles.md` - Added target check pattern, presentation role guidance
- `docs/architecture/quality/sonarcloud.md` - Updated prevention checklist

## Evidence
- **Lint**: 0 errors, 0 warnings
- **Doc updated**: sonarcloud.md