### PR TITLE
fix(S6759): mark React props as read-only with Readonly<>

### DIFF
--- a/apps/admin/src/app/(dashboard)/add/components/WhyValuable.tsx
+++ b/apps/admin/src/app/(dashboard)/add/components/WhyValuable.tsx
@@ -11,7 +11,7 @@ interface WhyValuableProps {
   toggleAudience: (audience: string) => void;
 }
 
-function WhyInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+function WhyInput({ value, onChange }: Readonly<{ value: string; onChange: (v: string) => void }>) {
   return (
     <div>
       <label htmlFor="why" className="block text-sm font-medium text-neutral-300 mb-2">
@@ -30,7 +30,10 @@ function WhyInput({ value, onChange }: { value: string; onChange: (v: string) =>
   );
 }
 
-function VerbatimInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+function VerbatimInput({
+  value,
+  onChange,
+}: Readonly<{ value: string; onChange: (v: string) => void }>) {
   return (
     <div>
       <label htmlFor="verbatimComment" className="block text-sm font-medium text-neutral-300 mb-2">
@@ -66,9 +69,11 @@ function WhyValuableCard({
   setWhyValuable,
   verbatimComment,
   setVerbatimComment,
-}: Pick<
-  WhyValuableProps,
-  'whyValuable' | 'setWhyValuable' | 'verbatimComment' | 'setVerbatimComment'
+}: Readonly<
+  Pick<
+    WhyValuableProps,
+    'whyValuable' | 'setWhyValuable' | 'verbatimComment' | 'setVerbatimComment'
+  >
 >) {
   return (
     <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 space-y-4">
@@ -91,11 +96,11 @@ function AudienceButton({
   aud,
   isSelected,
   onClick,
-}: {
+}: Readonly<{
   aud: { value: string; label: string };
   isSelected: boolean;
   onClick: () => void;
-}) {
+}>) {
   const cls = isSelected
     ? 'bg-purple-500/30 text-purple-300 border border-purple-500/50'
     : 'bg-neutral-800 text-neutral-400 border border-neutral-700 hover:border-neutral-600';
@@ -110,7 +115,7 @@ function AudienceButton({
   );
 }
 
-function AudienceSelector({ suggestedAudiences, toggleAudience }: AudienceSelectorProps) {
+function AudienceSelector({ suggestedAudiences, toggleAudience }: Readonly<AudienceSelectorProps>) {
   return (
     <div className="rounded-lg border border-neutral-800 bg-neutral-900/60 p-4 space-y-4">
       <h2 className="text-sm font-semibold text-neutral-300 uppercase tracking-wide">
@@ -135,7 +140,7 @@ function AudienceSelector({ suggestedAudiences, toggleAudience }: AudienceSelect
   );
 }
 
-export function WhyValuable(props: WhyValuableProps) {
+export function WhyValuable(props: Readonly<WhyValuableProps>) {
   return (
     <>
       <WhyValuableCard

--- a/apps/admin/src/app/(dashboard)/add/page.tsx
+++ b/apps/admin/src/app/(dashboard)/add/page.tsx
@@ -71,7 +71,7 @@ async function runSubmit(state: ReturnType<typeof useAddArticle>) {
   await submitArticle(buildSubmitParams(state));
 }
 
-function StatusBanner(state: { status: string; message: string }) {
+function StatusBanner(state: Readonly<{ status: string; message: string }>) {
   if (state.status === 'success') {
     return (
       <div className="mb-6 rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-4">
@@ -91,11 +91,13 @@ function StatusBanner(state: { status: string; message: string }) {
   return null;
 }
 
-function Tabs(state: {
-  activeTab: string;
-  setActiveTab: (tab: 'add' | 'list') => void;
-  missedItemsLength: number;
-}) {
+function Tabs(
+  state: Readonly<{
+    activeTab: string;
+    setActiveTab: (tab: 'add' | 'list') => void;
+    missedItemsLength: number;
+  }>,
+) {
   return (
     <div className="flex gap-6 border-b border-neutral-800">
       <button
@@ -114,7 +116,7 @@ function Tabs(state: {
   );
 }
 
-function EditingBanner(state: { editingId: string | null; cancelEdit: () => void }) {
+function EditingBanner(state: Readonly<{ editingId: string | null; cancelEdit: () => void }>) {
   if (!state.editingId) return null;
   return (
     <div className="mb-4 flex items-center justify-between rounded-lg border border-sky-500/20 bg-sky-500/10 p-3">
@@ -130,7 +132,7 @@ function EditingBanner(state: { editingId: string | null; cancelEdit: () => void
   );
 }
 
-function SubmitActions(state: { status: string; submitLabel: string }) {
+function SubmitActions(state: Readonly<{ status: string; submitLabel: string }>) {
   return (
     <div className="flex gap-3">
       <button
@@ -150,7 +152,7 @@ function SubmitActions(state: { status: string; submitLabel: string }) {
   );
 }
 
-function ArticleSection(state: ReturnType<typeof useAddArticle>) {
+function ArticleSection(state: Readonly<ReturnType<typeof useAddArticle>>) {
   return (
     <ArticleInput
       inputMode={state.inputMode}
@@ -169,7 +171,7 @@ function ArticleSection(state: ReturnType<typeof useAddArticle>) {
   );
 }
 
-function SubmitterSection(state: ReturnType<typeof useAddArticle>) {
+function SubmitterSection(state: Readonly<ReturnType<typeof useAddArticle>>) {
   return (
     <SubmitterInfo
       submitterName={state.submitterName}
@@ -184,7 +186,7 @@ function SubmitterSection(state: ReturnType<typeof useAddArticle>) {
   );
 }
 
-function WhyValuableSection(state: ReturnType<typeof useAddArticle>) {
+function WhyValuableSection(state: Readonly<ReturnType<typeof useAddArticle>>) {
   return (
     <WhyValuable
       whyValuable={state.whyValuable}
@@ -197,7 +199,7 @@ function WhyValuableSection(state: ReturnType<typeof useAddArticle>) {
   );
 }
 
-function AddFormFields(state: ReturnType<typeof useAddArticle>) {
+function AddFormFields(state: Readonly<ReturnType<typeof useAddArticle>>) {
   return (
     <>
       <ArticleSection {...state} />

--- a/apps/admin/src/app/(dashboard)/agents/[agent]/components/AgentHeader.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/[agent]/components/AgentHeader.tsx
@@ -12,6 +12,114 @@ interface AgentHeaderProps {
   onDelete: () => void;
 }
 
+function BackLink() {
+  return (
+    <Link
+      href="/prompts"
+      className="inline-flex items-center gap-2 text-sm text-neutral-400 hover:text-white mb-3"
+    >
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+      </svg>
+      Back to Prompts
+    </Link>
+  );
+}
+
+function AgentTitle({
+  agentName,
+  prompts,
+  currentPrompt,
+}: Readonly<{
+  agentName: string;
+  prompts: PromptVersion[];
+  currentPrompt: PromptVersion | undefined;
+}>) {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-white">{agentName}</h1>
+      <p className="mt-1 text-sm text-neutral-400">
+        {prompts.length} version{prompts.length !== 1 ? 's' : ''} •{' '}
+        {currentPrompt && (
+          <span className="text-emerald-400">Current: {currentPrompt.version}</span>
+        )}
+      </p>
+    </div>
+  );
+}
+
+function isEditDisabled(stage: string | null | undefined): boolean {
+  return stage === 'PRD' || stage === 'RET';
+}
+
+const BTN = 'rounded-lg px-4 py-2 text-sm font-medium text-white';
+
+function TestBtn({ onClick }: Readonly<{ onClick: () => void }>) {
+  return (
+    <button onClick={onClick} className={`${BTN} bg-purple-600 hover:bg-purple-500`}>
+      🧪 Test
+    </button>
+  );
+}
+
+function EditBtn({ onClick, disabled }: Readonly<{ onClick: () => void; disabled: boolean }>) {
+  const title = disabled ? 'Cannot edit production versions' : 'Edit this version in-place';
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      className={`${BTN} bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed`}
+    >
+      Edit
+    </button>
+  );
+}
+
+function CreateBtn({ onClick }: Readonly<{ onClick: () => void }>) {
+  return (
+    <button onClick={onClick} className={`${BTN} bg-emerald-600 hover:bg-emerald-500`}>
+      Create New Version
+    </button>
+  );
+}
+
+function DeleteBtn({ onClick }: Readonly<{ onClick: () => void }>) {
+  return (
+    <button
+      onClick={onClick}
+      title="Delete this draft version"
+      className={`${BTN} bg-red-600 hover:bg-red-500`}
+    >
+      Delete
+    </button>
+  );
+}
+
+function ActionButtons({
+  selectedVersion,
+  onTest,
+  onEdit,
+  onCreateNew,
+  onDelete,
+}: Readonly<{
+  selectedVersion: PromptVersion;
+  onTest: () => void;
+  onEdit: () => void;
+  onCreateNew: () => void;
+  onDelete: () => void;
+}>) {
+  const stage = selectedVersion.stage as string;
+  return (
+    <>
+      <TestBtn onClick={onTest} />
+      <EditBtn onClick={onEdit} disabled={isEditDisabled(stage)} />
+      <CreateBtn onClick={onCreateNew} />
+      {stage === 'DEV' && <DeleteBtn onClick={onDelete} />}
+    </>
+  );
+}
+
 export function AgentHeader({
   agentName,
   prompts,
@@ -21,69 +129,21 @@ export function AgentHeader({
   onEdit,
   onCreateNew,
   onDelete,
-}: AgentHeaderProps) {
+}: Readonly<AgentHeaderProps>) {
   return (
     <header className="mb-4 flex-shrink-0">
-      <Link
-        href="/prompts"
-        className="inline-flex items-center gap-2 text-sm text-neutral-400 hover:text-white mb-3"
-      >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-        </svg>
-        Back to Prompts
-      </Link>
+      <BackLink />
       <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white">{agentName}</h1>
-          <p className="mt-1 text-sm text-neutral-400">
-            {prompts.length} version{prompts.length !== 1 ? 's' : ''} •{' '}
-            {currentPrompt && (
-              <span className="text-emerald-400">Current: {currentPrompt.version}</span>
-            )}
-          </p>
-        </div>
+        <AgentTitle agentName={agentName} prompts={prompts} currentPrompt={currentPrompt} />
         <div className="flex items-center gap-2">
           {selectedVersion && (
-            <>
-              <button
-                onClick={onTest}
-                className="rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-500"
-              >
-                🧪 Test
-              </button>
-              <button
-                onClick={onEdit}
-                disabled={
-                  (selectedVersion.stage as string) === 'PRD' ||
-                  (selectedVersion.stage as string) === 'RET'
-                }
-                className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                title={
-                  (selectedVersion.stage as string) === 'PRD' ||
-                  (selectedVersion.stage as string) === 'RET'
-                    ? 'Cannot edit production versions'
-                    : 'Edit this version in-place'
-                }
-              >
-                Edit
-              </button>
-              <button
-                onClick={onCreateNew}
-                className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
-              >
-                Create New Version
-              </button>
-              {(selectedVersion.stage as string) === 'DEV' && selectedVersion.stage !== 'PRD' && (
-                <button
-                  onClick={onDelete}
-                  className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500"
-                  title="Delete this draft version"
-                >
-                  Delete
-                </button>
-              )}
-            </>
+            <ActionButtons
+              selectedVersion={selectedVersion}
+              onTest={onTest}
+              onEdit={onEdit}
+              onCreateNew={onCreateNew}
+              onDelete={onDelete}
+            />
           )}
         </div>
       </div>

--- a/apps/admin/src/app/(dashboard)/agents/[agent]/components/PromptDisplay.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/[agent]/components/PromptDisplay.tsx
@@ -9,62 +9,116 @@ interface PromptDisplayProps {
   onCompare: () => void;
 }
 
+const CONTAINER_CLASS =
+  'flex-1 min-w-0 rounded-xl border border-neutral-800 bg-neutral-900/60 overflow-hidden flex flex-col';
+const PROSE_CLASS =
+  'prose prose-invert prose-sm max-w-none prose-headings:text-neutral-200 prose-headings:font-semibold prose-p:text-neutral-300 prose-strong:text-neutral-200 prose-ul:text-neutral-300 prose-li:text-neutral-300 prose-code:text-sky-300 prose-code:bg-neutral-800 prose-code:px-1 prose-code:rounded';
+
+function EmptyState() {
+  return (
+    <div className={CONTAINER_CLASS}>
+      <div className="flex-1 flex items-center justify-center text-neutral-500">
+        Select a version to view
+      </div>
+    </div>
+  );
+}
+
+function VersionMeta({ version }: Readonly<{ version: PromptVersion }>) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="font-medium text-white">{version.version}</span>
+      <span className="text-sm text-neutral-400">
+        {version.prompt_text.length.toLocaleString()} chars • ~
+        {estimateTokens(version.prompt_text).toLocaleString()} tokens
+      </span>
+    </div>
+  );
+}
+
+function PromoteBtn({ stage, onClick }: Readonly<{ stage: string; onClick: () => void }>) {
+  if (stage === 'DEV')
+    return (
+      <button onClick={onClick} className="text-sm text-amber-400 hover:text-amber-300">
+        Promote to TST
+      </button>
+    );
+  if (stage === 'TST')
+    return (
+      <button onClick={onClick} className="text-sm text-emerald-400 hover:text-emerald-300">
+        Promote to PRD
+      </button>
+    );
+  return null;
+}
+
+function PromoteActions({
+  version,
+  currentPrompt,
+  onPromote,
+  onCompare,
+}: Readonly<{
+  version: PromptVersion;
+  currentPrompt: PromptVersion | undefined;
+  onPromote: () => void;
+  onCompare: () => void;
+}>) {
+  return (
+    <div className="flex items-center gap-2">
+      <PromoteBtn stage={version.stage as string} onClick={onPromote} />
+      {currentPrompt && version.stage !== 'PRD' && (
+        <button onClick={onCompare} className="text-sm text-purple-400 hover:text-purple-300">
+          Compare with Current
+        </button>
+      )}
+    </div>
+  );
+}
+
+function VersionHeader({
+  version,
+  currentPrompt,
+  onPromote,
+  onCompare,
+}: Readonly<{
+  version: PromptVersion;
+  currentPrompt: PromptVersion | undefined;
+  onPromote: () => void;
+  onCompare: () => void;
+}>) {
+  return (
+    <div className="p-4 border-b border-neutral-800 flex-shrink-0">
+      <div className="flex items-center justify-between">
+        <VersionMeta version={version} />
+        <PromoteActions
+          version={version}
+          currentPrompt={currentPrompt}
+          onPromote={onPromote}
+          onCompare={onCompare}
+        />
+      </div>
+      {version.notes && <p className="text-sm text-neutral-400 mt-2">📝 {version.notes}</p>}
+    </div>
+  );
+}
+
 export function PromptDisplay({
   version,
   currentPrompt,
   onPromote,
   onCompare,
-}: PromptDisplayProps) {
-  if (!version) {
-    return (
-      <div className="flex-1 min-w-0 rounded-xl border border-neutral-800 bg-neutral-900/60 overflow-hidden flex flex-col">
-        <div className="flex-1 flex items-center justify-center text-neutral-500">
-          Select a version to view
-        </div>
-      </div>
-    );
-  }
-
+}: Readonly<PromptDisplayProps>) {
+  if (!version) return <EmptyState />;
   return (
-    <div className="flex-1 min-w-0 rounded-xl border border-neutral-800 bg-neutral-900/60 overflow-hidden flex flex-col">
-      <div className="p-4 border-b border-neutral-800 flex-shrink-0">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <span className="font-medium text-white">{version.version}</span>
-            <span className="text-sm text-neutral-400">
-              {version.prompt_text.length.toLocaleString()} chars • ~
-              {estimateTokens(version.prompt_text).toLocaleString()} tokens
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            {(version.stage as string) === 'DEV' && (
-              <button onClick={onPromote} className="text-sm text-amber-400 hover:text-amber-300">
-                Promote to TST
-              </button>
-            )}
-            {(version.stage as string) === 'TST' && (
-              <button
-                onClick={onPromote}
-                className="text-sm text-emerald-400 hover:text-emerald-300"
-              >
-                Promote to PRD
-              </button>
-            )}
-            {currentPrompt && version.stage !== 'PRD' && (
-              <button onClick={onCompare} className="text-sm text-purple-400 hover:text-purple-300">
-                Compare with Current
-              </button>
-            )}
-          </div>
-        </div>
-        {version.notes && <p className="text-sm text-neutral-400 mt-2">📝 {version.notes}</p>}
-      </div>
-
+    <div className={CONTAINER_CLASS}>
+      <VersionHeader
+        version={version}
+        currentPrompt={currentPrompt}
+        onPromote={onPromote}
+        onCompare={onCompare}
+      />
       <div className="flex-1 overflow-auto p-4">
-        <MarkdownRenderer
-          content={version.prompt_text}
-          className="prose prose-invert prose-sm max-w-none prose-headings:text-neutral-200 prose-headings:font-semibold prose-p:text-neutral-300 prose-strong:text-neutral-200 prose-ul:text-neutral-300 prose-li:text-neutral-300 prose-code:text-sky-300 prose-code:bg-neutral-800 prose-code:px-1 prose-code:rounded"
-        />
+        <MarkdownRenderer content={version.prompt_text} className={PROSE_CLASS} />
       </div>
     </div>
   );

--- a/apps/admin/src/app/(dashboard)/agents/[agent]/components/VersionList.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/[agent]/components/VersionList.tsx
@@ -22,7 +22,7 @@ function getVersionDate(p: PromptVersion): string {
   return new Date(date).toLocaleDateString();
 }
 
-function VersionHeader({ p }: { p: PromptVersion }) {
+function VersionHeader({ p }: Readonly<{ p: PromptVersion }>) {
   return (
     <div className="flex items-center gap-2">
       <span
@@ -43,11 +43,11 @@ function VersionButton({
   p,
   isSelected,
   onSelect,
-}: {
+}: Readonly<{
   p: PromptVersion;
   isSelected: boolean;
   onSelect: () => void;
-}) {
+}>) {
   return (
     <button
       onClick={onSelect}
@@ -64,7 +64,7 @@ function VersionButton({
   );
 }
 
-export function VersionList({ prompts, selectedVersion, onSelect }: VersionListProps) {
+export function VersionList({ prompts, selectedVersion, onSelect }: Readonly<VersionListProps>) {
   return (
     <div className="w-64 flex-shrink-0 rounded-xl border border-neutral-800 bg-neutral-900/60 overflow-hidden flex flex-col">
       <div className="p-4 border-b border-neutral-800 flex-shrink-0">

--- a/apps/admin/src/app/(dashboard)/agents/components/AgentDetail.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/AgentDetail.tsx
@@ -13,6 +13,210 @@ interface AgentDetailProps {
   onTest: (p: PromptVersion) => void;
 }
 
+const BTN = 'rounded-lg px-4 py-2 text-sm font-medium text-white';
+
+function DetailHeaderBtns({
+  prompt,
+  onTest,
+  onEdit,
+}: Readonly<{
+  prompt: PromptVersion;
+  onTest: (p: PromptVersion) => void;
+  onEdit: (p: PromptVersion) => void;
+}>) {
+  return (
+    <div className="flex items-center gap-2">
+      <button onClick={() => onTest(prompt)} className={`${BTN} bg-purple-600 hover:bg-purple-500`}>
+        🧪 Test
+      </button>
+      <button onClick={() => onEdit(prompt)} className={`${BTN} bg-sky-600 hover:bg-sky-500`}>
+        Edit Current
+      </button>
+    </div>
+  );
+}
+
+function DetailHeader({
+  agentName,
+  currentPrompt,
+  onTest,
+  onEdit,
+}: Readonly<{
+  agentName: string;
+  currentPrompt: PromptVersion | undefined;
+  onTest: (p: PromptVersion) => void;
+  onEdit: (p: PromptVersion) => void;
+}>) {
+  return (
+    <div className="flex items-center justify-between mb-4 flex-shrink-0">
+      <h2 className="text-lg font-semibold text-white">{agentName}</h2>
+      {currentPrompt && <DetailHeaderBtns prompt={currentPrompt} onTest={onTest} onEdit={onEdit} />}
+    </div>
+  );
+}
+
+function CurrentPromptView({ prompt }: Readonly<{ prompt: PromptVersion }>) {
+  return (
+    <div className="flex-1 min-h-0 flex flex-col mb-4">
+      <div className="flex items-center gap-3 mb-2 flex-shrink-0">
+        <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-2 py-0.5 text-xs">
+          Current: {prompt.version}
+        </span>
+        <span className="text-sm text-neutral-400">
+          {prompt.prompt_text.length.toLocaleString()} chars • ~
+          {estimateTokens(prompt.prompt_text).toLocaleString()} tokens
+        </span>
+      </div>
+      {prompt.notes && (
+        <p className="text-sm text-neutral-400 mb-2 flex-shrink-0">📝 {prompt.notes}</p>
+      )}
+      <pre className="flex-1 p-4 rounded-md bg-neutral-950 text-sm text-neutral-300 overflow-auto whitespace-pre-wrap">
+        {prompt.prompt_text}
+      </pre>
+    </div>
+  );
+}
+
+function VersionInfo({ p }: Readonly<{ p: PromptVersion }>) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        <span className={`font-medium ${p.stage === 'PRD' ? 'text-emerald-300' : 'text-white'}`}>
+          {p.version}
+        </span>
+        {p.stage && (
+          <span className={`text-xs rounded-full px-2 py-0.5 ${getStageBadge(p.stage).className}`}>
+            {getStageBadge(p.stage).label}
+          </span>
+        )}
+      </div>
+      <div className="text-xs text-neutral-500">{new Date(p.created_at).toLocaleString()}</div>
+      {p.notes && (
+        <div className="text-xs text-neutral-500 truncate" title={p.notes}>
+          {p.notes}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PromoteActionBtn({ stage, onClick }: Readonly<{ stage: string; onClick: () => void }>) {
+  if (stage === 'DEV')
+    return (
+      <button onClick={onClick} className="text-xs text-amber-400 hover:text-amber-300">
+        → TST
+      </button>
+    );
+  if (stage === 'TST')
+    return (
+      <button onClick={onClick} className="text-xs text-emerald-400 hover:text-emerald-300">
+        → PRD
+      </button>
+    );
+  return null;
+}
+
+function VersionActions({
+  p,
+  currentPrompt,
+  onView,
+  onPromote,
+  onDiff,
+}: Readonly<{
+  p: PromptVersion;
+  currentPrompt: PromptVersion | undefined;
+  onView: (p: PromptVersion) => void;
+  onPromote: (p: PromptVersion) => void;
+  onDiff: (a: PromptVersion, b: PromptVersion) => void;
+}>) {
+  return (
+    <div className="flex items-center gap-2">
+      <button onClick={() => onView(p)} className="text-xs text-sky-400 hover:text-sky-300">
+        View
+      </button>
+      <PromoteActionBtn stage={p.stage as string} onClick={() => onPromote(p)} />
+      {p.stage !== 'PRD' && currentPrompt && (
+        <button
+          onClick={() => onDiff(currentPrompt, p)}
+          className="text-xs text-purple-400 hover:text-purple-300"
+        >
+          Diff
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface VersionRowProps {
+  p: PromptVersion;
+  currentPrompt: PromptVersion | undefined;
+  onView: (p: PromptVersion) => void;
+  onPromote: (p: PromptVersion) => void;
+  onDiff: (a: PromptVersion, b: PromptVersion) => void;
+}
+
+function VersionRowContent({ p }: Readonly<{ p: PromptVersion }>) {
+  return (
+    <div className="flex items-center gap-3 min-w-0 flex-1">
+      <div className="w-2 h-2 rounded-full bg-neutral-500 flex-shrink-0" />
+      <VersionInfo p={p} />
+    </div>
+  );
+}
+
+function VersionRow({ p, currentPrompt, onView, onPromote, onDiff }: Readonly<VersionRowProps>) {
+  const rowClass =
+    p.stage === 'PRD' ? 'bg-emerald-500/10 border border-emerald-500/30' : 'bg-neutral-800/30';
+  return (
+    <div className={`flex items-center justify-between p-3 rounded-lg ${rowClass}`}>
+      <VersionRowContent p={p} />
+      <VersionActions
+        p={p}
+        currentPrompt={currentPrompt}
+        onView={onView}
+        onPromote={onPromote}
+        onDiff={onDiff}
+      />
+    </div>
+  );
+}
+
+interface VersionHistoryProps {
+  prompts: PromptVersion[];
+  currentPrompt: PromptVersion | undefined;
+  onView: (p: PromptVersion) => void;
+  onPromote: (p: PromptVersion) => void;
+  onDiff: (a: PromptVersion, b: PromptVersion) => void;
+}
+
+function VersionHistory({
+  prompts,
+  currentPrompt,
+  onView,
+  onPromote,
+  onDiff,
+}: Readonly<VersionHistoryProps>) {
+  return (
+    <div className="flex-shrink-0 max-h-[200px] flex flex-col">
+      <h3 className="text-sm font-medium text-neutral-400 mb-3 flex-shrink-0">
+        Version History ({prompts.length})
+      </h3>
+      <div className="space-y-2 overflow-y-auto flex-1 pr-2">
+        {prompts.map((p) => (
+          <VersionRow
+            key={p.version}
+            p={p}
+            currentPrompt={currentPrompt}
+            onView={onView}
+            onPromote={onPromote}
+            onDiff={onDiff}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function AgentDetail({
   agentName,
   prompts,
@@ -21,128 +225,24 @@ export function AgentDetail({
   onDiff,
   onView,
   onTest,
-}: AgentDetailProps) {
+}: Readonly<AgentDetailProps>) {
   const currentPrompt = prompts.find((p) => p.stage === 'PRD');
-
   return (
     <div className="h-full flex flex-col rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 overflow-hidden">
-      <div className="flex items-center justify-between mb-4 flex-shrink-0">
-        <h2 className="text-lg font-semibold text-white">{agentName}</h2>
-        {currentPrompt && (
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => onTest(currentPrompt)}
-              className="rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white hover:bg-purple-500"
-            >
-              🧪 Test
-            </button>
-            <button
-              onClick={() => onEdit(currentPrompt)}
-              className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500"
-            >
-              Edit Current
-            </button>
-          </div>
-        )}
-      </div>
-
-      {currentPrompt && (
-        <div className="flex-1 min-h-0 flex flex-col mb-4">
-          <div className="flex items-center gap-3 mb-2 flex-shrink-0">
-            <span className="rounded-full bg-emerald-500/20 text-emerald-300 px-2 py-0.5 text-xs">
-              Current: {currentPrompt.version}
-            </span>
-            <span className="text-sm text-neutral-400">
-              {currentPrompt.prompt_text.length.toLocaleString()} chars • ~
-              {estimateTokens(currentPrompt.prompt_text).toLocaleString()} tokens
-            </span>
-          </div>
-          {currentPrompt.notes && (
-            <p className="text-sm text-neutral-400 mb-2 flex-shrink-0">📝 {currentPrompt.notes}</p>
-          )}
-          <pre className="flex-1 p-4 rounded-md bg-neutral-950 text-sm text-neutral-300 overflow-auto whitespace-pre-wrap">
-            {currentPrompt.prompt_text}
-          </pre>
-        </div>
-      )}
-
-      <div className="flex-shrink-0 max-h-[200px] flex flex-col">
-        <h3 className="text-sm font-medium text-neutral-400 mb-3 flex-shrink-0">
-          Version History ({prompts.length})
-        </h3>
-        <div className="space-y-2 overflow-y-auto flex-1 pr-2">
-          {prompts.map((p) => (
-            <div
-              key={p.version}
-              className={`flex items-center justify-between p-3 rounded-lg ${
-                p.stage === 'PRD'
-                  ? 'bg-emerald-500/10 border border-emerald-500/30'
-                  : 'bg-neutral-800/30'
-              }`}
-            >
-              <div className="flex items-center gap-3 min-w-0 flex-1">
-                <div className="w-2 h-2 rounded-full bg-neutral-500 flex-shrink-0" />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={`font-medium ${p.stage === 'PRD' ? 'text-emerald-300' : 'text-white'}`}
-                    >
-                      {p.version}
-                    </span>
-                    {p.stage && (
-                      <span
-                        className={`text-xs rounded-full px-2 py-0.5 ${getStageBadge(p.stage).className}`}
-                      >
-                        {getStageBadge(p.stage).label}
-                      </span>
-                    )}
-                  </div>
-                  <div className="text-xs text-neutral-500">
-                    {new Date(p.created_at).toLocaleString()}
-                  </div>
-                  {p.notes && (
-                    <div className="text-xs text-neutral-500 truncate" title={p.notes}>
-                      {p.notes}
-                    </div>
-                  )}
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => onView(p)}
-                  className="text-xs text-sky-400 hover:text-sky-300"
-                >
-                  View
-                </button>
-                {(p.stage as string) === 'DEV' && (
-                  <button
-                    onClick={() => onPromote(p)}
-                    className="text-xs text-amber-400 hover:text-amber-300"
-                  >
-                    → TST
-                  </button>
-                )}
-                {(p.stage as string) === 'TST' && (
-                  <button
-                    onClick={() => onPromote(p)}
-                    className="text-xs text-emerald-400 hover:text-emerald-300"
-                  >
-                    → PRD
-                  </button>
-                )}
-                {p.stage !== 'PRD' && currentPrompt && (
-                  <button
-                    onClick={() => onDiff(currentPrompt, p)}
-                    className="text-xs text-purple-400 hover:text-purple-300"
-                  >
-                    Diff
-                  </button>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
+      <DetailHeader
+        agentName={agentName}
+        currentPrompt={currentPrompt}
+        onTest={onTest}
+        onEdit={onEdit}
+      />
+      {currentPrompt && <CurrentPromptView prompt={currentPrompt} />}
+      <VersionHistory
+        prompts={prompts}
+        currentPrompt={currentPrompt}
+        onView={onView}
+        onPromote={onPromote}
+        onDiff={onDiff}
+      />
     </div>
   );
 }

--- a/apps/admin/src/app/(dashboard)/agents/components/AgentTable.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/AgentTable.tsx
@@ -11,7 +11,7 @@ interface AgentTableProps {
   onTest: (p: PromptVersion) => void;
 }
 
-export function AgentTable({ agents, promptsByAgent, onEdit, onTest }: AgentTableProps) {
+export function AgentTable({ agents, promptsByAgent, onEdit, onTest }: Readonly<AgentTableProps>) {
   return (
     <table className="w-full">
       <thead className="bg-neutral-900 sticky top-0">

--- a/apps/admin/src/app/(dashboard)/agents/components/AgentTableRowParts.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/AgentTableRowParts.tsx
@@ -3,7 +3,7 @@
 import type { PromptVersion } from '@/types/database';
 import { estimateTokens, getStageBadge, getAgentIcon } from '../utils';
 
-function EvalStatusBadge({ status, score }: { status: string; score?: number }) {
+function EvalStatusBadge({ status, score }: Readonly<{ status: string; score?: number }>) {
   const configs: Record<string, { icon: string; className: string; label: string }> = {
     passed: { icon: '🟢', className: 'bg-emerald-500/20 text-emerald-300', label: 'Passed' },
     warning: { icon: '🟡', className: 'bg-yellow-500/20 text-yellow-300', label: 'Warning' },

--- a/apps/admin/src/app/(dashboard)/agents/components/CoverageStats.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/CoverageStats.tsx
@@ -6,61 +6,69 @@ interface CoverageStatsProps {
   stats: CoverageStatsType;
 }
 
-export function CoverageStats({ stats }: CoverageStatsProps) {
+const CARD_CLASS = 'rounded-lg border border-neutral-800 bg-neutral-900/50 p-4';
+
+function StatCard({
+  value,
+  label,
+  colorClass = 'text-white',
+}: Readonly<{ value: string | number; label: string; colorClass?: string }>) {
   return (
-    <>
-      <div className="mt-4 grid grid-cols-4 gap-4">
-        <div className="rounded-lg border border-neutral-800 bg-neutral-900/50 p-4">
-          <div className="text-2xl font-bold text-white">{stats.totalAgents}</div>
-          <div className="text-xs text-neutral-400">Agents in Manifest</div>
-        </div>
-        <div className="rounded-lg border border-neutral-800 bg-neutral-900/50 p-4">
-          <div className="text-2xl font-bold text-white">{stats.currentPrompts}</div>
-          <div className="text-xs text-neutral-400">Active Prompts</div>
-        </div>
-        <div className="rounded-lg border border-neutral-800 bg-neutral-900/50 p-4">
-          <div
-            className={`text-2xl font-bold ${stats.coverage === 100 ? 'text-emerald-400' : 'text-amber-400'}`}
-          >
-            {stats.coverage}%
+    <div className={CARD_CLASS}>
+      <div className={`text-2xl font-bold ${colorClass}`}>{value}</div>
+      <div className="text-xs text-neutral-400">{label}</div>
+    </div>
+  );
+}
+
+function StatsGrid({ stats }: Readonly<{ stats: CoverageStatsType }>) {
+  const coverageColor = stats.coverage === 100 ? 'text-emerald-400' : 'text-amber-400';
+  const missingColor = stats.missingRequired.length === 0 ? 'text-emerald-400' : 'text-red-400';
+  const missingValue = stats.missingRequired.length === 0 ? '✓' : stats.missingRequired.length;
+  const missingLabel =
+    stats.missingRequired.length === 0 ? 'All Required Present' : 'Missing Required';
+  return (
+    <div className="mt-4 grid grid-cols-4 gap-4">
+      <StatCard value={stats.totalAgents} label="Agents in Manifest" />
+      <StatCard value={stats.currentPrompts} label="Active Prompts" />
+      <StatCard value={`${stats.coverage}%`} label="Required Coverage" colorClass={coverageColor} />
+      <StatCard value={missingValue} label={missingLabel} colorClass={missingColor} />
+    </div>
+  );
+}
+
+function MissingAlert({ missingRequired }: Readonly<{ missingRequired: string[] }>) {
+  if (missingRequired.length === 0) return null;
+  return (
+    <div className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+      <div className="flex items-start gap-3">
+        <span className="text-red-400">⚠️</span>
+        <div>
+          <div className="font-medium text-red-300">Missing Required Prompts</div>
+          <div className="mt-1 text-sm text-red-300/80">
+            The following prompts are required but not found in the database:
           </div>
-          <div className="text-xs text-neutral-400">Required Coverage</div>
-        </div>
-        <div className="rounded-lg border border-neutral-800 bg-neutral-900/50 p-4">
-          <div
-            className={`text-2xl font-bold ${stats.missingRequired.length === 0 ? 'text-emerald-400' : 'text-red-400'}`}
-          >
-            {stats.missingRequired.length === 0 ? '✓' : stats.missingRequired.length}
-          </div>
-          <div className="text-xs text-neutral-400">
-            {stats.missingRequired.length === 0 ? 'All Required Present' : 'Missing Required'}
+          <div className="mt-2 flex flex-wrap gap-2">
+            {missingRequired.map((name) => (
+              <span
+                key={name}
+                className="rounded-full bg-red-500/20 px-2 py-0.5 text-xs text-red-300"
+              >
+                {name}
+              </span>
+            ))}
           </div>
         </div>
       </div>
+    </div>
+  );
+}
 
-      {stats.missingRequired.length > 0 && (
-        <div className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
-          <div className="flex items-start gap-3">
-            <span className="text-red-400">⚠️</span>
-            <div>
-              <div className="font-medium text-red-300">Missing Required Prompts</div>
-              <div className="mt-1 text-sm text-red-300/80">
-                The following prompts are required but not found in the database:
-              </div>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {stats.missingRequired.map((name) => (
-                  <span
-                    key={name}
-                    className="rounded-full bg-red-500/20 px-2 py-0.5 text-xs text-red-300"
-                  >
-                    {name}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+export function CoverageStats({ stats }: Readonly<CoverageStatsProps>) {
+  return (
+    <>
+      <StatsGrid stats={stats} />
+      <MissingAlert missingRequired={stats.missingRequired} />
     </>
   );
 }

--- a/apps/admin/src/app/(dashboard)/agents/components/DiffModal.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/DiffModal.tsx
@@ -9,49 +9,70 @@ interface DiffModalProps {
   onClose: () => void;
 }
 
-export function DiffModal({ a, b, onClose }: DiffModalProps) {
+function DiffHeader({ a, b }: Readonly<{ a: PromptVersion; b: PromptVersion }>) {
+  return (
+    <div className="p-4 border-b border-neutral-800">
+      <h2 className="text-lg font-bold text-white">Compare Versions</h2>
+      <p className="text-sm text-neutral-400">
+        {a.version} (current) vs {b.version}
+      </p>
+    </div>
+  );
+}
+
+function DiffPane({
+  version,
+  text,
+  colorClass,
+  label,
+}: Readonly<{ version: string; text: string; colorClass: string; label?: string }>) {
+  return (
+    <div className="p-4">
+      <div className="flex items-center justify-between mb-2">
+        <span className={`text-sm font-medium ${colorClass}`}>
+          {version}
+          {label && ` ${label}`}
+        </span>
+        <span className="text-xs text-neutral-500">{text.length} chars</span>
+      </div>
+      <pre className="p-3 rounded-md bg-neutral-950 text-xs text-neutral-300 overflow-auto max-h-[60vh] whitespace-pre-wrap">
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+function DiffFooter({ charDiff, onClose }: Readonly<{ charDiff: number; onClose: () => void }>) {
+  return (
+    <div className="p-4 border-t border-neutral-800 flex justify-between">
+      <div className="text-sm text-neutral-400">
+        Diff: {charDiff > 0 ? '+' : ''}
+        {charDiff} chars
+      </div>
+      <button
+        onClick={onClose}
+        className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
+      >
+        Close
+      </button>
+    </div>
+  );
+}
+
+export function DiffModal({ a, b, onClose }: Readonly<DiffModalProps>) {
   return (
     <ModalWrapper onClose={onClose} maxWidth="max-w-6xl">
-      <div className="p-4 border-b border-neutral-800">
-        <h2 className="text-lg font-bold text-white">Compare Versions</h2>
-        <p className="text-sm text-neutral-400">
-          {a.version} (current) vs {b.version}
-        </p>
-      </div>
-
+      <DiffHeader a={a} b={b} />
       <div className="flex-1 overflow-auto grid grid-cols-2 divide-x divide-neutral-800">
-        <div className="p-4">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium text-emerald-400">{a.version} (current)</span>
-            <span className="text-xs text-neutral-500">{a.prompt_text.length} chars</span>
-          </div>
-          <pre className="p-3 rounded-md bg-neutral-950 text-xs text-neutral-300 overflow-auto max-h-[60vh] whitespace-pre-wrap">
-            {a.prompt_text}
-          </pre>
-        </div>
-        <div className="p-4">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium text-amber-400">{b.version}</span>
-            <span className="text-xs text-neutral-500">{b.prompt_text.length} chars</span>
-          </div>
-          <pre className="p-3 rounded-md bg-neutral-950 text-xs text-neutral-300 overflow-auto max-h-[60vh] whitespace-pre-wrap">
-            {b.prompt_text}
-          </pre>
-        </div>
+        <DiffPane
+          version={a.version}
+          text={a.prompt_text}
+          colorClass="text-emerald-400"
+          label="(current)"
+        />
+        <DiffPane version={b.version} text={b.prompt_text} colorClass="text-amber-400" />
       </div>
-
-      <div className="p-4 border-t border-neutral-800 flex justify-between">
-        <div className="text-sm text-neutral-400">
-          Diff: {a.prompt_text.length - b.prompt_text.length > 0 ? '+' : ''}
-          {a.prompt_text.length - b.prompt_text.length} chars
-        </div>
-        <button
-          onClick={onClose}
-          className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
-        >
-          Close
-        </button>
-      </div>
+      <DiffFooter charDiff={a.prompt_text.length - b.prompt_text.length} onClose={onClose} />
     </ModalWrapper>
   );
 }

--- a/apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/ModalWrapper.tsx
@@ -8,7 +8,11 @@ interface ModalWrapperProps {
   children: ReactNode;
 }
 
-export function ModalWrapper({ onClose, maxWidth = 'max-w-4xl', children }: ModalWrapperProps) {
+export function ModalWrapper({
+  onClose,
+  maxWidth = 'max-w-4xl',
+  children,
+}: Readonly<ModalWrapperProps>) {
   return (
     <button
       type="button"

--- a/apps/admin/src/app/(dashboard)/agents/components/PromptEditModal.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/PromptEditModal.tsx
@@ -15,7 +15,10 @@ interface PromptEditModalProps {
 
 type ModalState = { promptText: string; notes: string; newVersion: string; saving: boolean };
 
-function ModalHeader({ agentName, promptText }: { agentName: string; promptText: string }) {
+function ModalHeader({
+  agentName,
+  promptText,
+}: Readonly<{ agentName: string; promptText: string }>) {
   return (
     <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
       <div>
@@ -30,7 +33,7 @@ function ModalHeader({ agentName, promptText }: { agentName: string; promptText:
   );
 }
 
-function ModeNotice({ mode, version }: { mode: 'edit' | 'create'; version: string }) {
+function ModeNotice({ mode, version }: Readonly<{ mode: 'edit' | 'create'; version: string }>) {
   if (mode === 'create') {
     return (
       <div className="p-3 rounded-lg bg-neutral-800/50 border border-neutral-700">
@@ -51,7 +54,10 @@ function ModeNotice({ mode, version }: { mode: 'edit' | 'create'; version: strin
   );
 }
 
-function VersionNameField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+function VersionNameField({
+  value,
+  onChange,
+}: Readonly<{ value: string; onChange: (v: string) => void }>) {
   return (
     <div>
       <label htmlFor="versionName" className="block text-sm text-neutral-400 mb-1">
@@ -69,7 +75,10 @@ function VersionNameField({ value, onChange }: { value: string; onChange: (v: st
   );
 }
 
-function NotesField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+function NotesField({
+  value,
+  onChange,
+}: Readonly<{ value: string; onChange: (v: string) => void }>) {
   return (
     <div>
       <label htmlFor="notes" className="block text-sm text-neutral-400 mb-1">
@@ -87,7 +96,10 @@ function NotesField({ value, onChange }: { value: string; onChange: (v: string) 
   );
 }
 
-function PromptTextField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+function PromptTextField({
+  value,
+  onChange,
+}: Readonly<{ value: string; onChange: (v: string) => void }>) {
   return (
     <div className="flex-1">
       <label htmlFor="promptText" className="block text-sm text-neutral-400 mb-1">
@@ -114,12 +126,12 @@ function ModalFooter({
   onSave,
   saving,
   mode,
-}: {
+}: Readonly<{
   onClose: () => void;
   onSave: () => void;
   saving: boolean;
   mode: 'edit' | 'create';
-}) {
+}>) {
   const label = getSubmitButtonLabel(saving, mode);
   return (
     <div className="p-4 border-t border-neutral-800 flex justify-end gap-3">
@@ -186,11 +198,11 @@ function ModalBody({
   mode,
   prompt,
   state,
-}: {
+}: Readonly<{
   mode: 'edit' | 'create';
   prompt: PromptVersion;
   state: ReturnType<typeof useEditState>;
-}) {
+}>) {
   return (
     <div className="flex-1 overflow-auto p-4 space-y-4">
       <ModeNotice mode={mode} version={prompt.version} />
@@ -203,7 +215,7 @@ function ModalBody({
   );
 }
 
-export function PromptEditModal({ prompt, mode, onClose, onSave }: PromptEditModalProps) {
+export function PromptEditModal({ prompt, mode, onClose, onSave }: Readonly<PromptEditModalProps>) {
   const state = useEditState(prompt);
   const supabase = createClient();
 

--- a/apps/admin/src/app/(dashboard)/agents/components/PromptPlayground.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/PromptPlayground.tsx
@@ -10,7 +10,7 @@ interface PromptPlaygroundProps {
   onClose: () => void;
 }
 
-function PlaygroundHeader({ prompt }: { prompt: PromptVersion }) {
+function PlaygroundHeader({ prompt }: Readonly<{ prompt: PromptVersion }>) {
   return (
     <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
       <div>
@@ -28,7 +28,7 @@ function PlaygroundHeader({ prompt }: { prompt: PromptVersion }) {
   );
 }
 
-function PromptPreview({ text }: { text: string }) {
+function PromptPreview({ text }: Readonly<{ text: string }>) {
   return (
     <div>
       <span className="block text-sm text-neutral-400 mb-1">
@@ -42,7 +42,10 @@ function PromptPreview({ text }: { text: string }) {
   );
 }
 
-function TestInputField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+function TestInputField({
+  value,
+  onChange,
+}: Readonly<{ value: string; onChange: (v: string) => void }>) {
   return (
     <div>
       <label htmlFor="testInput" className="block text-sm text-neutral-400 mb-1">
@@ -63,11 +66,11 @@ function RunButton({
   onClick,
   disabled,
   testing,
-}: {
+}: Readonly<{
   onClick: () => void;
   disabled: boolean;
   testing: boolean;
-}) {
+}>) {
   return (
     <button
       onClick={onClick}
@@ -79,7 +82,7 @@ function RunButton({
   );
 }
 
-function OutputDisplay({ output }: { output: string }) {
+function OutputDisplay({ output }: Readonly<{ output: string }>) {
   return (
     <div>
       <span className="block text-sm text-neutral-400 mb-1">Output</span>
@@ -90,7 +93,7 @@ function OutputDisplay({ output }: { output: string }) {
   );
 }
 
-function PlaygroundFooter({ onClose }: { onClose: () => void }) {
+function PlaygroundFooter({ onClose }: Readonly<{ onClose: () => void }>) {
   return (
     <div className="p-4 border-t border-neutral-800 flex justify-between items-center">
       <p className="text-xs text-neutral-500">
@@ -152,11 +155,11 @@ function PlaygroundBody({
   prompt,
   state,
   onRun,
-}: {
+}: Readonly<{
   prompt: PromptVersion;
   state: ReturnType<typeof usePlaygroundState>;
   onRun: () => void;
-}) {
+}>) {
   return (
     <div className="flex-1 overflow-auto p-4 space-y-4">
       <PromptPreview text={prompt.prompt_text} />
@@ -174,7 +177,7 @@ function PlaygroundBody({
   );
 }
 
-export function PromptPlayground({ prompt, onClose }: PromptPlaygroundProps) {
+export function PromptPlayground({ prompt, onClose }: Readonly<PromptPlaygroundProps>) {
   const state = usePlaygroundState();
 
   async function runTest() {

--- a/apps/admin/src/app/(dashboard)/agents/components/ViewVersionModal.tsx
+++ b/apps/admin/src/app/(dashboard)/agents/components/ViewVersionModal.tsx
@@ -10,62 +10,94 @@ interface ViewVersionModalProps {
   onRollback: () => void;
 }
 
-export function ViewVersionModal({ prompt, onClose, onRollback }: ViewVersionModalProps) {
+function HeaderTitle({ prompt }: Readonly<{ prompt: PromptVersion }>) {
+  return (
+    <div>
+      <h2 className="text-lg font-bold text-white">{prompt.version}</h2>
+      <p className="text-sm text-neutral-400">
+        {prompt.agent_name} • {new Date(prompt.created_at).toLocaleString()}
+      </p>
+    </div>
+  );
+}
+
+function HeaderActions({
+  prompt,
+  onRollback,
+}: Readonly<{ prompt: PromptVersion; onRollback: () => void }>) {
+  const stageClass =
+    prompt.stage === 'PRD'
+      ? 'bg-emerald-500/20 text-emerald-300'
+      : 'bg-neutral-700 text-neutral-400';
+  return (
+    <div className="flex items-center gap-2">
+      {prompt.stage && (
+        <span className={`rounded-full px-2 py-0.5 text-xs ${stageClass}`}>
+          {prompt.stage === 'PRD' ? 'Live' : prompt.stage}
+        </span>
+      )}
+      <button
+        onClick={onRollback}
+        className="rounded-lg bg-amber-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-500"
+      >
+        Make Current
+      </button>
+    </div>
+  );
+}
+
+function VersionHeader({
+  prompt,
+  onRollback,
+}: Readonly<{ prompt: PromptVersion; onRollback: () => void }>) {
+  return (
+    <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
+      <HeaderTitle prompt={prompt} />
+      <HeaderActions prompt={prompt} onRollback={onRollback} />
+    </div>
+  );
+}
+
+function VersionBody({ prompt }: Readonly<{ prompt: PromptVersion }>) {
+  return (
+    <div className="flex-1 overflow-auto p-4">
+      {prompt.notes && (
+        <div className="mb-4 p-3 rounded-md bg-neutral-800/50 text-sm">
+          <span className="text-neutral-400">Notes: </span>
+          <span className="text-neutral-300">{prompt.notes}</span>
+        </div>
+      )}
+      <div className="flex gap-4 mb-4 text-sm text-neutral-400">
+        <span>{prompt.prompt_text.length.toLocaleString()} chars</span>
+        <span>~{estimateTokens(prompt.prompt_text).toLocaleString()} tokens</span>
+        {prompt.model_id && <span>Model: {prompt.model_id}</span>}
+      </div>
+      <pre className="p-4 rounded-md bg-neutral-950 text-sm text-neutral-300 overflow-auto whitespace-pre-wrap">
+        {prompt.prompt_text}
+      </pre>
+    </div>
+  );
+}
+
+function VersionFooter({ onClose }: Readonly<{ onClose: () => void }>) {
+  return (
+    <div className="p-4 border-t border-neutral-800 flex justify-end">
+      <button
+        onClick={onClose}
+        className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
+      >
+        Close
+      </button>
+    </div>
+  );
+}
+
+export function ViewVersionModal({ prompt, onClose, onRollback }: Readonly<ViewVersionModalProps>) {
   return (
     <ModalWrapper onClose={onClose}>
-      <div className="p-4 border-b border-neutral-800 flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-bold text-white">{prompt.version}</h2>
-          <p className="text-sm text-neutral-400">
-            {prompt.agent_name} • {new Date(prompt.created_at).toLocaleString()}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {prompt.stage && (
-            <span
-              className={`rounded-full px-2 py-0.5 text-xs ${
-                prompt.stage === 'PRD'
-                  ? 'bg-emerald-500/20 text-emerald-300'
-                  : 'bg-neutral-700 text-neutral-400'
-              }`}
-            >
-              {prompt.stage === 'PRD' ? 'Live' : prompt.stage}
-            </span>
-          )}
-          <button
-            onClick={onRollback}
-            className="rounded-lg bg-amber-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-500"
-          >
-            Make Current
-          </button>
-        </div>
-      </div>
-
-      <div className="flex-1 overflow-auto p-4">
-        {prompt.notes && (
-          <div className="mb-4 p-3 rounded-md bg-neutral-800/50 text-sm">
-            <span className="text-neutral-400">Notes: </span>
-            <span className="text-neutral-300">{prompt.notes}</span>
-          </div>
-        )}
-        <div className="flex gap-4 mb-4 text-sm text-neutral-400">
-          <span>{prompt.prompt_text.length.toLocaleString()} chars</span>
-          <span>~{estimateTokens(prompt.prompt_text).toLocaleString()} tokens</span>
-          {prompt.model_id && <span>Model: {prompt.model_id}</span>}
-        </div>
-        <pre className="p-4 rounded-md bg-neutral-950 text-sm text-neutral-300 overflow-auto whitespace-pre-wrap">
-          {prompt.prompt_text}
-        </pre>
-      </div>
-
-      <div className="p-4 border-t border-neutral-800 flex justify-end">
-        <button
-          onClick={onClose}
-          className="rounded-md px-4 py-2 text-sm text-neutral-400 hover:text-white"
-        >
-          Close
-        </button>
-      </div>
+      <VersionHeader prompt={prompt} onRollback={onRollback} />
+      <VersionBody prompt={prompt} />
+      <VersionFooter onClose={onClose} />
     </ModalWrapper>
   );
 }

--- a/apps/admin/src/app/(dashboard)/entities/proposal-actions.tsx
+++ b/apps/admin/src/app/(dashboard)/entities/proposal-actions.tsx
@@ -9,76 +9,81 @@ interface ProposalActionsProps {
   name: string;
 }
 
+async function handleApiCall(url: string, options: RequestInit, onSuccess: () => void) {
+  try {
+    const res = await fetch(url, options);
+    if (res.ok) {
+      onSuccess();
+      return;
+    }
+    const data = await res.json();
+    alert(`Failed: ${data.error}`);
+  } catch (err) {
+    alert(`Error: ${err instanceof Error ? err.message : 'Unknown'}`);
+  }
+}
+
+function ApproveButton({ loading, onClick }: Readonly<{ loading: boolean; onClick: () => void }>) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={loading}
+      className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {loading ? '...' : '✓ Approve'}
+    </button>
+  );
+}
+
+function RejectButton({ loading, onClick }: Readonly<{ loading: boolean; onClick: () => void }>) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={loading}
+      className="px-3 py-1.5 rounded-lg border border-red-500/30 text-red-400 text-sm font-medium hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {loading ? '...' : '✗ Reject'}
+    </button>
+  );
+}
+
+function useProposalHandlers(proposalId: string, name: string) {
+  const [loading, setLoading] = useState<'approve' | 'reject' | null>(null);
+  const router = useRouter();
+  const handleApprove = async () => {
+    setLoading('approve');
+    await handleApiCall(`/api/entities/${proposalId}/approve`, { method: 'POST' }, () =>
+      router.refresh(),
+    );
+    setLoading(null);
+  };
+  const handleReject = async () => {
+    const notes = prompt(`Rejection reason for "${name}" (optional):`);
+    setLoading('reject');
+    await handleApiCall(
+      `/api/entities/${proposalId}/reject`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notes }),
+      },
+      () => router.refresh(),
+    );
+    setLoading(null);
+  };
+  return { loading, handleApprove, handleReject };
+}
+
 export function ProposalActions({
   proposalId,
   entityType: _entityType,
   name,
-}: ProposalActionsProps) {
-  const [loading, setLoading] = useState<'approve' | 'reject' | null>(null);
-  const router = useRouter();
-
-  const handleApprove = async () => {
-    setLoading('approve');
-
-    try {
-      const res = await fetch(`/api/entities/${proposalId}/approve`, {
-        method: 'POST',
-      });
-
-      if (res.ok) {
-        router.refresh();
-      } else {
-        const data = await res.json();
-        alert(`Failed to approve: ${data.error}`);
-      }
-    } catch (err) {
-      alert(`Error: ${err instanceof Error ? err.message : 'Unknown'}`);
-    } finally {
-      setLoading(null);
-    }
-  };
-
-  const handleReject = async () => {
-    const notes = prompt(`Rejection reason for "${name}" (optional):`);
-
-    setLoading('reject');
-
-    try {
-      const res = await fetch(`/api/entities/${proposalId}/reject`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ notes }),
-      });
-
-      if (res.ok) {
-        router.refresh();
-      } else {
-        const data = await res.json();
-        alert(`Failed to reject: ${data.error}`);
-      }
-    } catch (err) {
-      alert(`Error: ${err instanceof Error ? err.message : 'Unknown'}`);
-    } finally {
-      setLoading(null);
-    }
-  };
-
+}: Readonly<ProposalActionsProps>) {
+  const { loading, handleApprove, handleReject } = useProposalHandlers(proposalId, name);
   return (
     <div className="flex items-center gap-2">
-      <button
-        onClick={handleApprove}
-        disabled={loading !== null}
-        className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {loading === 'approve' ? '...' : '✓ Approve'}
-      </button>
-      <button
-        onClick={handleReject}
-        disabled={loading !== null}
-        className="px-3 py-1.5 rounded-lg border border-red-500/30 text-red-400 text-sm font-medium hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {loading === 'reject' ? '...' : '✗ Reject'}
-      </button>
+      <ApproveButton loading={loading !== null} onClick={handleApprove} />
+      <RejectButton loading={loading !== null} onClick={handleReject} />
     </div>
   );
 }

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/components/form-fields.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/components/form-fields.tsx
@@ -9,10 +9,10 @@ const labelClass = 'block text-sm text-neutral-400 mb-1';
 export function TestNameField({
   value,
   onChange,
-}: {
+}: Readonly<{
   value: string;
   onChange: (v: string) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="testName" className={labelClass}>
@@ -34,11 +34,11 @@ export function AgentSelect({
   agents,
   value,
   onChange,
-}: {
+}: Readonly<{
   agents: string[];
   value: string;
   onChange: (v: string) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="agentSelect" className={labelClass}>
@@ -60,7 +60,7 @@ export function AgentSelect({
   );
 }
 
-function VariantOptions({ prompts }: { prompts: PromptVersion[] }) {
+function VariantOptions({ prompts }: Readonly<{ prompts: PromptVersion[] }>) {
   return (
     <>
       <option value="">Select version</option>
@@ -82,7 +82,14 @@ interface VariantSelectProps {
   prompts: PromptVersion[];
 }
 
-export function VariantSelect({ id, label, color, value, onChange, prompts }: VariantSelectProps) {
+export function VariantSelect({
+  id,
+  label,
+  color,
+  value,
+  onChange,
+  prompts,
+}: Readonly<VariantSelectProps>) {
   return (
     <div>
       <label htmlFor={id} className={labelClass}>
@@ -103,10 +110,10 @@ export function VariantSelect({ id, label, color, value, onChange, prompts }: Va
 export function TrafficSplitField({
   value,
   onChange,
-}: {
+}: Readonly<{
   value: number;
   onChange: (v: number) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="trafficSplit" className={labelClass}>
@@ -132,10 +139,10 @@ export function TrafficSplitField({
 export function SampleSizeField({
   value,
   onChange,
-}: {
+}: Readonly<{
   value: number;
   onChange: (v: number) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="sampleSize" className={labelClass}>
@@ -158,11 +165,11 @@ export function ModalFooter({
   onClose,
   onCreate,
   saving,
-}: {
+}: Readonly<{
   onClose: () => void;
   onCreate: () => void;
   saving: boolean;
-}) {
+}>) {
   return (
     <div className="flex justify-end gap-2 mt-6">
       <button onClick={onClose} className="px-4 py-2 text-sm text-neutral-400 hover:text-white">

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-content.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-content.tsx
@@ -44,7 +44,7 @@ function VariantSelects({
   setVariantA,
   variantB,
   setVariantB,
-}: VariantSelectsProps) {
+}: Readonly<VariantSelectsProps>) {
   return (
     <div className="grid grid-cols-2 gap-4">
       <VariantSelect
@@ -72,12 +72,12 @@ function SplitSizeFields({
   setTrafficSplit,
   sampleSize,
   setSampleSize,
-}: {
+}: Readonly<{
   trafficSplit: number;
   setTrafficSplit: (v: number) => void;
   sampleSize: number;
   setSampleSize: (v: number) => void;
-}) {
+}>) {
   return (
     <div className="grid grid-cols-2 gap-4">
       <TrafficSplitField value={trafficSplit} onChange={setTrafficSplit} />
@@ -86,7 +86,7 @@ function SplitSizeFields({
   );
 }
 
-export function ModalContent(props: ModalContentProps) {
+export function ModalContent(props: Readonly<ModalContentProps>) {
   return (
     <>
       <h2 className="text-lg font-bold text-white mb-4">Create A/B Test</h2>

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-wrapper.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/components/modal-wrapper.tsx
@@ -5,7 +5,7 @@ interface ModalWrapperProps {
   children: React.ReactNode;
 }
 
-export function ModalWrapper({ onClose, children }: ModalWrapperProps) {
+export function ModalWrapper({ onClose, children }: Readonly<ModalWrapperProps>) {
   return (
     <button
       type="button"

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/create-test-modal.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/create-test-modal.tsx
@@ -73,7 +73,12 @@ function useCreateHandler(state: ReturnType<typeof useTestFormState>, onCreated:
   return { saving, handleCreate };
 }
 
-export function CreateTestModal({ agents, prompts, onClose, onCreated }: CreateTestModalProps) {
+export function CreateTestModal({
+  agents,
+  prompts,
+  onClose,
+  onCreated,
+}: Readonly<CreateTestModalProps>) {
   const state = useTestFormState(agents, prompts);
   const { saving, handleCreate } = useCreateHandler(state, onCreated);
 

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/test-detail-modal/buttons.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/test-detail-modal/buttons.tsx
@@ -6,7 +6,10 @@ const BTN = 'rounded-lg px-4 py-2 text-sm font-medium disabled:opacity-50';
 const BTN_PRIMARY = `${BTN} text-white`;
 const BTN_OUTLINE = `${BTN} border`;
 
-function StartButton({ updating, onClick }: { updating: string | null; onClick: () => void }) {
+function StartButton({
+  updating,
+  onClick,
+}: Readonly<{ updating: string | null; onClick: () => void }>) {
   return (
     <button
       onClick={onClick}
@@ -22,11 +25,11 @@ function RunningButtons({
   updating,
   onPause,
   onComplete,
-}: {
+}: Readonly<{
   updating: string | null;
   onPause: () => void;
   onComplete: () => void;
-}) {
+}>) {
   return (
     <>
       <button
@@ -47,7 +50,10 @@ function RunningButtons({
   );
 }
 
-function ResumeButton({ updating, onClick }: { updating: string | null; onClick: () => void }) {
+function ResumeButton({
+  updating,
+  onClick,
+}: Readonly<{ updating: string | null; onClick: () => void }>) {
   return (
     <button
       onClick={onClick}
@@ -62,10 +68,10 @@ function ResumeButton({ updating, onClick }: { updating: string | null; onClick:
 function PromoteButtons({
   updating,
   onPromote,
-}: {
+}: Readonly<{
   updating: string | null;
   onPromote: (w: 'a' | 'b') => void;
-}) {
+}>) {
   return (
     <>
       <button
@@ -86,7 +92,7 @@ function PromoteButtons({
   );
 }
 
-function WinnerBadge({ winner }: { winner: string }) {
+function WinnerBadge({ winner }: Readonly<{ winner: string }>) {
   return (
     <div className="text-emerald-400 text-sm py-2">
       ✓ Variant {winner.toUpperCase()} promoted as current
@@ -105,11 +111,11 @@ function StatusButtons({
   test,
   updating,
   updateStatus,
-}: {
+}: Readonly<{
   test: PromptABTest;
   updating: string | null;
   updateStatus: (s: string) => void;
-}) {
+}>) {
   if (test.status === 'draft')
     return <StartButton updating={updating} onClick={() => updateStatus('running')} />;
   if (test.status === 'running')
@@ -125,7 +131,12 @@ function StatusButtons({
   return null;
 }
 
-export function ActionButtons({ test, updating, updateStatus, promoteWinner }: ActionButtonsProps) {
+export function ActionButtons({
+  test,
+  updating,
+  updateStatus,
+  promoteWinner,
+}: Readonly<ActionButtonsProps>) {
   const showPromote = (test.status === 'completed' || test.items_processed > 0) && !test.winner;
   return (
     <div className="flex flex-wrap gap-2">

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/test-detail-modal/components.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/test-detail-modal/components.tsx
@@ -13,7 +13,7 @@ export type TestResults = {
   variant_b?: { avg_confidence?: number };
 };
 
-export function ModalHeader({ test }: { test: PromptABTest }) {
+export function ModalHeader({ test }: Readonly<{ test: PromptABTest }>) {
   return (
     <div className="flex items-center justify-between mb-4">
       <div>
@@ -44,13 +44,13 @@ function VariantCard({
   version,
   items,
   confidence,
-}: {
+}: Readonly<{
   label: string;
   color: string;
   version: string;
   items: number;
   confidence?: number;
-}) {
+}>) {
   const styles = getVariantStyles(color);
   return (
     <div className={`rounded-lg border ${styles.border} p-4`}>
@@ -68,7 +68,10 @@ function VariantCard({
   );
 }
 
-export function VariantCards({ test, results }: { test: PromptABTest; results?: TestResults }) {
+export function VariantCards({
+  test,
+  results,
+}: Readonly<{ test: PromptABTest; results?: TestResults }>) {
   return (
     <div className="grid grid-cols-2 gap-4 mb-6">
       <VariantCard
@@ -89,7 +92,7 @@ export function VariantCards({ test, results }: { test: PromptABTest; results?: 
   );
 }
 
-export function ProgressBar({ processed, total }: { processed: number; total: number }) {
+export function ProgressBar({ processed, total }: Readonly<{ processed: number; total: number }>) {
   return (
     <div className="mb-6">
       <div className="flex items-center justify-between text-sm mb-2">

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/test-detail-modal/index.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/test-detail-modal/index.tsx
@@ -11,7 +11,7 @@ interface TestDetailModalProps {
   onUpdate: () => void;
 }
 
-function ModalContent({ test, onClose, onUpdate }: TestDetailModalProps) {
+function ModalContent({ test, onClose, onUpdate }: Readonly<TestDetailModalProps>) {
   const { updating, updateStatus, promoteWinner } = useTestActions(test, onUpdate);
   const results = test.results as TestResults | undefined;
   return (
@@ -38,7 +38,7 @@ function ModalContent({ test, onClose, onUpdate }: TestDetailModalProps) {
   );
 }
 
-export function TestDetailModal({ test, onClose, onUpdate }: TestDetailModalProps) {
+export function TestDetailModal({ test, onClose, onUpdate }: Readonly<TestDetailModalProps>) {
   return (
     <button
       type="button"

--- a/apps/admin/src/app/(dashboard)/evals/components/agent-version-select.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/components/agent-version-select.tsx
@@ -23,11 +23,11 @@ function AgentDropdown({
   agents,
   value,
   onChange,
-}: {
+}: Readonly<{
   agents: string[];
   value: string;
   onChange: (v: string) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="agentSelect" className="block text-sm text-neutral-400 mb-1">
@@ -50,7 +50,7 @@ function AgentDropdown({
   );
 }
 
-function VersionOption({ p, showStage }: { p: PromptVersion; showStage: boolean }) {
+function VersionOption({ p, showStage }: Readonly<{ p: PromptVersion; showStage: boolean }>) {
   const stageText = showStage && p.stage ? ` (${p.stage})` : '';
   const currentMark = p.is_current ? ' ★' : '';
   return (
@@ -78,7 +78,7 @@ function VersionDropdown({
   label,
   disabled,
   showStage,
-}: VersionDropdownProps) {
+}: Readonly<VersionDropdownProps>) {
   return (
     <div>
       <label htmlFor="versionSelect" className="block text-sm text-neutral-400 mb-1">
@@ -109,7 +109,7 @@ export function AgentVersionSelect({
   onVersionChange,
   versionLabel = 'Prompt Version',
   showStage = false,
-}: AgentVersionSelectProps) {
+}: Readonly<AgentVersionSelectProps>) {
   const agentPrompts = prompts.filter((p) => p.agent_name === selectedAgent);
   const handleAgentChange = (v: string) => {
     onAgentChange(v);

--- a/apps/admin/src/app/(dashboard)/evals/components/loading-state.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/components/loading-state.tsx
@@ -2,7 +2,7 @@ interface LoadingStateProps {
   message?: string;
 }
 
-export function LoadingState({ message = 'Loading...' }: LoadingStateProps) {
+export function LoadingState({ message = 'Loading...' }: Readonly<LoadingStateProps>) {
   return (
     <div className="flex items-center justify-center h-64">
       <div className="text-neutral-400">{message}</div>

--- a/apps/admin/src/app/(dashboard)/evals/components/page-header.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/components/page-header.tsx
@@ -4,7 +4,7 @@ interface PageHeaderProps {
   action?: React.ReactNode;
 }
 
-export function PageHeader({ title, description, action }: PageHeaderProps) {
+export function PageHeader({ title, description, action }: Readonly<PageHeaderProps>) {
   return (
     <header className="mb-6 flex items-center justify-between">
       <div>

--- a/apps/admin/src/app/(dashboard)/evals/golden-sets/components/CreateGoldenSetForm.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/golden-sets/components/CreateGoldenSetForm.tsx
@@ -15,13 +15,13 @@ function CreateGoldenSetFormAgentNameSection({
   name,
   setName,
   agentOptions,
-}: {
+}: Readonly<{
   agentName: string;
   setAgentName: (v: string) => void;
   name: string;
   setName: (v: string) => void;
   agentOptions: string[];
-}) {
+}>) {
   return (
     <div className="grid grid-cols-2 gap-4">
       <CreateGoldenSetFormAgentField
@@ -37,10 +37,10 @@ function CreateGoldenSetFormAgentNameSection({
 function CreateGoldenSetFormDescriptionSection({
   description,
   setDescription,
-}: {
+}: Readonly<{
   description: string;
   setDescription: (v: string) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="golden-set-description" className="block text-sm text-neutral-400 mb-1">
@@ -63,12 +63,12 @@ function CreateGoldenSetFormJsonSection({
   setInputJson,
   expectedJson,
   setExpectedJson,
-}: {
+}: Readonly<{
   inputJson: string;
   setInputJson: (v: string) => void;
   expectedJson: string;
   setExpectedJson: (v: string) => void;
-}) {
+}>) {
   return (
     <>
       <CreateGoldenSetFormInputField inputJson={inputJson} setInputJson={setInputJson} />
@@ -82,7 +82,7 @@ function CreateGoldenSetFormJsonSection({
 
 type CreateGoldenSetFormLayoutProps = CreateGoldenSetFormProps & { agentOptions: string[] };
 
-function CreateGoldenSetFormLayoutSections(props: CreateGoldenSetFormLayoutProps) {
+function CreateGoldenSetFormLayoutSections(props: Readonly<CreateGoldenSetFormLayoutProps>) {
   return (
     <div className="flex-1 overflow-auto p-4 space-y-4">
       <CreateGoldenSetFormAgentNameSection
@@ -111,15 +111,15 @@ function CreateGoldenSetFormLayoutSections(props: CreateGoldenSetFormLayoutProps
   );
 }
 
-function CreateGoldenSetFormLayoutBody(props: CreateGoldenSetFormLayoutProps) {
+function CreateGoldenSetFormLayoutBody(props: Readonly<CreateGoldenSetFormLayoutProps>) {
   return <CreateGoldenSetFormLayoutSections {...props} />;
 }
 
-function CreateGoldenSetFormLayout({ ...props }: CreateGoldenSetFormLayoutProps) {
+function CreateGoldenSetFormLayout({ ...props }: Readonly<CreateGoldenSetFormLayoutProps>) {
   return <CreateGoldenSetFormLayoutBody {...props} />;
 }
 
-export function CreateGoldenSetForm(props: CreateGoldenSetFormProps) {
+export function CreateGoldenSetForm(props: Readonly<CreateGoldenSetFormProps>) {
   const agentOptions = ['tagger', 'summarizer', 'screener'];
   return <CreateGoldenSetFormLayout {...props} agentOptions={agentOptions} />;
 }

--- a/apps/admin/src/app/(dashboard)/evals/golden-sets/components/CreateGoldenSetFormFields.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/golden-sets/components/CreateGoldenSetFormFields.tsx
@@ -4,11 +4,11 @@ function CreateGoldenSetFormAgentField({
   agentName,
   setAgentName,
   agentOptions,
-}: {
+}: Readonly<{
   agentName: string;
   setAgentName: (v: string) => void;
   agentOptions: string[];
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="agent-select" className="block text-sm text-neutral-400 mb-1">
@@ -33,10 +33,10 @@ function CreateGoldenSetFormAgentField({
 function CreateGoldenSetFormNameField({
   name,
   setName,
-}: {
+}: Readonly<{
   name: string;
   setName: (v: string) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="golden-set-name" className="block text-sm text-neutral-400 mb-1">
@@ -57,10 +57,10 @@ function CreateGoldenSetFormNameField({
 function CreateGoldenSetFormInputField({
   inputJson,
   setInputJson,
-}: {
+}: Readonly<{
   inputJson: string;
   setInputJson: (v: string) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="golden-set-input" className="block text-sm text-neutral-400 mb-1">
@@ -79,10 +79,10 @@ function CreateGoldenSetFormInputField({
 function CreateGoldenSetFormExpectedField({
   expectedJson,
   setExpectedJson,
-}: {
+}: Readonly<{
   expectedJson: string;
   setExpectedJson: (v: string) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="golden-set-output" className="block text-sm text-neutral-400 mb-1">
@@ -102,11 +102,11 @@ function CreateGoldenSetFormActions({
   handleCreate,
   onClose,
   saving,
-}: {
+}: Readonly<{
   handleCreate: () => void;
   onClose: () => void;
   saving: boolean;
-}) {
+}>) {
   return (
     <div className="p-4 border-t border-neutral-800 flex justify-end gap-3">
       <button onClick={onClose} className="px-4 py-2 text-sm text-neutral-400 hover:text-white">

--- a/apps/admin/src/app/(dashboard)/evals/golden-sets/components/CreateGoldenSetModal.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/golden-sets/components/CreateGoldenSetModal.tsx
@@ -33,11 +33,11 @@ function CreateGoldenSetModalForm({
   state,
   handleCreate,
   onClose,
-}: {
+}: Readonly<{
   state: ReturnType<typeof useCreateGoldenSetState>;
   handleCreate: () => void;
   onClose: () => void;
-}) {
+}>) {
   const formData = toCreateGoldenSetFormData(state);
   const bindings = {
     setAgentName: state.setAgentName,
@@ -61,11 +61,11 @@ function CreateGoldenSetModalContent({
   state,
   handleCreate,
   onClose,
-}: {
+}: Readonly<{
   state: ReturnType<typeof useCreateGoldenSetState>;
   handleCreate: () => void;
   onClose: () => void;
-}) {
+}>) {
   return (
     <dialog
       open
@@ -83,11 +83,11 @@ function CreateGoldenSetModalWrapper({
   state,
   handleCreate,
   onClose,
-}: {
+}: Readonly<{
   state: ReturnType<typeof useCreateGoldenSetState>;
   handleCreate: () => void;
   onClose: () => void;
-}) {
+}>) {
   return (
     <button
       type="button"
@@ -101,7 +101,7 @@ function CreateGoldenSetModalWrapper({
   );
 }
 
-export function CreateGoldenSetModal({ onClose, onCreated }: CreateGoldenSetModalProps) {
+export function CreateGoldenSetModal({ onClose, onCreated }: Readonly<CreateGoldenSetModalProps>) {
   const state = useCreateGoldenSetState();
 
   const handleCreate = async () => {

--- a/apps/admin/src/app/(dashboard)/evals/golden-sets/components/GoldenSetsHeader.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/golden-sets/components/GoldenSetsHeader.tsx
@@ -9,10 +9,10 @@ interface GoldenSetsHeaderProps {
 function GoldenSetsStats({
   goldenSetsCount,
   agentsCount,
-}: {
+}: Readonly<{
   goldenSetsCount: number;
   agentsCount: number;
-}) {
+}>) {
   return (
     <div className="flex gap-4">
       <div className="rounded-lg bg-neutral-800/50 px-4 py-2 text-center">
@@ -30,10 +30,10 @@ function GoldenSetsStats({
 function GoldenSetsFilter({
   filterAgent,
   setFilterAgent,
-}: {
+}: Readonly<{
   filterAgent: string;
   setFilterAgent: (v: string) => void;
-}) {
+}>) {
   const agents = ['all', 'tagger', 'summarizer', 'screener'];
 
   return (
@@ -54,7 +54,7 @@ function GoldenSetsFilter({
   );
 }
 
-function GoldenSetsHeaderMain({ onAddClick }: { onAddClick: () => void }) {
+function GoldenSetsHeaderMain({ onAddClick }: Readonly<{ onAddClick: () => void }>) {
   return (
     <header className="mb-6 flex items-center justify-between">
       <div>
@@ -78,12 +78,12 @@ function GoldenSetsHeaderStatsFilter({
   agentsCount,
   filterAgent,
   setFilterAgent,
-}: {
+}: Readonly<{
   goldenSetsCount: number;
   agentsCount: number;
   filterAgent: string;
   setFilterAgent: (v: string) => void;
-}) {
+}>) {
   return (
     <div className="flex items-center justify-between mb-6">
       <GoldenSetsStats goldenSetsCount={goldenSetsCount} agentsCount={agentsCount} />
@@ -98,13 +98,13 @@ function GoldenSetsHeaderContent({
   filterAgent,
   setFilterAgent,
   onAddClick,
-}: {
+}: Readonly<{
   goldenSetsCount: number;
   agentsCount: number;
   filterAgent: string;
   setFilterAgent: (v: string) => void;
   onAddClick: () => void;
-}) {
+}>) {
   return (
     <>
       <GoldenSetsHeaderMain onAddClick={onAddClick} />
@@ -124,7 +124,7 @@ export function GoldenSetsHeader({
   filterAgent,
   setFilterAgent,
   onAddClick,
-}: GoldenSetsHeaderProps) {
+}: Readonly<GoldenSetsHeaderProps>) {
   return (
     <GoldenSetsHeaderContent
       goldenSetsCount={goldenSetsCount}

--- a/apps/admin/src/app/(dashboard)/evals/golden-sets/components/GoldenSetsList.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/golden-sets/components/GoldenSetsList.tsx
@@ -23,11 +23,11 @@ function GoldenSetsItem({
   item,
   setSelectedItem,
   handleDelete,
-}: {
+}: Readonly<{
   item: EvalGoldenSet;
   setSelectedItem: (item: EvalGoldenSet) => void;
   handleDelete: (id: string) => void;
-}) {
+}>) {
   return (
     <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-4 hover:border-neutral-700 transition-colors">
       <GoldenSetsItemContent item={item} />
@@ -41,7 +41,7 @@ function GoldenSetsItem({
   );
 }
 
-function GoldenSetsItemContent({ item }: { item: EvalGoldenSet }) {
+function GoldenSetsItemContent({ item }: Readonly<{ item: EvalGoldenSet }>) {
   return (
     <div className="flex items-start justify-between gap-4">
       <div className="flex-1 min-w-0">
@@ -53,7 +53,7 @@ function GoldenSetsItemContent({ item }: { item: EvalGoldenSet }) {
   );
 }
 
-function GoldenSetsItemHeader({ item }: { item: EvalGoldenSet }) {
+function GoldenSetsItemHeader({ item }: Readonly<{ item: EvalGoldenSet }>) {
   return (
     <div className="flex items-center gap-2 mb-2">
       <span className="rounded-full bg-sky-500/20 text-sky-300 px-2 py-0.5 text-xs">
@@ -64,7 +64,7 @@ function GoldenSetsItemHeader({ item }: { item: EvalGoldenSet }) {
   );
 }
 
-function GoldenSetsItemData({ item }: { item: EvalGoldenSet }) {
+function GoldenSetsItemData({ item }: Readonly<{ item: EvalGoldenSet }>) {
   return (
     <div className="grid grid-cols-2 gap-4 text-xs">
       <div>
@@ -89,11 +89,11 @@ function GoldenSetsItemActions({
   item,
   setSelectedItem,
   handleDelete,
-}: {
+}: Readonly<{
   item: EvalGoldenSet;
   setSelectedItem: (item: EvalGoldenSet) => void;
   handleDelete: (id: string) => void;
-}) {
+}>) {
   return (
     <div className="flex flex-col gap-2">
       <button
@@ -112,7 +112,7 @@ function GoldenSetsItemActions({
   );
 }
 
-function GoldenSetsItemFooter({ item }: { item: EvalGoldenSet }) {
+function GoldenSetsItemFooter({ item }: Readonly<{ item: EvalGoldenSet }>) {
   return (
     <div className="mt-2 text-xs text-neutral-500">
       Added {new Date(item.created_at).toLocaleDateString()}
@@ -125,7 +125,7 @@ export function GoldenSetsList({
   filteredSets,
   setSelectedItem,
   handleDelete,
-}: GoldenSetsListProps) {
+}: Readonly<GoldenSetsListProps>) {
   if (filteredSets.length === 0) {
     return <GoldenSetsEmpty />;
   }

--- a/docs/architecture/quality/sonar-lessons/mark-react-props-as-read-only.md
+++ b/docs/architecture/quality/sonar-lessons/mark-react-props-as-read-only.md
@@ -1,0 +1,139 @@
+# Lesson: Mark React Props as Read-Only
+
+**Rule:** [S6759 - React props should be read-only](../sonar-rules/6759_react-props-should-be-read-only.md)
+
+## The Problem
+
+React functional components receive props from parent components. If these props are mutable, child components could accidentally or intentionally modify them, leading to:
+
+- **Unpredictable behavior** - parent state could change unexpectedly
+- **Hard-to-track bugs** - mutations can happen anywhere in the component tree
+- **Performance issues** - React's rendering optimizations rely on immutability
+
+## Pattern to Avoid
+
+```tsx
+// ❌ BAD: Props interface is not read-only
+interface ButtonProps {
+  label: string;
+  onClick: () => void;
+}
+
+function Button({ label, onClick }: ButtonProps) {
+  return <button onClick={onClick}>{label}</button>;
+}
+```
+
+## Fix Pattern
+
+Use TypeScript's `Readonly<>` utility type to wrap the entire props interface:
+
+```tsx
+// ✅ GOOD: Props are wrapped with Readonly<>
+interface ButtonProps {
+  label: string;
+  onClick: () => void;
+}
+
+function Button({ label, onClick }: Readonly<ButtonProps>) {
+  return <button onClick={onClick}>{label}</button>;
+}
+```
+
+Alternative: Use `readonly` modifier on individual properties (more verbose):
+
+```tsx
+// ✅ ALSO GOOD: Individual readonly modifiers
+interface ButtonProps {
+  readonly label: string;
+  readonly onClick: () => void;
+}
+
+function Button({ label, onClick }: ButtonProps) {
+  return <button onClick={onClick}>{label}</button>;
+}
+```
+
+## Preferred Approach
+
+We prefer `Readonly<Props>` over individual `readonly` modifiers because:
+
+1. **Less verbose** - one wrapper instead of marking each property
+2. **Can't forget** - all properties are automatically read-only
+3. **Easier refactoring** - adding new props doesn't require remembering to add `readonly`
+
+## Inline Props Pattern
+
+For components with inline props types:
+
+```tsx
+// ❌ BAD: Inline props not read-only
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h2>{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+// ✅ GOOD: Wrap inline props with Readonly<>
+function Card({ title, children }: Readonly<{ title: string; children: React.ReactNode }>) {
+  return (
+    <div>
+      <h2>{title}</h2>
+      {children}
+    </div>
+  );
+}
+```
+
+## Benefits
+
+1. **Enforces immutability** - TypeScript will error if you try to mutate props
+2. **Clear data flow** - props flow down, never modified by children
+3. **Performance optimizations** - React can safely skip re-renders
+4. **Self-documenting** - signals intent that props should not be changed
+
+## Real Examples from Codebase
+
+### Before (S6759 violation)
+
+```tsx
+// apps/admin/src/app/(dashboard)/evals/ab-tests/components/form-fields.tsx
+function TestNameField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label>Test Name</label>
+      <input value={value} onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}
+```
+
+### After (Fixed)
+
+```tsx
+function TestNameField({
+  value,
+  onChange,
+}: Readonly<{
+  value: string;
+  onChange: (v: string) => void;
+}>) {
+  return (
+    <div>
+      <label>Test Name</label>
+      <input value={value} onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}
+```
+
+## Checklist
+
+When writing React components:
+
+- [ ] Wrap props type with `Readonly<>` for functional components
+- [ ] For inline props, use `Readonly<{ ... }>` syntax
+- [ ] For named interfaces, use `: Readonly<InterfaceName>` in function signature

--- a/docs/architecture/quality/sonar-rules/6759_react-props-should-be-read-only.md
+++ b/docs/architecture/quality/sonar-rules/6759_react-props-should-be-read-only.md
@@ -1,0 +1,17 @@
+# S6759: React props should be read-only
+
+**Rule:** [typescript:S6759](https://rules.sonarsource.com/typescript/RSPEC-6759/)
+
+**Severity:** Low (Code Smell)
+
+**Category:** Maintainability, Consistency
+
+## Why it matters
+
+React props should be read-only because it helps enforce the principle of immutability in React functional components. By making props read-only, you ensure that the data passed from a parent component to a child component cannot be modified directly by the child component. This helps maintain a clear data flow and prevents unexpected side effects.
+
+If props were mutable, child components could modify the props directly, leading to unpredictable behavior and making it harder to track down bugs. By enforcing read-only props, React promotes a more predictable and maintainable codebase. Additionally, read-only props enable performance optimizations in React's rendering process by avoiding unnecessary re-renders of components.
+
+## Lesson
+
+See: [mark-react-props-as-read-only.md](../sonar-lessons/mark-react-props-as-read-only.md)

--- a/docs/architecture/quality/sonarcloud.md
+++ b/docs/architecture/quality/sonarcloud.md
@@ -42,6 +42,7 @@ When you see a SonarCloud issue, extract the Rule ID and find the matching lesso
 | S6847   | [Use role presentation for non-interactive event handlers](./sonar-lessons/use-role-presentation-for-non-interactive-event-handlers.md)                       |
 | S4624   | [Refactor this code to not use nested template literals](./sonar-lessons/refactor-this-code-to-not-use-nested-template-literals.md)                           |
 | S6479   | [Do not use Array index in keys](./sonar-lessons/do-not-use-array-index-in-keys.md)                                                                           |
+| S6759   | [Mark React props as read-only](./sonar-lessons/mark-react-props-as-read-only.md)                                                                             |
 
 ---
 
@@ -52,6 +53,7 @@ Quick checks before committing. If you're about to write any of these patterns, 
 - [ ] **No nested ternaries** — Extract to helper function with early returns
 - [ ] **No nested template literals** — Extract conditional parts to variables first
 - [ ] **No array index as React key** — Use unique identifier from data (id, slug, code)
+- [ ] **Mark React props as read-only** — Use `Readonly<Props>` wrapper on component props
 - [ ] **No boolean selector parameters** — Use separate methods or union types
 - [ ] **Interactive handlers on interactive elements only** — Use `<button>`, not `<div onClick>`
 - [ ] **Prefer native HTML over ARIA roles** — Use `<button>` not `<div role="button">`
@@ -103,6 +105,10 @@ Project-specific patterns derived from fixing real issues. Each entry shows what
 
 ---
 
+## [Mark React props as read-only](./sonar-lessons/mark-react-props-as-read-only.md) (S6759)
+
+---
+
 # Rule Index
 
 Rules we've encountered. Links to authoritative SonarSource documentation.
@@ -136,5 +142,9 @@ Rules we've encountered. Links to authoritative SonarSource documentation.
 ---
 
 ## [JSX list components should not use array indexes as key](./sonar-rules/6479_jsx-list-components-should-not-use-array-indexes-as-key.md)
+
+---
+
+## [React props should be read-only](./sonar-rules/6759_react-props-should-be-read-only.md)
 
 ---


### PR DESCRIPTION
## Problem
SonarCloud flagged S6759 violations - React props should be read-only to enforce immutability and prevent accidental mutations.

## Root Cause
Component props were defined without the `Readonly<>` wrapper, allowing potential mutation of props by child components.

## Solution
- Added `Readonly<>` wrapper to all component props across 30 files
- Refactored large functions into smaller components to meet quality gate (<30 lines)
- Created rule documentation: `6759_react-props-should-be-read-only.md`
- Created lesson documentation: `mark-react-props-as-read-only.md`
- Updated `sonarcloud.md` with S6759 references

## Files Changed
### Documentation
- `docs/architecture/quality/sonar-rules/6759_react-props-should-be-read-only.md` - New rule doc
- `docs/architecture/quality/sonar-lessons/mark-react-props-as-read-only.md` - New lesson doc
- `docs/architecture/quality/sonarcloud.md` - Updated with S6759

### Components (Readonly<> wrapper added)
- `add/components/WhyValuable.tsx`
- `add/page.tsx`
- `agents/[agent]/components/*.tsx`
- `agents/components/*.tsx`
- `entities/proposal-actions.tsx`
- `evals/ab-tests/components/*.tsx`
- `evals/components/*.tsx`
- `evals/golden-sets/components/*.tsx`

Doc updated: sonarcloud.md