### PR TITLE
fix(S6551): add type guards before string coercion

### DIFF
--- a/apps/admin/src/app/(dashboard)/evals/head-to-head/output-display.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/head-to-head/output-display.tsx
@@ -66,22 +66,31 @@ function ConfidenceSection({ confidence }: Readonly<{ confidence: unknown }>) {
 
 function ReasoningSection({ reasoning }: Readonly<{ reasoning: unknown }>) {
   if (!reasoning) return null;
+  const text = typeof reasoning === 'string' ? reasoning : JSON.stringify(reasoning);
   return (
     <div className="mb-3">
       <div className="text-xs font-medium text-neutral-400 mb-1">Reasoning</div>
-      <div className="text-xs text-neutral-300 italic">{String(reasoning)}</div>
+      <div className="text-xs text-neutral-300 italic">{text}</div>
     </div>
   );
+}
+
+function toNumber(val: unknown): number {
+  return typeof val === 'number' ? val : 0;
 }
 
 function UsageSection({ usage }: Readonly<{ usage: unknown }>) {
   if (!usage || typeof usage !== 'object') return null;
   const u = usage as Record<string, unknown>;
+  const promptTokens = toNumber(u.prompt_tokens);
+  const completionTokens = toNumber(u.completion_tokens);
+  const totalTokens = toNumber(u.total_tokens);
+  const model = typeof u.model === 'string' ? u.model : null;
   return (
     <div className="text-xs text-neutral-500 border-t border-neutral-800 pt-2 mt-2">
-      <span className="font-medium">Tokens:</span> {String(u.prompt_tokens || 0)} in /{' '}
-      {String(u.completion_tokens || 0)} out = {String(u.total_tokens || 0)} total
-      {u.model ? <span className="ml-2">({String(u.model)})</span> : null}
+      <span className="font-medium">Tokens:</span> {promptTokens} in / {completionTokens} out ={' '}
+      {totalTokens} total
+      {model ? <span className="ml-2">({model})</span> : null}
     </div>
   );
 }

--- a/apps/admin/src/app/(dashboard)/items/[id]/page-components.tsx
+++ b/apps/admin/src/app/(dashboard)/items/[id]/page-components.tsx
@@ -102,7 +102,7 @@ export function ThumbnailSection({ payload }: Readonly<{ payload: Record<string,
         // eslint-disable-next-line @next/next/no-img-element
         <img
           src={thumbnailUrl}
-          alt={`${payload.source_name || 'Source'} preview`}
+          alt={`${typeof payload.source_name === 'string' ? payload.source_name : 'Source'} preview`}
           className="absolute inset-0 w-full h-full object-cover"
         />
       ) : (

--- a/docs/architecture/quality/sonar-lessons/will-use-objects-default-stringification-format.md
+++ b/docs/architecture/quality/sonar-lessons/will-use-objects-default-stringification-format.md
@@ -1,0 +1,57 @@
+# Will use Object's default stringification format (S6551)
+
+**Rule**: S6551 - Objects and classes converted or coerced to strings should define a "toString()" method
+
+**Sonar message**: `'X' will use Object's default stringification format ('[object Object]') when stringified.`
+
+## Problem
+
+When coercing `unknown` values to strings (via template literals, `String()`, or `+`), objects without a custom `toString()` method return `[object Object]`.
+
+## Fix Pattern
+
+Add **type guards** before coercing to string:
+
+### For string values
+
+```typescript
+// ❌ Noncompliant
+const text = String(reasoning); // Could be "[object Object]"
+
+// ✅ Compliant
+const text = typeof reasoning === 'string' ? reasoning : JSON.stringify(reasoning);
+```
+
+### For number values
+
+```typescript
+// ❌ Noncompliant
+const tokens = String(u.prompt_tokens || 0); // Could be "[object Object]0"
+
+// ✅ Compliant
+function toNumber(val: unknown): number {
+  return typeof val === 'number' ? val : 0;
+}
+const tokens = toNumber(u.prompt_tokens);
+```
+
+### For optional string in template literal
+
+```typescript
+// ❌ Noncompliant
+alt={`${payload.source_name || 'Source'} preview`}
+
+// ✅ Compliant
+alt={`${typeof payload.source_name === 'string' ? payload.source_name : 'Source'} preview`}
+```
+
+## Why this pattern?
+
+1. **Type safety**: Explicit checks prevent runtime surprises
+2. **Clear intent**: Shows what type is expected
+3. **Graceful fallback**: `JSON.stringify` for objects, defaults for missing values
+
+## Files fixed with this pattern
+
+- `apps/admin/src/app/(dashboard)/evals/head-to-head/output-display.tsx`
+- `apps/admin/src/app/(dashboard)/items/[id]/page-components.tsx`

--- a/docs/architecture/quality/sonar-rules/6551_objects-converted-to-strings-should-define-tostring-method.md
+++ b/docs/architecture/quality/sonar-rules/6551_objects-converted-to-strings-should-define-tostring-method.md
@@ -1,0 +1,47 @@
+# S6551: Objects and classes converted or coerced to strings should define a "toString()" method
+
+**Rule ID**: typescript:S6551  
+**Type**: Code Smell  
+**Severity**: Low  
+**Effort**: 5 min
+
+## Description
+
+When calling `toString()` or coercing an object into a string that doesn't implement its own `toString` method, it returns `[object Object]` which is often not what was intended.
+
+## Why is this an issue?
+
+When using an object in a string context, a developer wants to get the string representation of the state of an object. Obtaining `[object Object]` is probably not the intended behaviour and might even denote a bug.
+
+## Noncompliant code example
+
+```typescript
+const foo = {};
+
+foo + ''; // Noncompliant - evaluates to "[object Object]"
+`Foo: ${foo}`; // Noncompliant - evaluates to "Foo: [object Object]"
+foo.toString(); // Noncompliant - evaluates to "[object Object]"
+```
+
+## Compliant solution
+
+```typescript
+// Option 1: Define a toString method
+const foo = {
+  toString: () => {
+    return 'foo';
+  },
+};
+
+foo + '';
+`Foo: ${foo}`;
+foo.toString();
+
+// Option 2: Use type guards before coercion
+const val: unknown = getData();
+const text = typeof val === 'string' ? val : JSON.stringify(val);
+```
+
+## See also
+
+- [SonarSource Rule](https://rules.sonarsource.com/typescript/RSPEC-6551/)

--- a/docs/architecture/quality/sonarcloud.md
+++ b/docs/architecture/quality/sonarcloud.md
@@ -2,11 +2,12 @@
 
 ---
 
-**Version**: 1.1.0  
-**Last updated**: 2026-01-04  
+**Version**: 1.2.0  
+**Last updated**: 2026-01-05  
 **Quality System Control**: C7 (Static analysis)  
 **Change history**:
 
+- 1.2.0 (2026-01-05): Added S6551 (use type guards before string coercion).
 - 1.1.0 (2026-01-04): Restructured to Prevention Checklist + Lessons Learned + Rule Index (no duplication of SonarSource docs).
 - 1.0.0 (2026-01-04): Initial version.
 
@@ -43,6 +44,7 @@ When you see a SonarCloud issue, extract the Rule ID and find the matching lesso
 | S4624   | [Refactor this code to not use nested template literals](./sonar-lessons/refactor-this-code-to-not-use-nested-template-literals.md)                           | `sonar-lessons/refactor-this-code-to-not-use-nested-template-literals.md`              |
 | S6479   | [Do not use Array index in keys](./sonar-lessons/do-not-use-array-index-in-keys.md)                                                                           | `sonar-lessons/do-not-use-array-index-in-keys.md`                                      |
 | S6759   | [Mark React props as read-only](./sonar-lessons/mark-react-props-as-read-only.md)                                                                             | `sonar-lessons/mark-react-props-as-read-only.md`                                       |
+| S6551   | [Will use Object's default stringification format](./sonar-lessons/will-use-objects-default-stringification-format.md)                                        | `sonar-lessons/will-use-objects-default-stringification-format.md`                     |
 
 ---
 
@@ -60,6 +62,7 @@ Quick checks before committing. If you're about to write any of these patterns, 
 - [ ] **Use target check for modal backdrops** — `e.target === e.currentTarget` instead of stopPropagation
 - [ ] **No code duplication** — Extract shared logic to functions/components
 - [ ] **No overly complex functions** — Keep cyclomatic complexity low
+- [ ] **Use type guards before string coercion** — Check `typeof val === 'string'` before using `unknown` in template literals
 
 ---
 
@@ -109,6 +112,10 @@ Project-specific patterns derived from fixing real issues. Each entry shows what
 
 ---
 
+## [Will use Object's default stringification format](./sonar-lessons/will-use-objects-default-stringification-format.md) (S6551)
+
+---
+
 # Rule Index
 
 Rules we've encountered. Links to authoritative SonarSource documentation.
@@ -146,5 +153,9 @@ Rules we've encountered. Links to authoritative SonarSource documentation.
 ---
 
 ## [React props should be read-only](./sonar-rules/6759_react-props-should-be-read-only.md)
+
+---
+
+## [Objects converted to strings should define a toString method](./sonar-rules/6551_objects-converted-to-strings-should-define-tostring-method.md)
 
 ---


### PR DESCRIPTION
## Summary
Fix SonarCloud S6551 violations and add documentation for this rule.

## Rule
**S6551**: Objects and classes converted or coerced to strings should define a "toString()" method

## Problem
When coercing `unknown` values to strings, objects without a custom `toString()` method return `[object Object]`.

## Fix Applied
Add **type guards** before coercing to string:
- `typeof val === 'string' ? val : JSON.stringify(val)` for strings
- `typeof val === 'number' ? val : 0` for numbers

## Files Changed

### Code fixes
- `apps/admin/src/app/(dashboard)/evals/head-to-head/output-display.tsx`
  - `ReasoningSection`: add type guard for `reasoning`
  - `UsageSection`: add `toNumber()` helper and type guards for token counts and model
- `apps/admin/src/app/(dashboard)/items/[id]/page-components.tsx`
  - `ThumbnailSection`: add type guard for `payload.source_name`

### Documentation
- `docs/architecture/quality/sonar-rules/6551_objects-converted-to-strings-should-define-tostring-method.md` (new)
- `docs/architecture/quality/sonar-lessons/will-use-objects-default-stringification-format.md` (new)
- `docs/architecture/quality/sonarcloud.md` (updated Quick Lookup, Prevention Checklist, Lessons, Rule Index)

## Verification
- Lint passes