### PR TITLE
fix: wrap React props with Readonly to fix SonarCloud S6759 (batch 3)

### DIFF
--- a/apps/admin/src/app/(dashboard)/evals/llm-judge/components/index.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/llm-judge/components/index.tsx
@@ -22,11 +22,11 @@ export function AgentSelect({
   agents,
   value,
   onChange,
-}: {
+}: Readonly<{
   agents: string[];
   value: string;
   onChange: (v: string) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="judgeAgent" className="block text-sm text-neutral-400 mb-1">
@@ -91,10 +91,10 @@ export function PromptSelect({ prompts, value, onChange, disabled }: Readonly<Pr
 export function CriteriaInput({
   value,
   onChange,
-}: {
+}: Readonly<{
   value: string;
   onChange: (v: string) => void;
-}) {
+}>) {
   return (
     <div>
       <label htmlFor="judgeCriteria" className="block text-sm text-neutral-400 mb-1">
@@ -116,11 +116,11 @@ export function RunButton({
   onClick,
   disabled,
   running,
-}: {
+}: Readonly<{
   onClick: () => void;
   disabled: boolean;
   running: boolean;
-}) {
+}>) {
   return (
     <div className="flex items-end">
       <button

--- a/apps/admin/src/app/(dashboard)/items/[id]/enrichment-panel/index.tsx
+++ b/apps/admin/src/app/(dashboard)/items/[id]/enrichment-panel/index.tsx
@@ -158,7 +158,7 @@ export function EnrichmentPanel({
   item,
   currentPrompts,
   utilityVersions = [],
-}: EnrichmentPanelProps) {
+}: Readonly<EnrichmentPanelProps>) {
   const actions = useEnrichmentActions(item);
   return (
     <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-4">

--- a/apps/admin/src/app/(dashboard)/items/detail-panel.tsx
+++ b/apps/admin/src/app/(dashboard)/items/detail-panel.tsx
@@ -79,7 +79,7 @@ function buildViewProps(
   };
 }
 
-export function DetailPanel(props: DetailPanelProps) {
+export function DetailPanel(props: Readonly<DetailPanelProps>) {
   const { item, loading } = useDetailPanelData(props.itemId);
   const { actionLoading, handleAction } = useDetailPanelAction(props.itemId, props.onAction);
   useDetailPanelShortcuts(props, (item as _QueueItem) || null, actionLoading, handleAction);

--- a/apps/admin/src/app/(dashboard)/items/master-detail.tsx
+++ b/apps/admin/src/app/(dashboard)/items/master-detail.tsx
@@ -147,18 +147,33 @@ function useMasterViewActions(
   return { handleNavigate, handleAction, handleClose };
 }
 
-export function MasterDetailView({ items, taxonomyConfig, taxonomyData }: MasterDetailViewProps) {
+function useMasterView(items: QueueItem[]) {
   const router = useRouter();
-  const { selectedId, listItems, selectedIndex, setSelectedId, setListItems } =
-    useMasterViewState(items);
-  const { handleNavigate, handleAction, handleClose } = useMasterViewActions(
-    listItems,
-    setListItems,
-    setSelectedId,
+  const state = useMasterViewState(items);
+  const actions = useMasterViewActions(
+    state.listItems,
+    state.setListItems,
+    state.setSelectedId,
     router,
-    selectedIndex,
+    state.selectedIndex,
   );
+  return { ...state, ...actions };
+}
 
+export function MasterDetailView({
+  items,
+  taxonomyConfig,
+  taxonomyData,
+}: Readonly<MasterDetailViewProps>) {
+  const {
+    selectedId,
+    listItems,
+    selectedIndex,
+    setSelectedId,
+    handleNavigate,
+    handleAction,
+    handleClose,
+  } = useMasterView(items);
   return (
     <div className="flex h-[calc(100vh-12rem)] gap-4">
       {renderItemList({ listItems, selectedId, setSelectedId, taxonomyConfig, taxonomyData })}

--- a/apps/admin/src/app/(dashboard)/items/page.tsx
+++ b/apps/admin/src/app/(dashboard)/items/page.tsx
@@ -19,7 +19,7 @@ export const revalidate = 0;
 
 export default async function ReviewPage({
   searchParams,
-}: {
+}: Readonly<{
   searchParams: Promise<{
     status?: string;
     source?: string;
@@ -29,7 +29,7 @@ export default async function ReviewPage({
     search?: string;
     url?: string;
   }>;
-}) {
+}>) {
   const params = await searchParams;
   const itemId = params.id || '';
   const urlSearch = params.url || '';

--- a/apps/admin/src/app/(dashboard)/items/review-list-bulk-actions.tsx
+++ b/apps/admin/src/app/(dashboard)/items/review-list-bulk-actions.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import type { QueueItem } from '@bfsi/types';
+import { SelectAllButton, BulkActionButtons } from './review-list-components';
+
+export interface ActionPermissions {
+  canApprove: boolean;
+  canReject: boolean;
+  canReenrich: boolean;
+}
+
+export interface BulkActions {
+  approve: () => void;
+  reject: () => void;
+  reenrich: () => void;
+}
+
+export function getActionPermissions(status: string): ActionPermissions {
+  return {
+    canApprove: status === 'pending_review',
+    canReject: ['pending_review', 'failed'].includes(status),
+    canReenrich: ['pending_review', 'failed', 'rejected', 'dead_letter'].includes(status),
+  };
+}
+
+interface BulkActionsBarProps {
+  items: QueueItem[];
+  selected: Set<string>;
+  loading: string | null;
+  selectAll: () => void;
+  permissions: ActionPermissions;
+  actions: BulkActions;
+}
+
+function SelectionInfo({ count }: Readonly<{ count: number }>) {
+  if (count === 0) return null;
+  return <span className="text-sm text-sky-400">{count} selected</span>;
+}
+
+function LeftSection({
+  selected,
+  items,
+  selectAll,
+}: Readonly<{ selected: Set<string>; items: QueueItem[]; selectAll: () => void }>) {
+  return (
+    <div className="flex items-center gap-4">
+      <SelectAllButton
+        selectedCount={selected.size}
+        totalCount={items.length}
+        onSelectAll={selectAll}
+      />
+      <SelectionInfo count={selected.size} />
+    </div>
+  );
+}
+
+function RightSection({
+  selected,
+  loading,
+  permissions,
+  actions,
+}: Readonly<{
+  selected: Set<string>;
+  loading: string | null;
+  permissions: ActionPermissions;
+  actions: BulkActions;
+}>) {
+  return (
+    <BulkActionButtons
+      selectedCount={selected.size}
+      loading={loading}
+      canApprove={permissions.canApprove}
+      canReject={permissions.canReject}
+      canReenrich={permissions.canReenrich}
+      onApprove={actions.approve}
+      onReject={actions.reject}
+      onReenrich={actions.reenrich}
+    />
+  );
+}
+
+export function BulkActionsBar({
+  items,
+  selected,
+  loading,
+  selectAll,
+  permissions,
+  actions,
+}: Readonly<BulkActionsBarProps>) {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex items-center justify-between rounded-lg bg-neutral-800/50 px-4 py-3">
+      <LeftSection selected={selected} items={items} selectAll={selectAll} />
+      <RightSection
+        selected={selected}
+        loading={loading}
+        permissions={permissions}
+        actions={actions}
+      />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/items/review-list-components.tsx
+++ b/apps/admin/src/app/(dashboard)/items/review-list-components.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import Link from 'next/link';
+import { formatDateTime, getStatusColor, truncate } from '@/lib/utils';
+import type { QueueItem } from '@bfsi/types';
+
+const STATUS_LABEL: Record<number, string> = {
+  300: 'pending_review',
+  330: 'approved',
+  500: 'failed',
+  540: 'rejected',
+};
+
+export function getStatusLabel(code: number): string {
+  return STATUS_LABEL[code] || String(code);
+}
+
+export function SuccessBanner({ message }: Readonly<{ message: string | null }>) {
+  if (!message) return null;
+  return (
+    <div className="rounded-lg bg-emerald-500/10 border border-emerald-500/20 px-4 py-3 text-emerald-400 text-sm font-medium animate-pulse">
+      {message}
+    </div>
+  );
+}
+
+export function LoadingIndicator({ loading }: Readonly<{ loading: string | null }>) {
+  if (!loading) return null;
+  const label =
+    loading === 'approve'
+      ? 'Approving...'
+      : loading === 'reject'
+        ? 'Rejecting...'
+        : 'Queuing for re-enrichment...';
+  return (
+    <div className="rounded-lg bg-sky-500/10 border border-sky-500/20 px-4 py-3 flex items-center gap-3">
+      <div className="animate-spin rounded-full h-4 w-4 border-2 border-sky-500 border-t-transparent"></div>
+      <span className="text-sky-400 text-sm font-medium">{label}</span>
+    </div>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg className="h-4 w-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+      <path
+        fillRule="evenodd"
+        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+export function SelectAllButton({
+  selectedCount,
+  totalCount,
+  onSelectAll,
+}: Readonly<{ selectedCount: number; totalCount: number; onSelectAll: () => void }>) {
+  const allSelected = selectedCount === totalCount;
+  return (
+    <button
+      onClick={onSelectAll}
+      className="flex items-center gap-2 text-sm text-neutral-300 hover:text-white"
+    >
+      <span
+        className={`h-4 w-4 rounded border ${allSelected ? 'border-sky-500 bg-sky-500' : 'border-neutral-600'}`}
+      >
+        {allSelected && <CheckIcon />}
+      </span>
+      {allSelected ? 'Deselect All' : 'Select All'}
+    </button>
+  );
+}
+
+interface BulkActionsProps {
+  selectedCount: number;
+  loading: string | null;
+  canApprove: boolean;
+  canReject: boolean;
+  canReenrich: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+  onReenrich: () => void;
+}
+
+function ApproveButton({
+  count,
+  loading,
+  onClick,
+}: Readonly<{ count: number; loading: string | null; onClick: () => void }>) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={loading !== null}
+      className="rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
+    >
+      {loading === 'approve' ? 'Approving...' : `✓ Approve (${count})`}
+    </button>
+  );
+}
+
+function RejectButton({
+  count,
+  loading,
+  onClick,
+}: Readonly<{ count: number; loading: string | null; onClick: () => void }>) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={loading !== null}
+      className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-500 disabled:opacity-50"
+    >
+      {loading === 'reject' ? 'Rejecting...' : `✗ Reject (${count})`}
+    </button>
+  );
+}
+
+function ReenrichButton({
+  count,
+  loading,
+  onClick,
+}: Readonly<{ count: number; loading: string | null; onClick: () => void }>) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={loading !== null}
+      className="rounded-lg bg-sky-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
+    >
+      {loading === 'reenrich' ? 'Queueing...' : `🔄 Re-enrich (${count})`}
+    </button>
+  );
+}
+
+export function BulkActionButtons({
+  selectedCount,
+  loading,
+  canApprove,
+  canReject,
+  canReenrich,
+  onApprove,
+  onReject,
+  onReenrich,
+}: Readonly<BulkActionsProps>) {
+  if (selectedCount === 0) return null;
+  return (
+    <div className="flex items-center gap-2">
+      {canApprove && <ApproveButton count={selectedCount} loading={loading} onClick={onApprove} />}
+      {canReject && <RejectButton count={selectedCount} loading={loading} onClick={onReject} />}
+      {canReenrich && (
+        <ReenrichButton count={selectedCount} loading={loading} onClick={onReenrich} />
+      )}
+    </div>
+  );
+}
+
+export function ItemCheckbox({
+  isSelected,
+  onToggle,
+}: Readonly<{ isSelected: boolean; onToggle: (e: React.MouseEvent) => void }>) {
+  return (
+    <button onClick={onToggle} className="p-4 hover:bg-neutral-800/50">
+      <span
+        className={`flex h-5 w-5 items-center justify-center rounded border ${isSelected ? 'border-sky-500 bg-sky-500' : 'border-neutral-600 hover:border-neutral-500'}`}
+      >
+        {isSelected && (
+          <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+            <path
+              fillRule="evenodd"
+              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+              clipRule="evenodd"
+            />
+          </svg>
+        )}
+      </span>
+    </button>
+  );
+}
+
+function ItemMeta({ item }: Readonly<{ item: QueueItem }>) {
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <span
+        className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${getStatusColor(getStatusLabel(item.status_code))}`}
+      >
+        {getStatusLabel(item.status_code)}
+      </span>
+      <span className="text-xs text-neutral-500">{formatDateTime(item.discovered_at)}</span>
+      {item.payload?.source_slug && (
+        <span className="text-xs text-neutral-600">{item.payload.source_slug}</span>
+      )}
+    </div>
+  );
+}
+
+function ItemContent({ item }: Readonly<{ item: QueueItem }>) {
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="font-medium text-white truncate">
+        {item.payload?.title || truncate(item.url, 60)}
+      </p>
+      {item.payload?.published_at && (
+        <p className="text-xs text-neutral-400 mt-0.5">
+          {new Date(item.payload.published_at).toLocaleDateString('en-GB', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          })}
+        </p>
+      )}
+      <p className="mt-1 text-sm text-neutral-500 truncate">{item.url}</p>
+      {item.payload?.summary?.short && (
+        <p className="mt-2 text-sm text-neutral-400 line-clamp-2">{item.payload.summary.short}</p>
+      )}
+      {item.status_code === 540 && item.payload?.rejection_reason && (
+        <p className="mt-2 text-sm text-red-400">Rejected: {item.payload.rejection_reason}</p>
+      )}
+    </div>
+  );
+}
+
+export function ItemRow({
+  item,
+  isSelected,
+  onToggle,
+}: Readonly<{ item: QueueItem; isSelected: boolean; onToggle: (e: React.MouseEvent) => void }>) {
+  return (
+    <div className="flex items-center">
+      <ItemCheckbox isSelected={isSelected} onToggle={onToggle} />
+      <Link
+        href={`/items/${item.id}`}
+        className="flex-1 p-4 pl-0 hover:bg-neutral-800/50 transition-colors"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <ItemContent item={item} />
+          <ItemMeta item={item} />
+        </div>
+      </Link>
+    </div>
+  );
+}
+
+export function EmptyState() {
+  return (
+    <div className="p-12 text-center">
+      <p className="text-neutral-400">No items found</p>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/items/review-list-hooks.tsx
+++ b/apps/admin/src/app/(dashboard)/items/review-list-hooks.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+import { bulkReenrichAction, bulkRejectAction, bulkApproveAction } from './actions';
+
+type SetSelected = (s: Set<string>) => void;
+type Router = { refresh: () => void };
+
+function useSuccessMessage() {
+  const [message, setMessage] = useState<string | null>(null);
+  const show = (msg: string) => {
+    setMessage(msg);
+    setTimeout(() => setMessage(null), 5000);
+  };
+  return { message, show };
+}
+
+async function runApprove(
+  ids: Set<string>,
+  clear: () => void,
+  setLoading: (s: string | null) => void,
+  show: (m: string) => void,
+  refresh: () => void,
+) {
+  if (ids.size === 0 || !confirm(`Approve ${ids.size} items?`)) return;
+  setLoading('approve');
+  show(`⏳ Approving ${ids.size} items...`);
+  const r = await bulkApproveAction(Array.from(ids));
+  show(r.success ? `✅ ${r.count} items approved` : `❌ Failed: ${r.error}`);
+  setLoading(null);
+  clear();
+  refresh();
+}
+
+async function runReject(
+  ids: Set<string>,
+  clear: () => void,
+  setLoading: (s: string | null) => void,
+  show: (m: string) => void,
+  refresh: () => void,
+) {
+  if (ids.size === 0) return;
+  const reason = prompt(`Rejection reason for ${ids.size} items:`);
+  if (!reason) return;
+  setLoading('reject');
+  show(`⏳ Rejecting ${ids.size} items...`);
+  const r = await bulkRejectAction(Array.from(ids), reason);
+  show(r.success ? `✅ ${r.count} items rejected` : `❌ Failed: ${r.error}`);
+  setLoading(null);
+  clear();
+  refresh();
+}
+
+async function runReenrich(
+  ids: Set<string>,
+  clear: () => void,
+  setLoading: (s: string | null) => void,
+  show: (m: string) => void,
+  refresh: () => void,
+) {
+  if (ids.size === 0 || !confirm(`Re-enrich ${ids.size} items?`)) return;
+  setLoading('reenrich');
+  show(`⏳ ${ids.size} items queued...`);
+  const r = await bulkReenrichAction(Array.from(ids));
+  show(r.success ? `✅ ${r.queued} items queued` : `❌ Failed: ${r.error}`);
+  setLoading(null);
+  clear();
+  refresh();
+}
+
+export function useBulkActions(selected: Set<string>, setSelected: SetSelected, router: Router) {
+  const [loading, setLoading] = useState<string | null>(null);
+  const { message, show } = useSuccessMessage();
+  const clear = () => setSelected(new Set());
+  const refresh = () => router.refresh();
+
+  const actions = {
+    approve: () => runApprove(selected, clear, setLoading, show, refresh),
+    reject: () => runReject(selected, clear, setLoading, show, refresh),
+    reenrich: () => runReenrich(selected, clear, setLoading, show, refresh),
+  };
+
+  return { loading, message, actions };
+}

--- a/apps/admin/src/app/(dashboard)/items/source-filter.tsx
+++ b/apps/admin/src/app/(dashboard)/items/source-filter.tsx
@@ -8,20 +8,30 @@ interface SourceFilterProps {
   baseUrl: string;
 }
 
-export function SourceFilter({ sources, currentSource, baseUrl }: SourceFilterProps) {
+function useSourceChange(baseUrl: string) {
   const router = useRouter();
-
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
+  return (e: React.ChangeEvent<HTMLSelectElement>) => {
     const url = new URL(baseUrl, window.location.origin);
-    if (value) {
-      url.searchParams.set('source', value);
-    } else {
-      url.searchParams.delete('source');
-    }
+    if (e.target.value) url.searchParams.set('source', e.target.value);
+    else url.searchParams.delete('source');
     router.push(url.pathname + url.search);
   };
+}
 
+function SourceOptions({ sources }: Readonly<{ sources: SourceFilterProps['sources'] }>) {
+  return (
+    <>
+      {sources.map((s) => (
+        <option key={s.slug} value={s.slug}>
+          {s.name}
+        </option>
+      ))}
+    </>
+  );
+}
+
+export function SourceFilter({ sources, currentSource, baseUrl }: Readonly<SourceFilterProps>) {
+  const handleChange = useSourceChange(baseUrl);
   return (
     <div className="flex items-center gap-2">
       <span className="text-xs text-neutral-500">Source:</span>
@@ -31,11 +41,7 @@ export function SourceFilter({ sources, currentSource, baseUrl }: SourceFilterPr
         className="rounded bg-neutral-700 px-2 py-1 text-xs text-neutral-200 border-none focus:ring-1 focus:ring-sky-500"
       >
         <option value="">All sources</option>
-        {sources.map((s) => (
-          <option key={s.slug} value={s.slug}>
-            {s.name}
-          </option>
-        ))}
+        <SourceOptions sources={sources} />
       </select>
     </div>
   );

--- a/apps/admin/src/app/(dashboard)/layout.tsx
+++ b/apps/admin/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
 import { Sidebar } from '@/components/ui/sidebar';
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+export default function DashboardLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <div className="min-h-screen bg-neutral-950">
       <Sidebar />

--- a/apps/admin/src/app/(dashboard)/missed/components/MissedList.tsx
+++ b/apps/admin/src/app/(dashboard)/missed/components/MissedList.tsx
@@ -29,7 +29,7 @@ function TableHeader() {
   );
 }
 
-function DomainCell({ item }: { item: MissedDiscovery }) {
+function DomainCell({ item }: Readonly<{ item: MissedDiscovery }>) {
   return (
     <td className="px-4 py-3">
       <a
@@ -45,7 +45,7 @@ function DomainCell({ item }: { item: MissedDiscovery }) {
   );
 }
 
-function SubmitterCell({ item }: { item: MissedDiscovery }) {
+function SubmitterCell({ item }: Readonly<{ item: MissedDiscovery }>) {
   return (
     <td className="px-4 py-3">
       <div className="text-sm text-white">{item.submitter_name || '—'}</div>
@@ -58,7 +58,7 @@ function SubmitterCell({ item }: { item: MissedDiscovery }) {
   );
 }
 
-function MissedRow({ item }: { item: MissedDiscovery }) {
+function MissedRow({ item }: Readonly<{ item: MissedDiscovery }>) {
   return (
     <tr key={item.id} className="hover:bg-neutral-800/30">
       <DomainCell item={item} />
@@ -90,7 +90,7 @@ interface MissedListProps {
   loading: boolean;
 }
 
-export function MissedList({ items, loading }: MissedListProps) {
+export function MissedList({ items, loading }: Readonly<MissedListProps>) {
   if (loading) return <div className="p-8 text-center text-neutral-500">Loading...</div>;
   if (items.length === 0)
     return (

--- a/apps/admin/src/app/(dashboard)/missed/components/missed-form/MissedForm.tsx
+++ b/apps/admin/src/app/(dashboard)/missed/components/missed-form/MissedForm.tsx
@@ -5,7 +5,7 @@ interface MissedFormProps {
   onSuccess: () => void;
 }
 
-export function MissedForm({ onSuccess }: MissedFormProps) {
+export function MissedForm({ onSuccess }: Readonly<MissedFormProps>) {
   const { form, detectedDomain, existingSource, onSubmit } = useMissedFormController(onSuccess);
 
   return (

--- a/apps/admin/src/app/(dashboard)/pipeline/pipeline-metrics.tsx
+++ b/apps/admin/src/app/(dashboard)/pipeline/pipeline-metrics.tsx
@@ -26,7 +26,10 @@ function getSuccessRateClass(rate: number): string {
   return 'bg-red-500/20 text-red-400';
 }
 
-function RefreshButton({ refreshing, onRefresh }: { refreshing: boolean; onRefresh: () => void }) {
+function RefreshButton({
+  refreshing,
+  onRefresh,
+}: Readonly<{ refreshing: boolean; onRefresh: () => void }>) {
   return (
     <div className="flex justify-end">
       <button
@@ -41,7 +44,7 @@ function RefreshButton({ refreshing, onRefresh }: { refreshing: boolean; onRefre
   );
 }
 
-function StepRow({ stat }: { stat: StepStats }) {
+function StepRow({ stat }: Readonly<{ stat: StepStats }>) {
   const total = stat.success_count + stat.failed_count;
   const successRate = total > 0 ? Math.round((stat.success_count / total) * 100) : 0;
   return (
@@ -61,7 +64,7 @@ function StepRow({ stat }: { stat: StepStats }) {
   );
 }
 
-function StepPerformanceTable({ stepStats }: { stepStats: StepStats[] }) {
+function StepPerformanceTable({ stepStats }: Readonly<{ stepStats: StepStats[] }>) {
   return (
     <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-6">
       <h2 className="text-lg font-semibold mb-4">Step Performance (24h)</h2>
@@ -95,7 +98,7 @@ function EmptyState() {
   );
 }
 
-export function PipelineMetrics({ initialHealth }: { initialHealth: PipelineHealth }) {
+export function PipelineMetrics({ initialHealth }: Readonly<{ initialHealth: PipelineHealth }>) {
   const [health] = useState(initialHealth);
   const [refreshing, setRefreshing] = useState(false);
   const router = useRouter();

--- a/apps/admin/src/app/(dashboard)/sources/components/SourcesContent.tsx
+++ b/apps/admin/src/app/(dashboard)/sources/components/SourcesContent.tsx
@@ -28,10 +28,10 @@ interface SourcesContentProps {
 function HeaderSection({
   modal,
   stats,
-}: {
+}: Readonly<{
   modal: SourcesContentProps['modal'];
   stats: ReturnType<typeof calculateStats>;
-}) {
+}>) {
   return (
     <>
       <PageHeader onAdd={modal.openAdd} />
@@ -47,13 +47,13 @@ function TableSection({
   toggleEnabled,
   modal,
   formatTimeAgo,
-}: {
+}: Readonly<{
   filteredSources: Source[];
   healthData: SourcesContentProps['healthData'];
   toggleEnabled: SourcesContentProps['toggleEnabled'];
   modal: SourcesContentProps['modal'];
   formatTimeAgo: SourcesContentProps['formatTimeAgo'];
-}) {
+}>) {
   return (
     <SourceTable
       sources={filteredSources}
@@ -68,7 +68,7 @@ function TableSection({
   );
 }
 
-function ModalSection({ modal }: { modal: SourcesContentProps['modal'] }) {
+function ModalSection({ modal }: Readonly<{ modal: SourcesContentProps['modal'] }>) {
   if (!modal.showModal) return null;
   return (
     <SourceModal
@@ -86,7 +86,7 @@ export function SourcesContent({
   filters,
   modal,
   formatTimeAgo,
-}: SourcesContentProps) {
+}: Readonly<SourcesContentProps>) {
   const filteredSources = filterSources({ sources, healthData, ...filters });
   const categories = [...new Set(sources.map((s) => s.category).filter(Boolean))];
   return (

--- a/apps/admin/src/components/dashboard/AgentJobCard.tsx
+++ b/apps/admin/src/components/dashboard/AgentJobCard.tsx
@@ -2,185 +2,20 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { DashboardCard } from './DashboardCard';
-
-interface AgentJob {
-  id: string;
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
-  total_items: number;
-  processed_items: number;
-  success_count: number;
-  failed_count: number;
-  started_at: string | null;
-  completed_at: string | null;
-  created_at: string;
-  current_item_title: string | null;
-}
+import {
+  AgentJob,
+  colorClasses,
+  ColorClasses,
+  RunningJobView,
+  IdleJobView,
+  RecentJobsList,
+} from './AgentJobCardComponents';
 
 interface AgentJobCardProps {
   title: string;
   pendingCount: number;
-  agentName: string; // 'summarizer', 'tagger', 'thumbnailer'
+  agentName: string;
   color: 'cyan' | 'emerald' | 'violet';
-}
-
-const colorClasses = {
-  cyan: {
-    button: 'bg-cyan-600 hover:bg-cyan-700',
-    progress: 'bg-cyan-500',
-    pulse: 'bg-cyan-400',
-    result: 'text-cyan-400',
-  },
-  emerald: {
-    button: 'bg-emerald-600 hover:bg-emerald-700',
-    progress: 'bg-emerald-500',
-    pulse: 'bg-emerald-400',
-    result: 'text-emerald-400',
-  },
-  violet: {
-    button: 'bg-violet-600 hover:bg-violet-700',
-    progress: 'bg-violet-500',
-    pulse: 'bg-violet-400',
-    result: 'text-violet-400',
-  },
-};
-
-function getJobStatusClass(status: AgentJob['status']): string {
-  if (status === 'completed') return 'text-emerald-400';
-  if (status === 'failed') return 'text-red-400';
-  return 'text-neutral-400';
-}
-
-function formatDuration(start: string, end: string | null): string {
-  const startTime = new Date(start).getTime();
-  const endTime = end ? new Date(end).getTime() : Date.now();
-  const seconds = Math.floor((endTime - startTime) / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  return `${minutes}m ${remainingSeconds}s`;
-}
-
-type ColorClasses = (typeof colorClasses)[keyof typeof colorClasses];
-
-function ProgressBar({ progress, colorClass }: { progress: number; colorClass: string }) {
-  return (
-    <div className="w-full bg-neutral-800 rounded-full h-2">
-      <div
-        className={`${colorClass} h-2 rounded-full transition-all duration-500`}
-        style={{ width: `${progress}%` }}
-      />
-    </div>
-  );
-}
-
-function JobStats({ job }: { job: AgentJob }) {
-  return (
-    <div className="flex justify-between text-xs text-neutral-400">
-      <span>
-        {job.processed_items} / {job.total_items}
-      </span>
-      <span>
-        {job.success_count} success, {job.failed_count} failed
-      </span>
-    </div>
-  );
-}
-
-function RunningJobView({ job, colors }: { job: AgentJob; colors: ColorClasses }) {
-  const progressPercent = Math.round((job.processed_items / job.total_items) * 100);
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2">
-        <div className={`animate-pulse h-2 w-2 rounded-full ${colors.pulse}`} />
-        <span className="text-sm text-neutral-300">Processing batch...</span>
-      </div>
-      <ProgressBar progress={progressPercent} colorClass={colors.progress} />
-      <JobStats job={job} />
-      {job.current_item_title && (
-        <p className="text-xs text-neutral-500 truncate">Current: {job.current_item_title}</p>
-      )}
-      {job.started_at && (
-        <p className="text-xs text-neutral-500">
-          Running for {formatDuration(job.started_at, null)}
-        </p>
-      )}
-    </div>
-  );
-}
-
-function BatchSizeSelect({ value, onChange }: { value: number; onChange: (n: number) => void }) {
-  return (
-    <select
-      value={value}
-      onChange={(e) => onChange(Number(e.target.value))}
-      className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-sm text-white"
-    >
-      <option value={1}>1 item</option>
-      <option value={5}>5 items</option>
-      <option value={10}>10 items</option>
-      <option value={25}>25 items</option>
-      <option value={50}>50 items</option>
-    </select>
-  );
-}
-
-interface IdleJobViewProps {
-  batchSize: number;
-  setBatchSize: (n: number) => void;
-  processing: boolean;
-  pendingCount: number;
-  colors: ColorClasses;
-  error: string | null;
-  result: { processed: number; message?: string } | null;
-  onRunBatch: () => void;
-}
-
-function IdleJobView(props: IdleJobViewProps) {
-  const { batchSize, setBatchSize, processing, pendingCount, colors, error, result, onRunBatch } =
-    props;
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2">
-        <BatchSizeSelect value={batchSize} onChange={setBatchSize} />
-        <button
-          onClick={onRunBatch}
-          disabled={processing || pendingCount === 0}
-          className={`flex-1 px-3 py-1.5 ${colors.button} disabled:bg-neutral-700 disabled:text-neutral-500 text-white text-sm rounded transition-colors`}
-        >
-          {processing ? 'Running...' : 'Run Batch'}
-        </button>
-      </div>
-      {error && <p className="text-xs text-red-400">{error}</p>}
-      {result && (
-        <p className={`text-xs ${colors.result}`}>
-          {result.message || `Processed ${result.processed} items`}
-        </p>
-      )}
-    </div>
-  );
-}
-
-function RecentJobsList({ jobs }: { jobs: AgentJob[] }) {
-  if (jobs.length === 0) return null;
-  return (
-    <div className="mt-4 pt-4 border-t border-neutral-800">
-      <p className="text-xs text-neutral-500 mb-2">Recent Jobs</p>
-      <div className="space-y-2">
-        {jobs.map((job) => (
-          <div key={job.id} className="flex items-center justify-between text-xs">
-            <span className={getJobStatusClass(job.status)}>
-              {job.success_count}/{job.total_items} success
-            </span>
-            <span className="text-neutral-500">
-              {job.started_at &&
-                job.completed_at &&
-                formatDuration(job.started_at, job.completed_at)}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
 }
 
 function useAgentJobs(agentName: string) {
@@ -242,32 +77,75 @@ function useRunBatch(agentName: string, batchSize: number, fetchJobs: () => Prom
   return { processing, result, error, runBatch };
 }
 
-export function AgentJobCard({ title, pendingCount, agentName, color }: AgentJobCardProps) {
+function useAgentJobCardState(agentName: string, color: AgentJobCardProps['color']) {
   const { jobs, fetchJobs } = useAgentJobs(agentName);
   const [batchSize, setBatchSize] = useState(10);
   const { processing, result, error, runBatch } = useRunBatch(agentName, batchSize, fetchJobs);
-
   const colors = colorClasses[color];
   const runningJob = jobs.find((j) => j.status === 'running');
   const recentJobs = jobs.filter((j) => j.status !== 'running').slice(0, 3);
+  return {
+    batchSize,
+    setBatchSize,
+    processing,
+    result,
+    error,
+    runBatch,
+    colors,
+    runningJob,
+    recentJobs,
+  };
+}
 
+interface JobContentProps {
+  runningJob: AgentJob | undefined;
+  colors: ColorClasses;
+  batchSize: number;
+  setBatchSize: (n: number) => void;
+  processing: boolean;
+  pendingCount: number;
+  error: string | null;
+  result: { processed: number; message?: string } | null;
+  runBatch: () => void;
+}
+
+function JobContent({
+  runningJob,
+  colors,
+  batchSize,
+  setBatchSize,
+  processing,
+  pendingCount,
+  error,
+  result,
+  runBatch,
+}: Readonly<JobContentProps>) {
+  if (runningJob) return <RunningJobView job={runningJob} colors={colors} />;
+  return (
+    <IdleJobView
+      batchSize={batchSize}
+      setBatchSize={setBatchSize}
+      processing={processing}
+      pendingCount={pendingCount}
+      colors={colors}
+      error={error}
+      result={result}
+      onRunBatch={runBatch}
+    />
+  );
+}
+
+export function AgentJobCard({
+  title,
+  pendingCount,
+  agentName,
+  color,
+}: Readonly<AgentJobCardProps>) {
+  const state = useAgentJobCardState(agentName, color);
   return (
     <DashboardCard title={title} badge={`${pendingCount} pending`} color={color}>
-      {runningJob ? (
-        <RunningJobView job={runningJob} colors={colors} />
-      ) : (
-        <IdleJobView
-          batchSize={batchSize}
-          setBatchSize={setBatchSize}
-          processing={processing}
-          pendingCount={pendingCount}
-          colors={colors}
-          error={error}
-          result={result}
-          onRunBatch={runBatch}
-        />
-      )}
-      <RecentJobsList jobs={recentJobs} />
+      <JobContent {...state} pendingCount={pendingCount} />
+      <RecentJobsList jobs={state.recentJobs} />
     </DashboardCard>
   );
 }

--- a/apps/admin/src/components/dashboard/AgentJobCardComponents.tsx
+++ b/apps/admin/src/components/dashboard/AgentJobCardComponents.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+export interface AgentJob {
+  id: string;
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+  total_items: number;
+  processed_items: number;
+  success_count: number;
+  failed_count: number;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  current_item_title: string | null;
+}
+
+export const colorClasses = {
+  cyan: {
+    button: 'bg-cyan-600 hover:bg-cyan-700',
+    progress: 'bg-cyan-500',
+    pulse: 'bg-cyan-400',
+    result: 'text-cyan-400',
+  },
+  emerald: {
+    button: 'bg-emerald-600 hover:bg-emerald-700',
+    progress: 'bg-emerald-500',
+    pulse: 'bg-emerald-400',
+    result: 'text-emerald-400',
+  },
+  violet: {
+    button: 'bg-violet-600 hover:bg-violet-700',
+    progress: 'bg-violet-500',
+    pulse: 'bg-violet-400',
+    result: 'text-violet-400',
+  },
+};
+
+export type ColorClasses = (typeof colorClasses)[keyof typeof colorClasses];
+
+export function getJobStatusClass(status: AgentJob['status']): string {
+  if (status === 'completed') return 'text-emerald-400';
+  if (status === 'failed') return 'text-red-400';
+  return 'text-neutral-400';
+}
+
+export function formatDuration(start: string, end: string | null): string {
+  const startTime = new Date(start).getTime();
+  const endTime = end ? new Date(end).getTime() : Date.now();
+  const seconds = Math.floor((endTime - startTime) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${seconds % 60}s`;
+}
+
+export function ProgressBar({
+  progress,
+  colorClass,
+}: Readonly<{ progress: number; colorClass: string }>) {
+  return (
+    <div className="w-full bg-neutral-800 rounded-full h-2">
+      <div
+        className={`${colorClass} h-2 rounded-full transition-all duration-500`}
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+}
+
+export function JobStats({ job }: Readonly<{ job: AgentJob }>) {
+  return (
+    <div className="flex justify-between text-xs text-neutral-400">
+      <span>
+        {job.processed_items} / {job.total_items}
+      </span>
+      <span>
+        {job.success_count} success, {job.failed_count} failed
+      </span>
+    </div>
+  );
+}
+
+function RunningJobDetails({ job }: Readonly<{ job: AgentJob }>) {
+  return (
+    <>
+      {job.current_item_title && (
+        <p className="text-xs text-neutral-500 truncate">Current: {job.current_item_title}</p>
+      )}
+      {job.started_at && (
+        <p className="text-xs text-neutral-500">
+          Running for {formatDuration(job.started_at, null)}
+        </p>
+      )}
+    </>
+  );
+}
+
+export function RunningJobView({ job, colors }: Readonly<{ job: AgentJob; colors: ColorClasses }>) {
+  const progressPercent = Math.round((job.processed_items / job.total_items) * 100);
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <div className={`animate-pulse h-2 w-2 rounded-full ${colors.pulse}`} />
+        <span className="text-sm text-neutral-300">Processing batch...</span>
+      </div>
+      <ProgressBar progress={progressPercent} colorClass={colors.progress} />
+      <JobStats job={job} />
+      <RunningJobDetails job={job} />
+    </div>
+  );
+}
+
+export function BatchSizeSelect({
+  value,
+  onChange,
+}: Readonly<{ value: number; onChange: (n: number) => void }>) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+      className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-sm text-white"
+    >
+      <option value={1}>1 item</option>
+      <option value={5}>5 items</option>
+      <option value={10}>10 items</option>
+      <option value={25}>25 items</option>
+      <option value={50}>50 items</option>
+    </select>
+  );
+}
+
+interface IdleJobViewProps {
+  batchSize: number;
+  setBatchSize: (n: number) => void;
+  processing: boolean;
+  pendingCount: number;
+  colors: ColorClasses;
+  error: string | null;
+  result: { processed: number; message?: string } | null;
+  onRunBatch: () => void;
+}
+
+function RunBatchButton({
+  processing,
+  pendingCount,
+  colors,
+  onRunBatch,
+}: Readonly<{
+  processing: boolean;
+  pendingCount: number;
+  colors: ColorClasses;
+  onRunBatch: () => void;
+}>) {
+  return (
+    <button
+      onClick={onRunBatch}
+      disabled={processing || pendingCount === 0}
+      className={`flex-1 px-3 py-1.5 ${colors.button} disabled:bg-neutral-700 disabled:text-neutral-500 text-white text-sm rounded transition-colors`}
+    >
+      {processing ? 'Running...' : 'Run Batch'}
+    </button>
+  );
+}
+
+function IdleJobMessages({
+  error,
+  result,
+  colors,
+}: Readonly<{
+  error: string | null;
+  result: { processed: number; message?: string } | null;
+  colors: ColorClasses;
+}>) {
+  return (
+    <>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+      {result && (
+        <p className={`text-xs ${colors.result}`}>
+          {result.message || `Processed ${result.processed} items`}
+        </p>
+      )}
+    </>
+  );
+}
+
+export function IdleJobView(props: Readonly<IdleJobViewProps>) {
+  const { batchSize, setBatchSize, processing, pendingCount, colors, error, result, onRunBatch } =
+    props;
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <BatchSizeSelect value={batchSize} onChange={setBatchSize} />
+        <RunBatchButton
+          processing={processing}
+          pendingCount={pendingCount}
+          colors={colors}
+          onRunBatch={onRunBatch}
+        />
+      </div>
+      <IdleJobMessages error={error} result={result} colors={colors} />
+    </div>
+  );
+}
+
+export function RecentJobsList({ jobs }: Readonly<{ jobs: AgentJob[] }>) {
+  if (jobs.length === 0) return null;
+  return (
+    <div className="mt-4 pt-4 border-t border-neutral-800">
+      <p className="text-xs text-neutral-500 mb-2">Recent Jobs</p>
+      <div className="space-y-2">
+        {jobs.map((job) => (
+          <div key={job.id} className="flex items-center justify-between text-xs">
+            <span className={getJobStatusClass(job.status)}>
+              {job.success_count}/{job.total_items} success
+            </span>
+            <span className="text-neutral-500">
+              {job.started_at &&
+                job.completed_at &&
+                formatDuration(job.started_at, job.completed_at)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/dashboard/DashboardCard.tsx
+++ b/apps/admin/src/components/dashboard/DashboardCard.tsx
@@ -17,7 +17,12 @@ const badgeColorClasses: Record<CardColor, string> = {
   violet: 'text-violet-400',
 };
 
-export function DashboardCard({ title, badge, color = 'emerald', children }: DashboardCardProps) {
+export function DashboardCard({
+  title,
+  badge,
+  color = 'emerald',
+  children,
+}: Readonly<DashboardCardProps>) {
   return (
     <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-4">
       <div className="flex items-center justify-between mb-4">

--- a/apps/admin/src/components/tags/InlineTagDisplay.tsx
+++ b/apps/admin/src/components/tags/InlineTagDisplay.tsx
@@ -10,7 +10,9 @@ interface InlineTagDisplayProps {
   sortedNonAudienceConfigs: TaxonomyConfig[];
 }
 
-function AudienceTags({ topAudiences }: { topAudiences: { slug: string; name: string }[] }) {
+function AudienceTags({
+  topAudiences,
+}: Readonly<{ topAudiences: { slug: string; name: string }[] }>) {
   const colors = COLOR_MAP.violet;
   return (
     <>
@@ -40,12 +42,12 @@ function InlineCodeTag({
   code,
   colors,
   lookupMap,
-}: {
+}: Readonly<{
   config: TaxonomyConfig;
   code: string;
   colors: { bg: string; text: string };
   lookupMap: Map<string, string> | null;
-}) {
+}>) {
   return (
     <span
       key={`${config.slug}-${code}`}
@@ -60,11 +62,11 @@ function ConfigTags({
   config,
   payload,
   taxonomyData,
-}: {
+}: Readonly<{
   config: TaxonomyConfig;
   payload: TagPayload;
   taxonomyData: TaxonomyData;
-}) {
+}>) {
   const colors = COLOR_MAP[config.color] || COLOR_MAP.neutral;
   const codes = getConfigCodes(config, payload);
   const lookupMap = taxonomyData[config.slug]
@@ -90,7 +92,7 @@ export function InlineTagDisplay({
   taxonomyData,
   topAudiences,
   sortedNonAudienceConfigs,
-}: InlineTagDisplayProps) {
+}: Readonly<InlineTagDisplayProps>) {
   return (
     <div className="flex flex-wrap gap-1">
       <AudienceTags topAudiences={topAudiences} />

--- a/apps/admin/src/components/tags/TableTagDisplay.tsx
+++ b/apps/admin/src/components/tags/TableTagDisplay.tsx
@@ -39,7 +39,7 @@ interface AudienceScoreTagProps {
   getAudienceLabel: GetAudienceLabelFn;
 }
 
-function AudienceScoreTag({ config, payload, getAudienceLabel }: AudienceScoreTagProps) {
+function AudienceScoreTag({ config, payload, getAudienceLabel }: Readonly<AudienceScoreTagProps>) {
   const score = getPayloadValue(payload, config.payload_field) as number | undefined;
   if (score === undefined || score < (config.score_threshold ?? 0.5)) return null;
   const colors = COLOR_MAP.violet;
@@ -60,7 +60,7 @@ function AudienceWithPercentages({
   audienceConfigs,
   payload,
   getAudienceLabel,
-}: AudienceWithPercentagesProps) {
+}: Readonly<AudienceWithPercentagesProps>) {
   if (!hasAnyAudienceScore(audienceConfigs, payload))
     return <span className="text-neutral-600 italic">—</span>;
   return (
@@ -77,7 +77,7 @@ function AudienceWithPercentages({
   );
 }
 
-function AudienceSimple({ topAudiences }: { topAudiences: AudienceInfo[] }) {
+function AudienceSimple({ topAudiences }: Readonly<{ topAudiences: AudienceInfo[] }>) {
   const colors = COLOR_MAP.violet;
   if (topAudiences.length === 0) return <span className="text-neutral-600 italic">—</span>;
   return (
@@ -105,7 +105,7 @@ function AudienceContent({
   payload,
   getAudienceLabel,
   getTopAudiences,
-}: AudienceContentProps) {
+}: Readonly<AudienceContentProps>) {
   if (showPercentages)
     return (
       <AudienceWithPercentages
@@ -133,7 +133,7 @@ function AudienceRow({
   showPercentages,
   getAudienceLabel,
   getTopAudiences,
-}: AudienceRowProps) {
+}: Readonly<AudienceRowProps>) {
   if (audienceConfigs.length === 0) return null;
   return (
     <div className="flex items-start justify-between gap-2">
@@ -157,7 +157,7 @@ interface GeographyCodeTagProps {
   lookupMap: Map<string, string> | null;
 }
 
-function GeographyCodeTag({ code, colors, lookupMap }: GeographyCodeTagProps) {
+function GeographyCodeTag({ code, colors, lookupMap }: Readonly<GeographyCodeTagProps>) {
   return (
     <span key={code} className={`px-1.5 py-0.5 rounded ${colors.bg} ${colors.text}`}>
       {lookupMap?.get(code) || code}
@@ -172,7 +172,7 @@ interface GeographyRowProps {
   labelWidth: string;
 }
 
-function GeographyRow({ config, payload, taxonomyData, labelWidth }: GeographyRowProps) {
+function GeographyRow({ config, payload, taxonomyData, labelWidth }: Readonly<GeographyRowProps>) {
   const codes = extractCodes(getPayloadValue(payload, config.payload_field));
   const colors = COLOR_MAP[config.color] || COLOR_MAP.neutral;
   const lookupMap = taxonomyData[config.slug]
@@ -207,7 +207,7 @@ function ConfigRow({
   labelWidth,
   validationLookups,
   showValidation,
-}: ConfigRowProps) {
+}: Readonly<ConfigRowProps>) {
   if (config.slug === 'geography')
     return (
       <GeographyRow
@@ -238,7 +238,7 @@ interface ConfigRowListProps {
   showValidation: boolean;
 }
 
-function ConfigRowList({ configs, ...rowProps }: ConfigRowListProps) {
+function ConfigRowList({ configs, ...rowProps }: Readonly<ConfigRowListProps>) {
   return (
     <>
       {configs.map((config) => (
@@ -248,7 +248,7 @@ function ConfigRowList({ configs, ...rowProps }: ConfigRowListProps) {
   );
 }
 
-export function TableTagDisplay(props: TableTagDisplayProps) {
+export function TableTagDisplay(props: Readonly<TableTagDisplayProps>) {
   const {
     audienceConfigs,
     sortedNonAudienceConfigs,

--- a/apps/admin/src/components/tags/TagCategoryRow.tsx
+++ b/apps/admin/src/components/tags/TagCategoryRow.tsx
@@ -21,7 +21,7 @@ interface TagCategoryRowProps {
   showValidation?: boolean;
 }
 
-function ScoreTag({ score, colors }: { score: number; colors: TagColors }) {
+function ScoreTag({ score, colors }: Readonly<{ score: number; colors: TagColors }>) {
   return (
     <span className={`px-1.5 py-0.5 rounded ${colors.bg} ${colors.text}`}>
       {(score * 100).toFixed(0)}%
@@ -29,7 +29,7 @@ function ScoreTag({ score, colors }: { score: number; colors: TagColors }) {
   );
 }
 
-function ScoringRow({ config, payload, labelWidth, colors }: ConfigRowProps) {
+function ScoringRow({ config, payload, labelWidth, colors }: Readonly<ConfigRowProps>) {
   const score = getPayloadValue(payload, config.payload_field) as number | undefined;
   const showScore = score !== undefined && score >= (config.score_threshold ?? 0.5);
   return (
@@ -53,7 +53,12 @@ interface ExpandableValueTagProps {
   showValidation: boolean;
 }
 
-function ExpandableValueTag({ name, isKnown, tagClass, showValidation }: ExpandableValueTagProps) {
+function ExpandableValueTag({
+  name,
+  isKnown,
+  tagClass,
+  showValidation,
+}: Readonly<ExpandableValueTagProps>) {
   return (
     <span key={name} className={tagClass} title={isKnown ? undefined : 'Not in reference table'}>
       {name}
@@ -80,7 +85,7 @@ function ExpandableValuesList({
   lookupSet,
   colors,
   showValidation,
-}: ExpandableValuesListProps) {
+}: Readonly<ExpandableValuesListProps>) {
   if (values.length === 0) return <span className="text-neutral-600 italic">—</span>;
   return (
     <>
@@ -107,7 +112,7 @@ function ExpandableRow({
   colors,
   validationLookups,
   showValidation,
-}: ConfigRowWithValidationProps) {
+}: Readonly<ConfigRowWithValidationProps>) {
   const values = extractStrings(getPayloadValue(payload, config.payload_field));
   const lookupSet = showValidation && validationLookups ? validationLookups[config.slug] : null;
   return (
@@ -131,7 +136,7 @@ interface CodeTagProps {
   lookupMap: Map<string, string> | null;
 }
 
-function CodeTag({ code, colors, lookupMap }: CodeTagProps) {
+function CodeTag({ code, colors, lookupMap }: Readonly<CodeTagProps>) {
   return (
     <span key={code} className={`px-1.5 py-0.5 rounded ${colors.bg} ${colors.text}`}>
       {lookupMap?.get(code) || code}
@@ -145,7 +150,7 @@ interface CodesListProps {
   lookupMap: Map<string, string> | null;
 }
 
-function CodesList({ codes, colors, lookupMap }: CodesListProps) {
+function CodesList({ codes, colors, lookupMap }: Readonly<CodesListProps>) {
   if (codes.length === 0) return <span className="text-neutral-600 italic">—</span>;
   return (
     <>
@@ -162,7 +167,7 @@ function CodeBasedRow({
   taxonomyData,
   labelWidth,
   colors,
-}: ConfigRowWithDataProps) {
+}: Readonly<ConfigRowWithDataProps>) {
   const codes = extractCodes(getPayloadValue(payload, config.payload_field));
   const lookupMap = taxonomyData[config.slug]
     ? new Map(taxonomyData[config.slug].map((i) => [i.code, i.name]))
@@ -184,7 +189,7 @@ export function TagCategoryRow({
   labelWidth = 'w-24',
   validationLookups,
   showValidation = false,
-}: TagCategoryRowProps) {
+}: Readonly<TagCategoryRowProps>) {
   const colors = COLOR_MAP[config.color] || COLOR_MAP.neutral;
   const baseProps = { config, payload, labelWidth, colors };
 

--- a/apps/admin/src/components/tags/TagDisplay.tsx
+++ b/apps/admin/src/components/tags/TagDisplay.tsx
@@ -57,12 +57,12 @@ function InlineView({
   taxonomyData,
   audienceConfigs,
   sortedNonAudienceConfigs,
-}: {
+}: Readonly<{
   payload: TagPayload;
   taxonomyData: TaxonomyData;
   audienceConfigs: TaxonomyConfig[];
   sortedNonAudienceConfigs: TaxonomyConfig[];
-}) {
+}>) {
   return (
     <InlineTagDisplay
       payload={payload}
@@ -93,7 +93,7 @@ function TableView({
   audienceConfigs,
   sortedNonAudienceConfigs,
   variant,
-}: TableViewProps) {
+}: Readonly<TableViewProps>) {
   return (
     <TableTagDisplay
       payload={payload}
@@ -118,7 +118,7 @@ export function TagDisplay({
   labelWidth = 'w-24',
   validationLookups,
   showValidation = false,
-}: TagDisplayProps) {
+}: Readonly<TagDisplayProps>) {
   const { audienceConfigs, sortedNonAudienceConfigs } = useTagDisplayData(taxonomyConfig);
   const viewProps = { payload, taxonomyData, audienceConfigs, sortedNonAudienceConfigs };
 

--- a/apps/admin/src/components/ui/markdown-renderer.tsx
+++ b/apps/admin/src/components/ui/markdown-renderer.tsx
@@ -8,7 +8,7 @@ interface MarkdownRendererProps {
   className?: string;
 }
 
-export function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
+export function MarkdownRenderer({ content, className }: Readonly<MarkdownRendererProps>) {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {

--- a/apps/admin/src/components/ui/sidebar/ActionButtons.tsx
+++ b/apps/admin/src/components/ui/sidebar/ActionButtons.tsx
@@ -20,6 +20,63 @@ interface ActionButtonsProps {
   onTriggerBuild: () => void;
 }
 
+function StatusMessage({ message }: Readonly<{ message: string | null }>) {
+  if (!message) return null;
+  return <div className="text-xs text-center py-1 text-emerald-400 animate-pulse">{message}</div>;
+}
+
+function ProcessQueueButton({
+  processing,
+  lastRun,
+  onClick,
+}: Readonly<{ processing: boolean; lastRun: string | null; onClick: () => void }>) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={processing}
+      className="flex w-full flex-col items-center justify-center gap-0.5 rounded-lg bg-sky-600 px-3 py-2 text-white hover:bg-sky-500 disabled:opacity-50 transition-colors"
+    >
+      {processing ? (
+        <span className="text-sm font-medium">Processing...</span>
+      ) : (
+        <>
+          <span className="text-sm font-medium">Process Queue</span>
+          {lastRun && (
+            <span className="text-[10px] text-sky-200/70">Last: {formatTimeAgo(lastRun)}</span>
+          )}
+        </>
+      )}
+    </button>
+  );
+}
+
+function TriggerBuildButton({
+  building,
+  lastBuild,
+  onClick,
+}: Readonly<{ building: boolean; lastBuild: string | null; onClick: () => void }>) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={building}
+      className="flex w-full flex-col items-center justify-center gap-0.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-emerald-400 hover:bg-emerald-500/20 disabled:opacity-50 transition-colors"
+    >
+      {building ? (
+        <span className="text-sm font-medium">Building...</span>
+      ) : (
+        <>
+          <span className="text-sm font-medium">Trigger Build</span>
+          {lastBuild && (
+            <span className="text-[10px] text-emerald-400/70">
+              Last: {formatTimeAgo(lastBuild)}
+            </span>
+          )}
+        </>
+      )}
+    </button>
+  );
+}
+
 export function ActionButtons({
   statusMessage,
   processingQueue,
@@ -27,50 +84,20 @@ export function ActionButtons({
   pipelineStatus,
   onProcessQueue,
   onTriggerBuild,
-}: ActionButtonsProps) {
+}: Readonly<ActionButtonsProps>) {
   return (
     <div className="absolute bottom-24 left-0 right-0 border-t border-neutral-800 p-4 space-y-2">
-      {statusMessage && (
-        <div className="text-xs text-center py-1 text-emerald-400 animate-pulse">
-          {statusMessage}
-        </div>
-      )}
-      <button
+      <StatusMessage message={statusMessage} />
+      <ProcessQueueButton
+        processing={processingQueue}
+        lastRun={pipelineStatus?.lastQueueRun ?? null}
         onClick={onProcessQueue}
-        disabled={processingQueue}
-        className="flex w-full flex-col items-center justify-center gap-0.5 rounded-lg bg-sky-600 px-3 py-2 text-white hover:bg-sky-500 disabled:opacity-50 transition-colors"
-      >
-        {processingQueue ? (
-          <span className="text-sm font-medium">Processing...</span>
-        ) : (
-          <>
-            <span className="text-sm font-medium">Process Queue</span>
-            {pipelineStatus?.lastQueueRun && (
-              <span className="text-[10px] text-sky-200/70">
-                Last: {formatTimeAgo(pipelineStatus.lastQueueRun)}
-              </span>
-            )}
-          </>
-        )}
-      </button>
-      <button
+      />
+      <TriggerBuildButton
+        building={triggeringBuild}
+        lastBuild={pipelineStatus?.lastBuildTime ?? null}
         onClick={onTriggerBuild}
-        disabled={triggeringBuild}
-        className="flex w-full flex-col items-center justify-center gap-0.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-emerald-400 hover:bg-emerald-500/20 disabled:opacity-50 transition-colors"
-      >
-        {triggeringBuild ? (
-          <span className="text-sm font-medium">Building...</span>
-        ) : (
-          <>
-            <span className="text-sm font-medium">Trigger Build</span>
-            {pipelineStatus?.lastBuildTime && (
-              <span className="text-[10px] text-emerald-400/70">
-                Last: {formatTimeAgo(pipelineStatus.lastBuildTime)}
-              </span>
-            )}
-          </>
-        )}
-      </button>
+      />
     </div>
   );
 }

--- a/apps/admin/src/components/ui/sidebar/MobileHeader.tsx
+++ b/apps/admin/src/components/ui/sidebar/MobileHeader.tsx
@@ -5,38 +5,47 @@ interface MobileHeaderProps {
   onToggle: () => void;
 }
 
-export function MobileHeader({ isOpen, onToggle }: MobileHeaderProps) {
+function LogoLink() {
+  return (
+    <Link href="/" className="flex items-center gap-2">
+      <span className="text-lg font-normal tracking-tight text-white">BFSI</span>
+      <span className="text-xs font-bold uppercase text-sky-400">Admin</span>
+    </Link>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+}
+
+function MenuIcon() {
+  return (
+    <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 6h16M4 12h16M4 18h16"
+      />
+    </svg>
+  );
+}
+
+export function MobileHeader({ isOpen, onToggle }: Readonly<MobileHeaderProps>) {
   return (
     <div className="fixed top-0 left-0 right-0 z-50 flex h-14 items-center justify-between border-b border-neutral-800 bg-neutral-950 px-4 md:hidden">
-      <Link href="/" className="flex items-center gap-2">
-        <span className="text-lg font-normal tracking-tight text-white">BFSI</span>
-        <span className="text-xs font-bold uppercase text-sky-400">Admin</span>
-      </Link>
+      <LogoLink />
       <button
         onClick={onToggle}
         className="flex h-10 w-10 items-center justify-center rounded-lg text-neutral-400 hover:bg-neutral-800 hover:text-white"
         aria-label={isOpen ? 'Close menu' : 'Open menu'}
         aria-expanded={isOpen}
       >
-        {isOpen ? (
-          <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-        ) : (
-          <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 6h16M4 12h16M4 18h16"
-            />
-          </svg>
-        )}
+        {isOpen ? <CloseIcon /> : <MenuIcon />}
       </button>
     </div>
   );

--- a/apps/admin/src/components/ui/sidebar/Navigation.tsx
+++ b/apps/admin/src/components/ui/sidebar/Navigation.tsx
@@ -15,73 +15,119 @@ interface NavigationProps {
   onToggleMenu: (href: string) => void;
 }
 
-export function Navigation({ items, pathname, expandedMenus, onToggleMenu }: NavigationProps) {
+function getNavLinkClass(isActive: boolean) {
+  return cn(
+    'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+    isActive
+      ? 'bg-neutral-800 text-white'
+      : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-white',
+  );
+}
+
+function ChildLink({
+  child,
+  pathname,
+}: Readonly<{ child: { href: string; label: string }; pathname: string }>) {
+  const isActive = pathname === child.href;
+  return (
+    <Link
+      href={child.href}
+      className={cn(
+        'flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm transition-colors',
+        isActive
+          ? 'bg-neutral-800/70 text-white'
+          : 'text-neutral-500 hover:bg-neutral-800/30 hover:text-neutral-300',
+      )}
+    >
+      <span className="text-neutral-600">•</span>
+      <span>{child.label}</span>
+    </Link>
+  );
+}
+
+function ExpandableNavItem({
+  item,
+  isActive,
+  isExpanded,
+  onToggle,
+  pathname,
+}: Readonly<{
+  item: NavItem;
+  isActive: boolean;
+  isExpanded: boolean;
+  onToggle: () => void;
+  pathname: string;
+}>) {
+  return (
+    <div>
+      <button onClick={onToggle} className={getNavLinkClass(isActive)}>
+        <span>{item.icon}</span>
+        <span>{item.label}</span>
+        <span className="ml-auto text-xs">{isExpanded ? '▼' : '▶'}</span>
+      </button>
+      {isExpanded && (
+        <div className="ml-6 mt-1 space-y-1">
+          {item.children!.map((child) => (
+            <ChildLink key={child.href} child={child} pathname={pathname} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SimpleNavItem({ item, isActive }: Readonly<{ item: NavItem; isActive: boolean }>) {
+  return (
+    <Link href={item.href} className={getNavLinkClass(isActive)}>
+      <span>{item.icon}</span>
+      <span>{item.label}</span>
+    </Link>
+  );
+}
+
+function NavItem({
+  item,
+  pathname,
+  expandedMenus,
+  onToggleMenu,
+}: Readonly<{
+  item: NavItem;
+  pathname: string;
+  expandedMenus: Set<string>;
+  onToggleMenu: (href: string) => void;
+}>) {
+  const isActive = pathname === item.href || (item.href !== '/' && pathname.startsWith(item.href));
+  const hasChildren = item.children && item.children.length > 0;
+  if (hasChildren)
+    return (
+      <ExpandableNavItem
+        item={item}
+        isActive={isActive}
+        isExpanded={expandedMenus.has(item.href)}
+        onToggle={() => onToggleMenu(item.href)}
+        pathname={pathname}
+      />
+    );
+  return <SimpleNavItem item={item} isActive={isActive} />;
+}
+
+export function Navigation({
+  items,
+  pathname,
+  expandedMenus,
+  onToggleMenu,
+}: Readonly<NavigationProps>) {
   return (
     <nav className="p-4 space-y-1">
-      {items.map((item) => {
-        const isActive =
-          pathname === item.href || (item.href !== '/' && pathname.startsWith(item.href));
-        const hasChildren = item.children && item.children.length > 0;
-        const isExpanded = hasChildren && expandedMenus.has(item.href);
-
-        if (hasChildren) {
-          return (
-            <div key={item.href}>
-              <button
-                onClick={() => onToggleMenu(item.href)}
-                className={cn(
-                  'flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                  isActive
-                    ? 'bg-neutral-800 text-white'
-                    : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-white',
-                )}
-              >
-                <span>{item.icon}</span>
-                <span>{item.label}</span>
-                <span className="ml-auto text-xs">{isExpanded ? '▼' : '▶'}</span>
-              </button>
-              {isExpanded && (
-                <div className="ml-6 mt-1 space-y-1">
-                  {item.children!.map((child) => {
-                    const isChildActive = pathname === child.href;
-                    return (
-                      <Link
-                        key={child.href}
-                        href={child.href}
-                        className={cn(
-                          'flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm transition-colors',
-                          isChildActive
-                            ? 'bg-neutral-800/70 text-white'
-                            : 'text-neutral-500 hover:bg-neutral-800/30 hover:text-neutral-300',
-                        )}
-                      >
-                        <span className="text-neutral-600">•</span>
-                        <span>{child.label}</span>
-                      </Link>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          );
-        }
-
-        return (
-          <Link
-            key={item.href}
-            href={item.href}
-            className={cn(
-              'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-              isActive
-                ? 'bg-neutral-800 text-white'
-                : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-white',
-            )}
-          >
-            <span>{item.icon}</span>
-            <span>{item.label}</span>
-          </Link>
-        );
-      })}
+      {items.map((item) => (
+        <NavItem
+          key={item.href}
+          item={item}
+          pathname={pathname}
+          expandedMenus={expandedMenus}
+          onToggleMenu={onToggleMenu}
+        />
+      ))}
     </nav>
   );
 }

--- a/apps/admin/src/components/ui/sidebar/PipelineStatusBadge.tsx
+++ b/apps/admin/src/components/ui/sidebar/PipelineStatusBadge.tsx
@@ -16,51 +16,64 @@ interface PipelineStatusBadgeProps {
   status: PipelineStatus;
 }
 
-export function PipelineStatusBadge({ status }: PipelineStatusBadgeProps) {
+function getBadgeClass(s: PipelineStatus['status']) {
+  return cn(
+    'flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium',
+    s === 'processing' && 'bg-sky-500/20 text-sky-400',
+    s === 'idle' && 'bg-emerald-500/20 text-emerald-400',
+    s === 'degraded' && 'bg-red-500/20 text-red-400',
+    s === 'unknown' && 'bg-neutral-500/20 text-neutral-400',
+  );
+}
+
+function getDotClass(s: PipelineStatus['status']) {
+  return cn(
+    'h-1.5 w-1.5 rounded-full',
+    s === 'processing' && 'bg-sky-400 animate-pulse',
+    s === 'idle' && 'bg-emerald-400',
+    s === 'degraded' && 'bg-red-400 animate-pulse',
+    s === 'unknown' && 'bg-neutral-400',
+  );
+}
+
+function TooltipRow({
+  label,
+  value,
+  valueClass = 'text-neutral-200',
+}: Readonly<{ label: string; value: string | number; valueClass?: string }>) {
+  return (
+    <div className="flex justify-between">
+      <span className="text-neutral-400">{label}</span>
+      <span className={valueClass}>{value}</span>
+    </div>
+  );
+}
+
+function StatusTooltip({ status }: Readonly<{ status: PipelineStatus }>) {
+  return (
+    <div className="absolute left-0 top-full mt-2 hidden group-hover:block z-50 w-48 rounded-lg border border-neutral-700 bg-neutral-900 p-3 text-xs shadow-xl">
+      <div className="space-y-1.5">
+        <TooltipRow label="Last run" value={formatTimeAgo(status.lastQueueRun)} />
+        <TooltipRow label="Last build" value={formatTimeAgo(status.lastBuildTime)} />
+        <TooltipRow label="Processing" value={status.processingCount} valueClass="text-sky-400" />
+        <TooltipRow
+          label="Failed (24h)"
+          value={status.recentFailedCount}
+          valueClass={status.recentFailedCount > 0 ? 'text-red-400' : 'text-neutral-200'}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function PipelineStatusBadge({ status }: Readonly<PipelineStatusBadgeProps>) {
   return (
     <div className="group relative">
-      <div
-        className={cn(
-          'flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium',
-          status.status === 'processing' && 'bg-sky-500/20 text-sky-400',
-          status.status === 'idle' && 'bg-emerald-500/20 text-emerald-400',
-          status.status === 'degraded' && 'bg-red-500/20 text-red-400',
-          status.status === 'unknown' && 'bg-neutral-500/20 text-neutral-400',
-        )}
-      >
-        <span
-          className={cn(
-            'h-1.5 w-1.5 rounded-full',
-            status.status === 'processing' && 'bg-sky-400 animate-pulse',
-            status.status === 'idle' && 'bg-emerald-400',
-            status.status === 'degraded' && 'bg-red-400 animate-pulse',
-            status.status === 'unknown' && 'bg-neutral-400',
-          )}
-        />
+      <div className={getBadgeClass(status.status)}>
+        <span className={getDotClass(status.status)} />
         {status.status}
       </div>
-      <div className="absolute left-0 top-full mt-2 hidden group-hover:block z-50 w-48 rounded-lg border border-neutral-700 bg-neutral-900 p-3 text-xs shadow-xl">
-        <div className="space-y-1.5">
-          <div className="flex justify-between">
-            <span className="text-neutral-400">Last run</span>
-            <span className="text-neutral-200">{formatTimeAgo(status.lastQueueRun)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-neutral-400">Last build</span>
-            <span className="text-neutral-200">{formatTimeAgo(status.lastBuildTime)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-neutral-400">Processing</span>
-            <span className="text-sky-400">{status.processingCount}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-neutral-400">Failed (24h)</span>
-            <span className={status.recentFailedCount > 0 ? 'text-red-400' : 'text-neutral-200'}>
-              {status.recentFailedCount}
-            </span>
-          </div>
-        </div>
-      </div>
+      <StatusTooltip status={status} />
     </div>
   );
 }

--- a/apps/admin/src/components/ui/status-pill.tsx
+++ b/apps/admin/src/components/ui/status-pill.tsx
@@ -43,11 +43,11 @@ function CodeSpan({
   code,
   isActive,
   activeColor,
-}: {
+}: Readonly<{
   code: number;
   isActive?: boolean;
   activeColor?: string;
-}) {
+}>) {
   return (
     <span className={cn('pl-2 pr-1 py-1 font-mono', getCodeClass(isActive, activeColor))}>
       {code}
@@ -59,11 +59,11 @@ function NameSpan({
   name,
   isActive,
   activeColor,
-}: {
+}: Readonly<{
   name: string;
   isActive?: boolean;
   activeColor?: string;
-}) {
+}>) {
   return (
     <span className={cn('pr-2 py-1', getNameClass(isActive, activeColor))}>
       {name.replace(/_/g, ' ')}
@@ -76,12 +76,12 @@ function CountSpan({
   color,
   isActive,
   activeColor,
-}: {
+}: Readonly<{
   count: number;
   color: string;
   isActive?: boolean;
   activeColor?: string;
-}) {
+}>) {
   return (
     <span
       className={cn(
@@ -101,7 +101,7 @@ function PillContent({
   color,
   isActive,
   activeColor,
-}: Omit<StatusPillProps, 'borderColor' | 'href'>) {
+}: Readonly<Omit<StatusPillProps, 'borderColor' | 'href'>>) {
   return (
     <>
       <CodeSpan code={code} isActive={isActive} activeColor={activeColor} />
@@ -132,12 +132,12 @@ function PillWrapper({
   className,
   title,
   children,
-}: {
+}: Readonly<{
   href?: string;
   className: string;
   title: string;
   children: React.ReactNode;
-}) {
+}>) {
   if (href)
     return (
       <Link href={href} className={className} title={title}>
@@ -151,7 +151,7 @@ function PillWrapper({
   );
 }
 
-export function StatusPill(props: StatusPillProps) {
+export function StatusPill(props: Readonly<StatusPillProps>) {
   const { code, name, count, color, borderColor, isActive = false, activeColor, href } = props;
   const containerClass = useContainerClass(isActive, count, borderColor, activeColor, href);
   const title = `Code ${code}: ${name} (${count} items)`;


### PR DESCRIPTION
Apply Readonly utility type to React component props and refactor functions to ~15 LoC (quality gate: <30 LoC).

## Changes
- Applied Readonly to React component props across 28 files
- Refactored large functions to meet quality gate requirements
- Created new component files for better organization
- Fixed lint warnings (ternary expressions for side effects)

## Files Modified
- evals/llm-judge/components, items/*.tsx, layout.tsx
- missed/components, pipeline/pipeline-metrics.tsx, sources/SourcesContent.tsx  
- components/dashboard/*.tsx, components/tags/*.tsx
- components/ui/*.tsx, contexts/StatusContext.tsx

## New Files
- items/review-list-components.tsx
- items/review-list-bulk-actions.tsx
- items/review-list-hooks.tsx
- components/dashboard/AgentJobCardComponents.tsx

## Quality Metrics
- All functions now <30 LoC (target ~15-20 LoC)
- 0 errors, 0 warnings from lint
- Passes Boy Scout Rule quality gate