### PR TITLE
fix(S7781): prefer replaceAll() over replace() with global regex

### DIFF
--- a/apps/admin/src/app/(dashboard)/items/[id]/propose-entity.tsx
+++ b/apps/admin/src/app/(dashboard)/items/[id]/propose-entity.tsx
@@ -13,8 +13,8 @@ interface ProposeEntityProps {
 function generateSlug(name: string): string {
   return name
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
+    .replaceAll(/[^a-z0-9]+/, '-')
+    .replaceAll(/(^-)|(-$)/, '');
 }
 
 async function proposeEntity(

--- a/apps/admin/src/app/(dashboard)/items/[id]/unknown-entities.tsx
+++ b/apps/admin/src/app/(dashboard)/items/[id]/unknown-entities.tsx
@@ -31,8 +31,8 @@ function getEntityKey(entity: UnknownEntity): string {
 function generateSlug(name: string): string {
   return name
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
+    .replaceAll(/[^a-z0-9]+/, '-')
+    .replaceAll(/(^-)|(-$)/, '');
 }
 
 async function submitProposal(

--- a/apps/admin/src/app/(dashboard)/items/lib/publication-helpers.ts
+++ b/apps/admin/src/app/(dashboard)/items/lib/publication-helpers.ts
@@ -198,7 +198,7 @@ async function handleCodesArray(
 export function extractDomain(url: string): string {
   try {
     const hostname = new URL(url).hostname;
-    return hostname.replace(/^www\./, '');
+    return hostname.replaceAll(/^www\./, '');
   } catch {
     return 'unknown';
   }
@@ -214,8 +214,8 @@ export function buildPublicStorageUrl(bucket?: string | null, path?: string | nu
 export function generateSlug(title: string): string {
   return title
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
+    .replaceAll(/[^a-z0-9]+/, '-')
+    .replaceAll(/(^-)|(-$)/, '')
     .slice(0, 80);
 }
 

--- a/apps/admin/src/components/ui/status-pill.tsx
+++ b/apps/admin/src/components/ui/status-pill.tsx
@@ -66,7 +66,7 @@ function NameSpan({
 }>) {
   return (
     <span className={cn('pr-2 py-1', getNameClass(isActive, activeColor))}>
-      {name.replace(/_/g, ' ')}
+      {name.replaceAll('_', ' ')}
     </span>
   );
 }

--- a/docs/architecture/quality/sonar-lessons/prefer-string-replaceall-over-string-replace.md
+++ b/docs/architecture/quality/sonar-lessons/prefer-string-replaceall-over-string-replace.md
@@ -1,0 +1,53 @@
+# Prefer 'String#replaceAll()' over 'String#replace()'
+
+**Sonar Rule**: S7781  
+**Sonar Message**: `Prefer 'String#replaceAll()' over 'String#replace()'.`
+
+## Pattern
+
+When you see `.replace(/pattern/g, replacement)`, convert to `.replaceAll()`.
+
+## Fix Strategy
+
+1. **Simple string patterns** → Use string literal:
+
+   ```typescript
+   // Before
+   name.replace(/_/g, ' ');
+
+   // After
+   name.replaceAll('_', ' ');
+   ```
+
+2. **Regex patterns** → Remove the `g` flag:
+
+   ```typescript
+   // Before
+   title.replace(/[^a-z0-9]+/g, '-');
+
+   // After
+   title.replaceAll(/[^a-z0-9]+/, '-');
+   ```
+
+3. **Alternation patterns** → Add explicit grouping (prevents S5869):
+
+   ```typescript
+   // Before
+   slug.replace(/^-|-$/g, '');
+
+   // After
+   slug.replaceAll(/(^-)|(-$)/, '');
+   ```
+
+## Files fixed with this pattern
+
+- `apps/admin/src/app/(dashboard)/items/[id]/propose-entity.tsx`
+- `apps/admin/src/app/(dashboard)/items/[id]/unknown-entities.tsx`
+- `apps/admin/src/app/(dashboard)/items/lib/publication-helpers.ts`
+- `apps/admin/src/components/ui/status-pill.tsx`
+
+## Why this matters
+
+- **Clearer intent**: `replaceAll` explicitly states all occurrences will be replaced
+- **Safer**: No need to remember the `g` flag
+- **ES2021 standard**: Modern JavaScript best practice

--- a/docs/architecture/quality/sonar-rules/7781_strings-should-use-replaceall-instead-of-replace-with-global-regex.md
+++ b/docs/architecture/quality/sonar-rules/7781_strings-should-use-replaceall-instead-of-replace-with-global-regex.md
@@ -1,0 +1,39 @@
+# S7781: Strings should use "replaceAll()" instead of "replace()" with global regex
+
+**Rule ID**: typescript:S7781  
+**Type**: Code Smell  
+**Severity**: Low  
+**Tags**: es2021
+
+## Why is this an issue?
+
+When using `String#replace()` with a global regex pattern, developers must:
+
+1. Include the global flag (`g`)
+2. Properly escape special regex characters
+
+The `String#replaceAll()` method (ES2021) provides a clearer, safer way to replace all occurrences. It:
+
+- Clearly indicates intent to replace all matches
+- Can use a simple string literal when no regex features are needed
+- Throws a `TypeError` if a regex without the `g` flag is used, preventing bugs
+
+## Non-compliant code
+
+```typescript
+const result = text.replace(/hello/g, 'hi'); // Global regex
+const slug = name.replace(/[^a-z0-9]+/g, '-'); // Character class with global
+```
+
+## Compliant code
+
+```typescript
+const result = text.replaceAll('hello', 'hi'); // String literal
+const slug = name.replaceAll(/[^a-z0-9]+/, '-'); // Regex without g flag
+```
+
+## See also
+
+- [SonarSource Rule: typescript:S7781](https://rules.sonarsource.com/typescript/RSPEC-7781/)
+- [MDN: String.prototype.replaceAll()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll)
+- [MDN: String.prototype.replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace)

--- a/docs/architecture/quality/sonarcloud.md
+++ b/docs/architecture/quality/sonarcloud.md
@@ -2,11 +2,12 @@
 
 ---
 
-**Version**: 1.2.0  
+**Version**: 1.3.0  
 **Last updated**: 2026-01-05  
 **Quality System Control**: C7 (Static analysis)  
 **Change history**:
 
+- 1.3.0 (2026-01-05): Added S7781 (prefer replaceAll over replace with global regex).
 - 1.2.0 (2026-01-05): Added S6551 (use type guards before string coercion).
 - 1.1.0 (2026-01-04): Restructured to Prevention Checklist + Lessons Learned + Rule Index (no duplication of SonarSource docs).
 - 1.0.0 (2026-01-04): Initial version.
@@ -45,6 +46,7 @@ When you see a SonarCloud issue, extract the Rule ID and find the matching lesso
 | S6479   | [Do not use Array index in keys](./sonar-lessons/do-not-use-array-index-in-keys.md)                                                                           | `sonar-lessons/do-not-use-array-index-in-keys.md`                                      |
 | S6759   | [Mark React props as read-only](./sonar-lessons/mark-react-props-as-read-only.md)                                                                             | `sonar-lessons/mark-react-props-as-read-only.md`                                       |
 | S6551   | [Will use Object's default stringification format](./sonar-lessons/will-use-objects-default-stringification-format.md)                                        | `sonar-lessons/will-use-objects-default-stringification-format.md`                     |
+| S7781   | [Prefer 'String#replaceAll()' over 'String#replace()'](./sonar-lessons/prefer-string-replaceall-over-string-replace.md)                                       | `sonar-lessons/prefer-string-replaceall-over-string-replace.md`                        |
 
 ---
 
@@ -63,6 +65,7 @@ Quick checks before committing. If you're about to write any of these patterns, 
 - [ ] **No code duplication** — Extract shared logic to functions/components
 - [ ] **No overly complex functions** — Keep cyclomatic complexity low
 - [ ] **Use type guards before string coercion** — Check `typeof val === 'string'` before using `unknown` in template literals
+- [ ] **Use replaceAll() for global replacement** — Prefer `.replaceAll()` over `.replace(/pattern/g, ...)`
 
 ---
 
@@ -116,6 +119,10 @@ Project-specific patterns derived from fixing real issues. Each entry shows what
 
 ---
 
+## [Prefer 'String#replaceAll()' over 'String#replace()'](./sonar-lessons/prefer-string-replaceall-over-string-replace.md) (S7781)
+
+---
+
 # Rule Index
 
 Rules we've encountered. Links to authoritative SonarSource documentation.
@@ -157,5 +164,9 @@ Rules we've encountered. Links to authoritative SonarSource documentation.
 ---
 
 ## [Objects converted to strings should define a toString method](./sonar-rules/6551_objects-converted-to-strings-should-define-tostring-method.md)
+
+---
+
+## [Strings should use replaceAll instead of replace with global regex](./sonar-rules/7781_strings-should-use-replaceall-instead-of-replace-with-global-regex.md)
 
 ---


### PR DESCRIPTION
## Problem

SonarCloud flagged 7 violations of S7781: `Prefer 'String#replaceAll()' over 'String#replace()'`

Using `.replace(/pattern/g, ...)` requires developers to remember the `g` flag and properly escape special regex characters. The ES2021 `.replaceAll()` method is clearer and safer.

## Files Fixed

| File | Function | Change |
|------|----------|--------|
| `propose-entity.tsx` | `generateSlug` | `.replace(/[^a-z0-9]+/g, '-')` → `.replaceAll()` |
| `unknown-entities.tsx` | `generateSlug` | `.replace(/[^a-z0-9]+/g, '-')` → `.replaceAll()` |
| `publication-helpers.ts` | `extractDomain`, `generateSlug` | `.replace()` → `.replaceAll()` |
| `status-pill.tsx` | `NameSpan` | `.replace(/_/g, ' ')` → `.replaceAll('_', ' ')` |

## Fix Pattern

```typescript
// Before - global regex
name.replace(/_/g, ' ')
title.replace(/[^a-z0-9]+/g, '-')

// After - replaceAll
name.replaceAll('_', ' ')           // String literal when possible
title.replaceAll(/[^a-z0-9]+/, '-') // Regex without g flag
```

## Documentation

- Created rule doc: `sonar-rules/7781_strings-should-use-replaceall-instead-of-replace-with-global-regex.md`
- Created lesson doc: `sonar-lessons/prefer-string-replaceall-over-string-replace.md`
- Updated `sonarcloud.md` with Quick Lookup, Prevention Checklist, Lessons Learned, and Rule Index entries