### PR TITLE
refactor(scorer): extract helpers to reduce file from 487 to 170 lines

### DIFF
--- a/services/agent-api/src/agents/scorer-checks.js
+++ b/services/agent-api/src/agents/scorer-checks.js
@@ -1,0 +1,115 @@
+/**
+ * Scorer Validation Checks
+ *
+ * Helper functions for content validation and filtering.
+ * KB-155: Agentic Discovery System - Phase 1
+ */
+
+import {
+  TRUSTED_SOURCES,
+  STALENESS_INDICATORS,
+  AGE_PENALTY_THRESHOLD_YEARS,
+} from './scorer-config.js';
+
+/**
+ * Check if a source is in the trusted allowlist
+ * @param {string} sourceSlug - Source slug to check
+ * @returns {boolean}
+ */
+export function isTrustedSource(sourceSlug) {
+  if (!sourceSlug) return false;
+  const normalized = sourceSlug.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
+  return TRUSTED_SOURCES.has(normalized);
+}
+
+/**
+ * Check content age and calculate penalty
+ * KB-206: Soft signal approach - penalize old content but don't auto-reject
+ * @param {string|Date} publishedDate - Publication date
+ * @returns {{ageInDays: number|null, ageInYears: number|null, penalty: number}}
+ */
+export function checkContentAge(publishedDate) {
+  if (!publishedDate) {
+    return { ageInDays: null, ageInYears: null, penalty: 0 };
+  }
+
+  const pubDate = new Date(publishedDate);
+  if (Number.isNaN(pubDate.getTime())) {
+    return { ageInDays: null, ageInYears: null, penalty: 0 };
+  }
+
+  const ageMs = Date.now() - pubDate.getTime();
+  const ageInDays = Math.floor(ageMs / (1000 * 60 * 60 * 24));
+  const ageInYears = ageInDays / 365;
+
+  const penalty = calculateAgePenalty(ageInYears);
+  return { ageInDays, ageInYears, penalty };
+}
+
+/** Calculate age penalty: -1 per 2 years over threshold, max -3 */
+function calculateAgePenalty(ageInYears) {
+  if (ageInYears <= AGE_PENALTY_THRESHOLD_YEARS) return 0;
+  return Math.min(3, Math.floor((ageInYears - AGE_PENALTY_THRESHOLD_YEARS) / 2) + 1);
+}
+
+/**
+ * Check if content contains staleness indicators
+ * KB-206: Detect tombstone/expired pages
+ * @param {string} title - Content title
+ * @param {string} description - Content description
+ * @param {string} url - Content URL
+ * @returns {{hasStaleIndicators: boolean, matchedIndicator: string|null}}
+ */
+export function checkStaleIndicators(title, description = '', url = '') {
+  const text = `${title} ${description} ${url}`.toLowerCase();
+
+  for (const indicator of STALENESS_INDICATORS) {
+    if (text.includes(indicator)) {
+      return { hasStaleIndicators: true, matchedIndicator: indicator };
+    }
+  }
+
+  return { hasStaleIndicators: false, matchedIndicator: null };
+}
+
+/**
+ * Check if content matches rejection patterns (pre-filter before LLM)
+ * KB-210: Deterministic rejection for obvious patterns
+ * @param {string} title - Content title
+ * @param {string} description - Content description
+ * @param {string} source - Content source
+ * @param {Array} patterns - Rejection patterns from DB
+ * @returns {{shouldReject: boolean, pattern: string|null, maxScore: number}}
+ */
+export function checkRejectionPatterns(title, description = '', source = '', patterns = []) {
+  if (patterns.length === 0) {
+    return { shouldReject: false, pattern: null, maxScore: 10 };
+  }
+
+  const text = `${title} ${description} ${source}`.toLowerCase();
+
+  for (const p of patterns) {
+    const match = findPatternMatch(text, p.patterns);
+    if (match) {
+      return {
+        shouldReject: true,
+        pattern: p.name,
+        reason: p.description,
+        matchedKeyword: match,
+        maxScore: p.max_score,
+      };
+    }
+  }
+
+  return { shouldReject: false, pattern: null, maxScore: 10 };
+}
+
+/** Find first matching keyword in text */
+function findPatternMatch(text, keywords) {
+  for (const keyword of keywords) {
+    if (text.includes(keyword.toLowerCase())) {
+      return keyword;
+    }
+  }
+  return null;
+}

--- a/services/agent-api/src/agents/scorer-config.js
+++ b/services/agent-api/src/agents/scorer-config.js
@@ -1,0 +1,60 @@
+/**
+ * Scorer Configuration
+ *
+ * Constants and configuration for the scorer agent.
+ * KB-155: Agentic Discovery System - Phase 1
+ */
+
+// Minimum score to queue (below this = auto-skip)
+export const MIN_RELEVANCE_SCORE = 4;
+
+// Content age thresholds for soft scoring penalties
+// KB-206: Use as soft signal, not hard cutoff (don't reject "Attention is All You Need")
+export const AGE_PENALTY_THRESHOLD_YEARS = 2;
+
+// Staleness indicators - content with these terms is likely outdated/invalid
+// KB-206: Detect tombstone pages and expired content
+export const STALENESS_INDICATORS = [
+  'inactive',
+  'rescinded',
+  'expired',
+  'superseded',
+  'archived',
+  'no longer active',
+  'no longer valid',
+  'no longer current',
+  'this page has been removed',
+  'this document has been withdrawn',
+  'this content is outdated',
+];
+
+// Trusted sources that auto-pass relevance filter (core BFSI institutions)
+// Slugs must match kb_source.slug in the database
+export const TRUSTED_SOURCES = new Set([
+  // Central Banks
+  'bis',
+  'bis-research',
+  'bis-innovation',
+  'ecb',
+  'fed',
+  'boe',
+  'dnb',
+  // Regulators
+  'eba',
+  'esma',
+  'eiopa',
+  'fca',
+  'pra',
+  'fsb',
+  'bcbs',
+  'fatf',
+  'fdic',
+  'occ',
+  'sec',
+  // International Organizations
+  'imf',
+  // Premium Consultants
+  'mckinsey',
+  'bcg',
+  'bain',
+]);

--- a/services/agent-api/src/agents/scorer-prompt.js
+++ b/services/agent-api/src/agents/scorer-prompt.js
@@ -1,0 +1,163 @@
+/**
+ * Scorer Prompt Generation
+ *
+ * Dynamic prompt generation from database content.
+ * KB-155: Agentic Discovery System - Phase 1
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import process from 'node:process';
+
+let supabase = null;
+let cachedPrompt = null;
+let cachedAudiences = null;
+let cachedRejectionPatterns = null;
+
+function getSupabase() {
+  if (!supabase) {
+    supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  }
+  return supabase;
+}
+
+/**
+ * Load audience definitions from DB (cached for performance)
+ * KB-208: Single source of truth for audience definitions
+ */
+export async function getAudiences() {
+  if (cachedAudiences) return cachedAudiences;
+
+  const { data, error } = await getSupabase()
+    .from('kb_audience')
+    .select('code, name, description, cares_about, doesnt_care_about, scoring_guide')
+    .order('sort_order');
+
+  if (error || !data || data.length === 0) {
+    throw new Error(
+      'CRITICAL: No audiences found in kb_audience table. ' +
+        'Run migrations to seed audience data. ' +
+        `DB error: ${error?.message || 'No data returned'}`,
+    );
+  }
+
+  cachedAudiences = data;
+  return cachedAudiences;
+}
+
+/**
+ * Load rejection patterns from DB (cached for performance)
+ * KB-210: Single source of truth for rejection criteria
+ */
+export async function getRejectionPatterns() {
+  if (cachedRejectionPatterns) return cachedRejectionPatterns;
+
+  const { data, error } = await getSupabase()
+    .from('kb_rejection_pattern')
+    .select('name, category, description, patterns, max_score')
+    .eq('is_active', true)
+    .order('sort_order');
+
+  if (error) {
+    console.warn('Warning: Failed to load rejection patterns:', error.message);
+    return [];
+  }
+
+  cachedRejectionPatterns = data || [];
+  return cachedRejectionPatterns;
+}
+
+/** Format a single audience for the prompt */
+function formatAudienceSection(audience) {
+  return `## ${audience.name} (${audience.code})
+${audience.description}
+
+They care about:
+${audience.cares_about}
+
+They don't care about:
+${audience.doesnt_care_about}
+
+Scoring guide:
+${audience.scoring_guide}`;
+}
+
+/** Build rejection section from patterns */
+function buildRejectionSection(patterns) {
+  if (patterns.length === 0) return '';
+
+  const items = patterns
+    .map((p) => {
+      const keywords = p.patterns.slice(0, 5).join(', ');
+      const suffix = p.patterns.length > 5 ? '...' : '';
+      return `- **${p.description}** - Keywords: ${keywords}${suffix}`;
+    })
+    .join('\n');
+
+  return `## AUTOMATIC REJECTION (score 1-3 for ALL audiences)
+
+The following content types are NOT relevant regardless of BFSI keywords:
+${items}
+
+If title/description contains these patterns, score 1-3 for ALL audiences.\n\n`;
+}
+
+/** Build the scoring guidelines section */
+function buildScoringGuidelines() {
+  return `## SCORING GUIDELINES
+
+- Score 8-10: Directly actionable, high-impact content for that audience
+- Score 5-7: Relevant background knowledge, worth reading
+- Score 3-4: Tangentially related, low priority
+- Score 1-2: Not relevant or should be rejected (see rejection criteria above)`;
+}
+
+/** Build the response format section */
+function buildResponseFormat(audiences) {
+  const scoreFields = audiences.map((a) => `    "${a.code}": <1-10>`).join(',\n');
+  return `## RESPONSE FORMAT
+
+Respond with JSON:
+{
+  "relevance_scores": {
+${scoreFields}
+  },
+  "primary_audience": "<audience code with highest score>",
+  "executive_summary": "<1 sentence: what this content is about>",
+  "skip_reason": "<null if any score >= 4, otherwise brief reason why rejected>"
+}`;
+}
+
+/** Assemble the full system prompt from sections */
+function assemblePrompt(rejectionSection, audienceSections, audiences) {
+  const intro = `You are an expert content curator for BFSI (Banking, Financial Services, Insurance) professionals.
+
+Your job is to score content relevance. Be STRICT about filtering out irrelevant content.
+
+${rejectionSection}## TARGET AUDIENCES
+
+Score content relevance (1-10) for EACH audience based on their needs:
+
+${audienceSections}`;
+
+  return `${intro}
+
+${buildScoringGuidelines()}
+
+${buildResponseFormat(audiences)}`;
+}
+
+/**
+ * Generate system prompt dynamically from audience definitions
+ * KB-208: Prompts pull from kb_audience table, not hardcoded
+ */
+export async function getSystemPrompt() {
+  if (cachedPrompt) return cachedPrompt;
+
+  const audiences = await getAudiences();
+  const rejectionPatterns = await getRejectionPatterns();
+  const audienceSections = audiences.map(formatAudienceSection).join('\n\n');
+  const rejectionSection = buildRejectionSection(rejectionPatterns);
+
+  cachedPrompt = assemblePrompt(rejectionSection, audienceSections, audiences);
+  return cachedPrompt;
+}

--- a/services/agent-api/src/agents/scorer-results.js
+++ b/services/agent-api/src/agents/scorer-results.js
@@ -1,0 +1,140 @@
+/**
+ * Scorer Result Builders
+ *
+ * Functions to build scoring results for different scenarios.
+ * KB-155: Agentic Discovery System - Phase 1
+ */
+
+import { MIN_RELEVANCE_SCORE } from './scorer-config.js';
+
+/** Build result for stale content */
+export function buildStaleResult(matchedIndicator) {
+  return {
+    relevance_score: 1,
+    executive_summary: `Stale content: contains "${matchedIndicator}"`,
+    skip_reason: `Stale indicator: ${matchedIndicator}`,
+    should_queue: false,
+    usage: null,
+    stale_content: true,
+  };
+}
+
+/** Build result for rejected content */
+export function buildRejectionResult(rejectionCheck) {
+  return {
+    relevance_score: rejectionCheck.maxScore,
+    relevance_scores: {
+      executive: rejectionCheck.maxScore,
+      functional_specialist: rejectionCheck.maxScore,
+      engineer: rejectionCheck.maxScore,
+      researcher: rejectionCheck.maxScore,
+    },
+    primary_audience: null,
+    executive_summary: `Auto-rejected: ${rejectionCheck.reason}`,
+    skip_reason: `Matched rejection pattern: ${rejectionCheck.matchedKeyword}`,
+    should_queue: rejectionCheck.maxScore >= MIN_RELEVANCE_SCORE,
+    usage: null,
+    rejection_pattern: rejectionCheck.pattern,
+  };
+}
+
+/** Build result for trusted source */
+export function buildTrustedSourceResult(source, agePenalty) {
+  const adjustedScore = Math.max(1, 8 - agePenalty);
+  const penaltyNote = agePenalty > 0 ? ` (age penalty: -${agePenalty})` : '';
+
+  return {
+    relevance_score: adjustedScore,
+    relevance_scores: {
+      executive: adjustedScore,
+      functional_specialist: adjustedScore,
+      engineer: Math.max(1, 6 - agePenalty),
+      researcher: Math.max(1, 6 - agePenalty),
+    },
+    primary_audience: 'executive',
+    executive_summary: `Trusted source: ${source}${penaltyNote}`,
+    skip_reason: adjustedScore < MIN_RELEVANCE_SCORE ? 'Old content from trusted source' : null,
+    should_queue: adjustedScore >= MIN_RELEVANCE_SCORE,
+    usage: null,
+    trusted_source: true,
+    age_penalty: agePenalty,
+  };
+}
+
+/** Build result for missing title */
+export function buildNoTitleResult() {
+  return {
+    relevance_score: 1,
+    executive_summary: 'No title available',
+    skip_reason: 'No title',
+    should_queue: false,
+    usage: null,
+  };
+}
+
+/** Build result from LLM response */
+export function buildLLMResult(result, usage, modelId, agePenalty) {
+  const scores = result.relevance_scores || {};
+  const adjustedScores = applyAgePenalty(scores, agePenalty);
+  const maxScore = Math.max(...Object.values(adjustedScores));
+  const primaryAudience = getPrimaryAudience(result, adjustedScores);
+
+  return {
+    relevance_score: maxScore,
+    relevance_scores: adjustedScores,
+    primary_audience: primaryAudience,
+    executive_summary: result.executive_summary || '',
+    skip_reason: getSkipReason(result, maxScore, agePenalty),
+    should_queue: maxScore >= MIN_RELEVANCE_SCORE,
+    usage: formatUsage(usage, modelId),
+    age_penalty: agePenalty > 0 ? agePenalty : undefined,
+  };
+}
+
+/** Build result for scoring error */
+export function buildErrorResult(errorMessage) {
+  return {
+    relevance_score: 5,
+    executive_summary: 'Scoring failed - queued for manual review',
+    skip_reason: null,
+    should_queue: true,
+    usage: null,
+    error: errorMessage,
+  };
+}
+
+/** Apply age penalty to all scores */
+function applyAgePenalty(scores, penalty) {
+  return {
+    executive: Math.max(1, (scores.executive || 5) - penalty),
+    functional_specialist: Math.max(1, (scores.functional_specialist || 5) - penalty),
+    engineer: Math.max(1, (scores.engineer || 5) - penalty),
+    researcher: Math.max(1, (scores.researcher || 5) - penalty),
+  };
+}
+
+/** Get primary audience from result or scores */
+function getPrimaryAudience(result, scores) {
+  if (result.primary_audience) return result.primary_audience;
+  return Object.entries(scores).sort((a, b) => b[1] - a[1])[0][0];
+}
+
+/** Get skip reason based on score and penalty */
+function getSkipReason(result, maxScore, agePenalty) {
+  if (result.skip_reason) return result.skip_reason;
+  if (maxScore < MIN_RELEVANCE_SCORE && agePenalty > 0) {
+    return 'Score reduced by age penalty';
+  }
+  return null;
+}
+
+/** Format usage data */
+function formatUsage(usage, modelId) {
+  if (!usage) return null;
+  return {
+    prompt_tokens: usage.prompt_tokens,
+    completion_tokens: usage.completion_tokens,
+    total_tokens: usage.total_tokens,
+    model: modelId,
+  };
+}


### PR DESCRIPTION
## Problem

`scorer.js` was 487 lines with functions exceeding 30+ lines, violating quality guidelines.

## Solution

Split into 5 focused modules:

| File | Lines | Purpose |
|------|-------|---------|
| `scorer-config.js` | 60 | Constants (TRUSTED_SOURCES, STALENESS_INDICATORS, etc.) |
| `scorer-checks.js` | 115 | Validation helpers (isTrustedSource, checkContentAge, etc.) |
| `scorer-prompt.js` | 164 | Prompt generation from DB |
| `scorer-results.js` | 140 | Result builders for different scenarios |
| `scorer.js` | 170 | Main orchestration (was 487) |

## Function Size Summary

All functions are now **under 30 lines** (quality gate requirement).

Largest functions:
- `scoreRelevance()`: 25 lines
- `checkRejectionPatterns()`: 22 lines
- `buildTrustedSourceResult()`: 21 lines

## Backwards Compatibility

Re-exports maintained so existing imports continue to work:
```js
export { isTrustedSource, checkContentAge, checkStaleIndicators } from './scorer-checks.js';
export { MIN_RELEVANCE_SCORE, AGE_PENALTY_THRESHOLD_YEARS, STALENESS_INDICATORS } from './scorer-config.js';
```

## Testing

- No behavioral changes, pure refactoring
- All existing functionality preserved