### PR TITLE
fix: extract nested ternary in enrichment panel (S3358)

### DIFF
--- a/apps/admin/src/app/(dashboard)/items/[id]/enrichment-panel/components.tsx
+++ b/apps/admin/src/app/(dashboard)/items/[id]/enrichment-panel/components.tsx
@@ -124,6 +124,12 @@ function StepLabel({
   );
 }
 
+function getStepButtonText(loading: string | null, stepKey: string, hasRun: boolean): string {
+  if (loading === stepKey) return '...';
+  if (hasRun) return 'Re-run';
+  return 'Run';
+}
+
 function StepButton({
   loading,
   stepKey,
@@ -146,7 +152,7 @@ function StepButton({
       disabled={loading !== null || upToDate}
       className={`shrink-0 rounded px-2.5 py-1 text-xs font-medium transition-colors ${cls} disabled:opacity-50`}
     >
-      {loading === stepKey ? '...' : hasRun ? 'Re-run' : 'Run'}
+      {getStepButtonText(loading, stepKey, hasRun)}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
Fix SonarCloud rule S3358 violation by extracting a nested ternary operator into a helper function.

## Rule
- **Rule ID**: typescript:S3358  
- **Message**: "Ternary operators should not be nested"
- **Documentation**: [docs/architecture/quality/sonar-rules/3358_ternary-operators-should-not-be-nested.md](docs/architecture/quality/sonar-rules/3358_ternary-operators-should-not-be-nested.md)

## Changes
- **File**: `apps/admin/src/app/(dashboard)/items/[id]/enrichment-panel/components.tsx`
- **Before**: `{loading === stepKey ? '...' : hasRun ? 'Re-run' : 'Run'}`
- **After**: Extracted to `getStepButtonText()` helper function with early returns

## Pattern Applied
Following the lesson from [docs/architecture/quality/sonar-lessons/extract-this-nested-ternary-operation-into-an-independent-statement.md](docs/architecture/quality/sonar-lessons/extract-this-nested-ternary-operation-into-an-independent-statement.md):

```tsx
function getStepButtonText(loading: string | null, stepKey: string, hasRun: boolean): string {
  if (loading === stepKey) return '...';
  if (hasRun) return 'Re-run';
  return 'Run';
}
```

## Verification
- `npm run lint -w apps/admin` passes (0 errors, 0 warnings)
- Pre-commit quality gate passes
