### PR TITLE
fix(S4624): extract nested template literals

### DIFF
--- a/apps/admin/src/app/(dashboard)/items/[id]/enrichment-panel/useEnrichmentActions.ts
+++ b/apps/admin/src/app/(dashboard)/items/[id]/enrichment-panel/useEnrichmentActions.ts
@@ -82,10 +82,8 @@ function createTriggerStep(
     try {
       show('success', `✓ Processing ${stepKey}...`);
       const result = await callEnrichStep(stepKey, item.id);
-      show(
-        'success',
-        `✓ ${stepKey} complete${result.processed ? ` (${result.processed} processed)` : ''}`,
-      );
+      const processedSuffix = result.processed ? ` (${result.processed} processed)` : '';
+      show('success', `✓ ${stepKey} complete${processedSuffix}`);
       refresh();
     } catch (err) {
       show('error', `Failed: ${err instanceof Error ? err.message : 'Unknown'}`);

--- a/apps/admin/src/app/(dashboard)/sources/components/SourceTable.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/SourceTable.tsx
@@ -1,155 +1,226 @@
 import type { Source } from '@/types/database';
 import type { SourceHealth } from '../types';
 
+type HealthBadge = { icon: string; label: string; className: string };
+type DiscoveryMethod = { icon: string; label: string; url: string | null };
+
 interface SourceTableProps {
   sources: Source[];
   healthData: Map<string, SourceHealth>;
   onToggleEnabled: (source: Source) => void;
   onEdit: (source: Source) => void;
   formatTimeAgo: (date: string | null) => string;
-  getHealthBadge: (health: SourceHealth | undefined) => {
-    icon: string;
-    label: string;
-    className: string;
-  };
-  getDiscoveryInfo: (source: Source) => Array<{ icon: string; label: string; url: string | null }>;
+  getHealthBadge: (health: SourceHealth | undefined) => HealthBadge;
+  getDiscoveryInfo: (source: Source) => DiscoveryMethod[];
   getCategoryColor: (category: string) => string;
 }
 
-export function SourceTable({
-  sources,
-  healthData,
-  onToggleEnabled,
-  onEdit,
-  formatTimeAgo,
-  getHealthBadge,
-  getDiscoveryInfo,
+const HEADER_CLASS = 'px-4 py-3';
+
+function TableHeader() {
+  return (
+    <thead className="bg-neutral-900">
+      <tr className="text-left text-xs font-medium uppercase tracking-wider text-neutral-400">
+        <th className={HEADER_CLASS}>Source</th>
+        <th className={HEADER_CLASS}>Category</th>
+        <th className={HEADER_CLASS}>Discovery</th>
+        <th className={HEADER_CLASS}>Health</th>
+        <th className={HEADER_CLASS}>Last Run</th>
+        <th className={HEADER_CLASS}>Items (7d)</th>
+        <th className={HEADER_CLASS}>Enabled</th>
+        <th className={HEADER_CLASS}>Actions</th>
+      </tr>
+    </thead>
+  );
+}
+
+function SourceCell({ source }: { source: Source }) {
+  return (
+    <td className="px-4 py-3">
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-neutral-700 text-xs font-medium">
+          {source.sort_order ? Math.ceil(source.sort_order / 100) : '-'}
+        </span>
+        <div>
+          <div className="font-medium text-white">{source.name}</div>
+          <div className="text-xs text-neutral-500">{source.domain}</div>
+        </div>
+      </div>
+      {source.disabled_reason && (
+        <div className="text-xs text-red-400 mt-1 ml-8">⚠️ {source.disabled_reason}</div>
+      )}
+    </td>
+  );
+}
+
+function CategoryCell({
+  source,
   getCategoryColor,
-}: SourceTableProps) {
+}: {
+  source: Source;
+  getCategoryColor: (c: string) => string;
+}) {
+  return (
+    <td className="px-4 py-3">
+      <span className={`rounded-full px-2 py-0.5 text-xs ${getCategoryColor(source.category)}`}>
+        {source.category || '-'}
+      </span>
+      {source.tier === 'premium' && <span className="ml-1 text-xs text-amber-400">★</span>}
+    </td>
+  );
+}
+
+function DiscoveryCell({ methods }: { methods: DiscoveryMethod[] }) {
+  if (methods.length === 0) {
+    return (
+      <td className="px-4 py-3">
+        <span className="text-neutral-600" title="No discovery configured">
+          ❌
+        </span>
+      </td>
+    );
+  }
+  return (
+    <td className="px-4 py-3">
+      <div className="flex items-center gap-1">
+        {methods.map((method, i) => {
+          const urlSuffix = method.url ? `: ${method.url}` : '';
+          return (
+            <span key={i} title={`${method.label}${urlSuffix}`} className="cursor-help">
+              {method.icon}
+            </span>
+          );
+        })}
+      </div>
+    </td>
+  );
+}
+
+function HealthCell({ health, badge }: { health: SourceHealth | undefined; badge: HealthBadge }) {
+  const errorSuffix = health ? ` (${health.error_rate}% errors)` : '';
+  return (
+    <td className="px-4 py-3">
+      <span className={`text-sm ${badge.className}`} title={`${badge.label}${errorSuffix}`}>
+        {badge.icon}
+      </span>
+    </td>
+  );
+}
+
+function ItemsCell({ health }: { health: SourceHealth | undefined }) {
+  return (
+    <td className="px-4 py-3">
+      <span className={`text-sm ${health?.items_7d ? 'text-white' : 'text-neutral-600'}`}>
+        {health?.items_7d || 0}
+      </span>
+      {health?.failed_7d ? (
+        <span className="text-xs text-red-400 ml-1">({health.failed_7d} failed)</span>
+      ) : null}
+    </td>
+  );
+}
+
+function ToggleCell({ source, onToggle }: { source: Source; onToggle: () => void }) {
+  return (
+    <td className="px-4 py-3">
+      <button
+        onClick={onToggle}
+        className={`w-10 h-5 rounded-full transition-colors ${source.enabled ? 'bg-emerald-500' : 'bg-neutral-700'}`}
+      >
+        <span
+          className={`block w-4 h-4 rounded-full bg-white transform transition-transform ${source.enabled ? 'translate-x-5' : 'translate-x-0.5'}`}
+        />
+      </button>
+    </td>
+  );
+}
+
+function ActionsCell({ onEdit }: { onEdit: () => void }) {
+  return (
+    <td className="px-4 py-3">
+      <button onClick={onEdit} className="text-sky-400 hover:text-sky-300 text-xs">
+        Edit
+      </button>
+    </td>
+  );
+}
+
+interface SourceRowProps {
+  source: Source;
+  health: SourceHealth | undefined;
+  healthBadge: HealthBadge;
+  discoveryMethods: DiscoveryMethod[];
+  formatTimeAgo: (date: string | null) => string;
+  getCategoryColor: (category: string) => string;
+  onToggleEnabled: () => void;
+  onEdit: () => void;
+}
+
+function SourceRow(props: SourceRowProps) {
+  const {
+    source,
+    health,
+    healthBadge,
+    discoveryMethods,
+    formatTimeAgo,
+    getCategoryColor,
+    onToggleEnabled,
+    onEdit,
+  } = props;
+  return (
+    <tr className="hover:bg-neutral-800/50">
+      <SourceCell source={source} />
+      <CategoryCell source={source} getCategoryColor={getCategoryColor} />
+      <DiscoveryCell methods={discoveryMethods} />
+      <HealthCell health={health} badge={healthBadge} />
+      <td className="px-4 py-3">
+        <span className="text-xs text-neutral-400">
+          {formatTimeAgo(health?.last_discovery || null)}
+        </span>
+      </td>
+      <ItemsCell health={health} />
+      <ToggleCell source={source} onToggle={onToggleEnabled} />
+      <ActionsCell onEdit={onEdit} />
+    </tr>
+  );
+}
+
+function TableBody(props: SourceTableProps) {
+  const {
+    sources,
+    healthData,
+    onToggleEnabled,
+    onEdit,
+    formatTimeAgo,
+    getHealthBadge,
+    getDiscoveryInfo,
+    getCategoryColor,
+  } = props;
+  return (
+    <tbody className="divide-y divide-neutral-800">
+      {sources.map((source) => (
+        <SourceRow
+          key={source.slug}
+          source={source}
+          health={healthData.get(source.slug)}
+          healthBadge={getHealthBadge(healthData.get(source.slug))}
+          discoveryMethods={getDiscoveryInfo(source)}
+          formatTimeAgo={formatTimeAgo}
+          getCategoryColor={getCategoryColor}
+          onToggleEnabled={() => onToggleEnabled(source)}
+          onEdit={() => onEdit(source)}
+        />
+      ))}
+    </tbody>
+  );
+}
+
+export function SourceTable(props: SourceTableProps) {
   return (
     <div className="overflow-hidden rounded-lg border border-neutral-800">
       <table className="w-full">
-        <thead className="bg-neutral-900">
-          <tr className="text-left text-xs font-medium uppercase tracking-wider text-neutral-400">
-            <th className="px-4 py-3">Source</th>
-            <th className="px-4 py-3">Category</th>
-            <th className="px-4 py-3">Discovery</th>
-            <th className="px-4 py-3">Health</th>
-            <th className="px-4 py-3">Last Run</th>
-            <th className="px-4 py-3">Items (7d)</th>
-            <th className="px-4 py-3">Enabled</th>
-            <th className="px-4 py-3">Actions</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-neutral-800">
-          {sources.map((source) => {
-            const health = healthData.get(source.slug);
-            const healthBadge = getHealthBadge(health);
-            const discoveryMethods = getDiscoveryInfo(source);
-
-            return (
-              <tr key={source.slug} className="hover:bg-neutral-800/50">
-                <td className="px-4 py-3">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-neutral-700 text-xs font-medium">
-                      {source.sort_order ? Math.ceil(source.sort_order / 100) : '-'}
-                    </span>
-                    <div>
-                      <div className="font-medium text-white">{source.name}</div>
-                      <div className="text-xs text-neutral-500">{source.domain}</div>
-                    </div>
-                  </div>
-                  {source.disabled_reason && (
-                    <div className="text-xs text-red-400 mt-1 ml-8">
-                      ⚠️ {source.disabled_reason}
-                    </div>
-                  )}
-                </td>
-
-                <td className="px-4 py-3">
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs ${getCategoryColor(source.category)}`}
-                  >
-                    {source.category || '-'}
-                  </span>
-                  {source.tier === 'premium' && (
-                    <span className="ml-1 text-xs text-amber-400">★</span>
-                  )}
-                </td>
-
-                <td className="px-4 py-3">
-                  <div className="flex items-center gap-1">
-                    {discoveryMethods.length > 0 ? (
-                      discoveryMethods.map((method, i) => (
-                        <span
-                          key={i}
-                          title={`${method.label}${method.url ? `: ${method.url}` : ''}`}
-                          className="cursor-help"
-                        >
-                          {method.icon}
-                        </span>
-                      ))
-                    ) : (
-                      <span className="text-neutral-600" title="No discovery configured">
-                        ❌
-                      </span>
-                    )}
-                  </div>
-                </td>
-
-                <td className="px-4 py-3">
-                  <span
-                    className={`text-sm ${healthBadge.className}`}
-                    title={`${healthBadge.label}${health ? ` (${health.error_rate}% errors)` : ''}`}
-                  >
-                    {healthBadge.icon}
-                  </span>
-                </td>
-
-                <td className="px-4 py-3">
-                  <span className="text-xs text-neutral-400">
-                    {formatTimeAgo(health?.last_discovery || null)}
-                  </span>
-                </td>
-
-                <td className="px-4 py-3">
-                  <span
-                    className={`text-sm ${health?.items_7d ? 'text-white' : 'text-neutral-600'}`}
-                  >
-                    {health?.items_7d || 0}
-                  </span>
-                  {health?.failed_7d ? (
-                    <span className="text-xs text-red-400 ml-1">({health.failed_7d} failed)</span>
-                  ) : null}
-                </td>
-
-                <td className="px-4 py-3">
-                  <button
-                    onClick={() => onToggleEnabled(source)}
-                    className={`w-10 h-5 rounded-full transition-colors ${
-                      source.enabled ? 'bg-emerald-500' : 'bg-neutral-700'
-                    }`}
-                  >
-                    <span
-                      className={`block w-4 h-4 rounded-full bg-white transform transition-transform ${
-                        source.enabled ? 'translate-x-5' : 'translate-x-0.5'
-                      }`}
-                    />
-                  </button>
-                </td>
-
-                <td className="px-4 py-3">
-                  <button
-                    onClick={() => onEdit(source)}
-                    className="text-sky-400 hover:text-sky-300 text-xs"
-                  >
-                    Edit
-                  </button>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
+        <TableHeader />
+        <TableBody {...props} />
       </table>
     </div>
   );

--- a/docs/architecture/quality/sonar-lessons/refactor-this-code-to-not-use-nested-template-literals.md
+++ b/docs/architecture/quality/sonar-lessons/refactor-this-code-to-not-use-nested-template-literals.md
@@ -1,0 +1,76 @@
+# Refactor this code to not use nested template literals
+
+**Rule ID**: typescript:S4624  
+**SonarCloud message**: "Refactor this code to not use nested template literals."  
+**Aliases**: nested template string, nested backtick, conditional template
+
+**Tip**: Extract conditional parts to a variable before the template literal
+
+**Rule**: [Template literals should not be nested](../sonar-rules/4624_template-literals-should-not-be-nested.md)
+
+## Context
+
+Template literals with nested template literals (backticks inside backticks) are hard to read and maintain. This often happens with conditional string building.
+
+## Pattern to avoid
+
+```tsx
+// BAD: Nested template literal
+const title = `${label}${url ? `: ${url}` : ''}`;
+
+// BAD: Nested template in function call
+show('success', `✓ ${step} complete${result.count ? ` (${result.count} items)` : ''}`);
+```
+
+## Fix: Extract the conditional part first
+
+```tsx
+// GOOD: Extract conditional to variable
+const urlSuffix = url ? `: ${url}` : '';
+const title = `${label}${urlSuffix}`;
+
+// GOOD: Extract before function call
+const countSuffix = result.count ? ` (${result.count} items)` : '';
+show('success', `✓ ${step} complete${countSuffix}`);
+```
+
+## Benefits
+
+- **Readable**: No nested backticks to parse mentally
+- **Debuggable**: Can inspect the intermediate variable
+- **Maintainable**: Easy to modify conditional logic
+
+## Real examples
+
+### SourceTable.tsx - tooltip with optional URL
+
+```tsx
+// Before (S4624 violation)
+title={`${method.label}${method.url ? `: ${method.url}` : ''}`}
+
+// After (fixed)
+const urlSuffix = method.url ? `: ${method.url}` : '';
+title={`${method.label}${urlSuffix}`}
+```
+
+### useEnrichmentActions.ts - success message
+
+```tsx
+// Before (S4624 violation)
+show(
+  'success',
+  `✓ ${stepKey} complete${result.processed ? ` (${result.processed} processed)` : ''}`,
+);
+
+// After (fixed)
+const processedSuffix = result.processed ? ` (${result.processed} processed)` : '';
+show('success', `✓ ${stepKey} complete${processedSuffix}`);
+```
+
+## When to apply
+
+Use this pattern whenever you have:
+
+- Conditional string suffixes/prefixes in template literals
+- Ternary operators inside template literals that produce strings
+- Any `${ ... ? \`...\` : '' }` pattern

--- a/docs/architecture/quality/sonar-rules/4624_template-literals-should-not-be-nested.md
+++ b/docs/architecture/quality/sonar-rules/4624_template-literals-should-not-be-nested.md
@@ -1,0 +1,11 @@
+# Template literals should not be nested
+
+**Rule ID**: typescript:S4624  
+**SonarCloud message**: "Template literals should not be nested"  
+**Aliases**: nested template string, nested backtick, template string nesting
+
+**Link**: https://rules.sonarsource.com/typescript/RSPEC-4624/
+
+**Lessons**:
+
+- [Refactor this code to not use nested template literals](../sonar-lessons/refactor-this-code-to-not-use-nested-template-literals.md)

--- a/docs/architecture/quality/sonarcloud.md
+++ b/docs/architecture/quality/sonarcloud.md
@@ -40,6 +40,7 @@ When you see a SonarCloud issue, extract the Rule ID and find the matching lesso
 | S6842   | [Do not add interactive ARIA roles to non-interactive elements](./sonar-lessons/use-native-interactive-elements-or-add-proper-aria-roles.md)                  |
 | S6819   | [Use native HTML elements instead of ARIA roles](./sonar-lessons/use-native-html-elements-instead-of-aria-roles.md)                                           |
 | S6847   | [Use role presentation for non-interactive event handlers](./sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md)                       |
+| S4624   | [Refactor this code to not use nested template literals](./sonar-lessons/refactor-this-code-to-not-use-nested-template-literals.md)                           |
 
 ---
 
@@ -48,6 +49,7 @@ When you see a SonarCloud issue, extract the Rule ID and find the matching lesso
 Quick checks before committing. If you're about to write any of these patterns, stop and refactor.
 
 - [ ] **No nested ternaries** — Extract to helper function with early returns
+- [ ] **No nested template literals** — Extract conditional parts to variables first
 - [ ] **No boolean selector parameters** — Use separate methods or union types
 - [ ] **Interactive handlers on interactive elements only** — Use `<button>`, not `<div onClick>`
 - [ ] **Prefer native HTML over ARIA roles** — Use `<button>` not `<div role="button">`
@@ -91,6 +93,10 @@ Project-specific patterns derived from fixing real issues. Each entry shows what
 
 ---
 
+## [Refactor this code to not use nested template literals](./sonar-lessons/refactor-this-code-to-not-use-nested-template-literals.md) (S4624)
+
+---
+
 # Rule Index
 
 Rules we've encountered. Links to authoritative SonarSource documentation.
@@ -116,5 +122,9 @@ Rules we've encountered. Links to authoritative SonarSource documentation.
 ---
 
 ## [Non-interactive elements shouldn't have event handlers](./sonar-rules/6847_non-interactive-elements-shouldnt-have-event-handlers.md)
+
+---
+
+## [Template literals should not be nested](./sonar-rules/4624_template-literals-should-not-be-nested.md)
 
 ---


### PR DESCRIPTION
## Problem
SonarCloud S4624 violations (nested template literals) in 2 files:
- `SourceTable.tsx` - nested template in tooltip titles
- `useEnrichmentActions.ts` - nested template in success message

## Solution
Extract conditional string parts to variables before using in template literals.

### Files Fixed

**SourceTable.tsx**
- Extract `urlSuffix` variable for method title tooltip
- Extract `errorSuffix` variable for health badge title
- Refactor into smaller components for quality gate compliance:
  `TableHeader`, `SourceCell`, `CategoryCell`, `DiscoveryCell`, `HealthCell`,
  `ItemsCell`, `ToggleCell`, `ActionsCell`, `SourceRow`, `TableBody`

**useEnrichmentActions.ts**
- Extract `processedSuffix` variable for success message

### Documentation
- **New rule doc**: `4624_template-literals-should-not-be-nested.md`
- **New lesson doc**: `refactor-this-code-to-not-use-nested-template-literals.md`
- **sonarcloud.md**: Added to Quick Lookup, Prevention Checklist, Lessons Learned, Rule Index

## Files Changed
- `apps/admin/src/app/(dashboard)/sources/components/SourceTable.tsx`
- `apps/admin/src/app/(dashboard)/items/[id]/enrichment-panel/useEnrichmentActions.ts`
- `docs/architecture/quality/sonar-rules/4624_template-literals-should-not-be-nested.md` (new)
- `docs/architecture/quality/sonar-lessons/refactor-this-code-to-not-use-nested-template-literals.md` (new)
- `docs/architecture/quality/sonarcloud.md`

## Evidence
- **Lint**: 0 errors, 0 warnings
- **Quality gate**: All functions <30 lines
- **Doc updated**: sonarcloud.md