### PR TITLE
refactor(publication-filters): extract helpers to reduce file from 472 to 164 lines

### DIFF
--- a/apps/web/features/publications/filters/advanced-toggle.ts
+++ b/apps/web/features/publications/filters/advanced-toggle.ts
@@ -1,0 +1,56 @@
+/**
+ * Advanced Filters Toggle
+ *
+ * Handles the expand/collapse of advanced filters section.
+ */
+
+import { saveAdvancedFiltersState, getAdvancedFiltersState } from './storage';
+
+/** Update toggle button text */
+function updateButtonText(button: HTMLElement, isExpanded: boolean) {
+  const buttonText = button.querySelector('span');
+  if (buttonText) {
+    buttonText.textContent = isExpanded ? 'Fewer filters' : 'More filters';
+  }
+}
+
+/** Set expanded state on UI elements */
+function setExpandedState(
+  button: HTMLElement,
+  filters: HTMLElement,
+  icon: HTMLElement,
+  isExpanded: boolean,
+) {
+  if (isExpanded) {
+    filters.classList.remove('hidden');
+    icon.classList.add('rotate-90');
+  } else {
+    filters.classList.add('hidden');
+    icon.classList.remove('rotate-90');
+  }
+  button.setAttribute('aria-expanded', String(isExpanded));
+  updateButtonText(button, isExpanded);
+}
+
+/** Setup advanced filters toggle */
+export function setupAdvancedFiltersToggle() {
+  const toggleBtn = document.getElementById('toggle-advanced-filters');
+  const advancedFilters = document.getElementById('advanced-filters');
+  const advancedIcon = document.getElementById('advanced-filters-icon');
+
+  if (!toggleBtn || !advancedFilters || !advancedIcon) return;
+
+  // Restore saved state
+  const savedState = getAdvancedFiltersState();
+  if (savedState) {
+    setExpandedState(toggleBtn, advancedFilters, advancedIcon, true);
+  }
+
+  // Toggle handler
+  toggleBtn.addEventListener('click', () => {
+    const isExpanded = toggleBtn.getAttribute('aria-expanded') === 'true';
+    const newState = !isExpanded;
+    setExpandedState(toggleBtn, advancedFilters, advancedIcon, newState);
+    saveAdvancedFiltersState(newState);
+  });
+}

--- a/apps/web/features/publications/filters/handlers.ts
+++ b/apps/web/features/publications/filters/handlers.ts
@@ -1,0 +1,179 @@
+/**
+ * Filter Event Handlers
+ *
+ * Event handlers for filter changes, search, clear, and load more.
+ */
+
+import type { FilterValues } from './types';
+import { getVals, setVals, saveToStorage, clearStorage } from './storage';
+import {
+  addToSearchHistory,
+  renderSearchHistory,
+  syncSearchInputs,
+  createDebouncer,
+} from './search';
+import {
+  renderChipsSummary,
+  showSearchSuggestions,
+  hideSearchSuggestions,
+  showSpinner,
+  hideSpinner,
+} from './ui';
+
+interface FilterElement {
+  key: string;
+  el: HTMLSelectElement;
+}
+
+interface HandlerDeps {
+  filters: FilterElement[];
+  list: HTMLElement;
+  qEl: HTMLInputElement | null;
+  mobileSearchEl: HTMLInputElement | null;
+  chipsEl: HTMLElement | null;
+  badgeEl: HTMLElement | null;
+  loadMoreBtn: HTMLButtonElement | null;
+  clearBtn: HTMLElement | null;
+  searchSpinner: HTMLElement | null;
+  mobileSearchSpinner: HTMLElement | null;
+  searchSuggestions: HTMLElement | null;
+  mobileSearchSuggestions: HTMLElement | null;
+  searchHistory: HTMLElement | null;
+  mobileSearchHistory: HTMLElement | null;
+  apply: (vals?: FilterValues, resetPage?: boolean) => number;
+  getCurrentPage: () => number;
+  setCurrentPage: (page: number) => void;
+}
+
+/** Setup filter dropdown change handlers */
+export function setupFilterChangeHandlers(deps: HandlerDeps) {
+  deps.filters.forEach(({ key, el }) => {
+    el.addEventListener('change', () => {
+      const vals = getVals(deps.filters, deps.qEl, deps.mobileSearchEl);
+      saveToStorage(vals);
+      if (key === 'role') {
+        try {
+          localStorage.setItem('bfsi-persona-preference', vals.role || 'all');
+        } catch {}
+      }
+      deps.apply(vals, true);
+      renderChipsSummary(vals, deps.chipsEl, deps.badgeEl, () => {});
+    });
+  });
+}
+
+/** Create search input handler */
+function createSearchInputHandler(deps: HandlerDeps) {
+  const debounced = createDebouncer();
+
+  return (inputEl: HTMLInputElement | null) => {
+    if (!inputEl) return;
+    debounced(
+      () => {
+        const query = inputEl.value.trim();
+        syncSearchInputs(query, inputEl, deps.qEl, deps.mobileSearchEl);
+        if (query.length >= 2) addToSearchHistory(query);
+        const vals = getVals(deps.filters, deps.qEl, deps.mobileSearchEl);
+        saveToStorage(vals);
+        deps.apply(vals, true);
+        renderChipsSummary(vals, deps.chipsEl, deps.badgeEl, () => {});
+      },
+      true,
+      () => showSpinner(deps.searchSpinner, deps.mobileSearchSpinner),
+      () => hideSpinner(deps.searchSpinner, deps.mobileSearchSpinner),
+    );
+  };
+}
+
+/** Setup desktop search handlers */
+function setupDesktopSearch(deps: HandlerDeps, handleInput: (el: HTMLInputElement | null) => void) {
+  if (!deps.qEl) return;
+
+  deps.qEl.addEventListener('input', () => handleInput(deps.qEl));
+  deps.qEl.addEventListener('focus', () => {
+    showSearchSuggestions(
+      deps.searchSuggestions,
+      deps.searchHistory,
+      renderSearchHistory,
+      (query) => {
+        if (deps.qEl) deps.qEl.value = query;
+        syncSearchInputs(query, deps.qEl, deps.qEl, deps.mobileSearchEl);
+        hideSearchSuggestions(deps.searchSuggestions);
+        handleInput(deps.qEl);
+      },
+    );
+  });
+  deps.qEl.addEventListener('blur', () =>
+    setTimeout(() => hideSearchSuggestions(deps.searchSuggestions), 150),
+  );
+}
+
+/** Setup mobile search handlers */
+function setupMobileSearch(deps: HandlerDeps, handleInput: (el: HTMLInputElement | null) => void) {
+  if (!deps.mobileSearchEl) return;
+
+  deps.mobileSearchEl.addEventListener('input', () => handleInput(deps.mobileSearchEl));
+  deps.mobileSearchEl.addEventListener('focus', () => {
+    showSearchSuggestions(
+      deps.mobileSearchSuggestions,
+      deps.mobileSearchHistory,
+      renderSearchHistory,
+      (query) => {
+        if (deps.mobileSearchEl) deps.mobileSearchEl.value = query;
+        syncSearchInputs(query, deps.mobileSearchEl, deps.qEl, deps.mobileSearchEl);
+        hideSearchSuggestions(deps.mobileSearchSuggestions);
+        handleInput(deps.mobileSearchEl);
+      },
+    );
+  });
+  deps.mobileSearchEl.addEventListener('blur', () =>
+    setTimeout(() => hideSearchSuggestions(deps.mobileSearchSuggestions), 150),
+  );
+}
+
+/** Setup all search handlers */
+export function setupSearchHandlers(deps: HandlerDeps) {
+  const handleInput = createSearchInputHandler(deps);
+  setupDesktopSearch(deps, handleInput);
+  setupMobileSearch(deps, handleInput);
+}
+
+/** Setup clear button handler */
+export function setupClearButton(deps: HandlerDeps) {
+  deps.clearBtn?.addEventListener('click', () => {
+    const cleared: FilterValues = {
+      role: 'all',
+      industry: '',
+      topic: '',
+      content_type: '',
+      geography: '',
+      q: '',
+    };
+    setVals(cleared, deps.filters, deps.qEl, deps.mobileSearchEl);
+    clearStorage();
+    deps.apply(getVals(deps.filters, deps.qEl, deps.mobileSearchEl), true);
+    renderChipsSummary(
+      getVals(deps.filters, deps.qEl, deps.mobileSearchEl),
+      deps.chipsEl,
+      deps.badgeEl,
+      () => {},
+    );
+  });
+}
+
+/** Setup load more button handler */
+export function setupLoadMoreButton(deps: HandlerDeps) {
+  deps.loadMoreBtn?.addEventListener('click', () => {
+    const newPage = deps.getCurrentPage() + 1;
+    deps.setCurrentPage(newPage);
+    deps.apply(getVals(deps.filters, deps.qEl, deps.mobileSearchEl), false);
+
+    const visibleItems = Array.from(deps.list.children).filter(
+      (el) => !(el as HTMLElement).classList.contains('hidden'),
+    );
+    const firstNewItem = visibleItems[(newPage - 1) * 30];
+    if (firstNewItem) {
+      (firstNewItem as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  });
+}

--- a/apps/web/features/publications/filters/mobile-sheet.ts
+++ b/apps/web/features/publications/filters/mobile-sheet.ts
@@ -1,0 +1,240 @@
+/**
+ * Mobile Filter Sheet
+ *
+ * Handles the mobile filter sheet UI and interactions.
+ */
+
+import type { FilterValues } from './types';
+import { getVals, setVals, saveToStorage } from './storage';
+import { renderChipsSummary } from './ui';
+import { createDebouncer } from './search';
+
+interface MobileElements {
+  q: HTMLInputElement | null;
+  role: HTMLSelectElement | null;
+  industry: HTMLSelectElement | null;
+  topic: HTMLSelectElement | null;
+  content_type: HTMLSelectElement | null;
+  geography: HTMLSelectElement | null;
+}
+
+interface FilterElement {
+  key: string;
+  el: HTMLSelectElement;
+}
+
+interface MobileSheetDeps {
+  list: HTMLElement;
+  qEl: HTMLInputElement | null;
+  mobileSearchEl: HTMLInputElement | null;
+  chipsEl: HTMLElement | null;
+  badgeEl: HTMLElement | null;
+  filters: FilterElement[];
+  apply: (vals?: FilterValues, resetPage?: boolean) => number;
+  setCurrentPage: (page: number) => void;
+}
+
+/** Get desktop filter elements */
+function getDesktopElements(): MobileElements {
+  return {
+    q: document.getElementById('q') as HTMLInputElement | null,
+    role: document.getElementById('f-role') as HTMLSelectElement | null,
+    industry: document.getElementById('f-industry') as HTMLSelectElement | null,
+    topic: document.getElementById('f-topic') as HTMLSelectElement | null,
+    content_type: document.getElementById('f-content_type') as HTMLSelectElement | null,
+    geography: document.getElementById('f-geography') as HTMLSelectElement | null,
+  };
+}
+
+/** Get mobile filter elements */
+function getMobileElements(): MobileElements {
+  return {
+    q: document.getElementById('m-q') as HTMLInputElement | null,
+    role: document.getElementById('m-f-role') as HTMLSelectElement | null,
+    industry: document.getElementById('m-f-industry') as HTMLSelectElement | null,
+    topic: document.getElementById('m-f-topic') as HTMLSelectElement | null,
+    content_type: document.getElementById('m-f-content_type') as HTMLSelectElement | null,
+    geography: document.getElementById('m-f-geography') as HTMLSelectElement | null,
+  };
+}
+
+/** Get values from mobile elements */
+function getMobileVals(
+  mobile: MobileElements,
+  mobileSearchEl: HTMLInputElement | null,
+): FilterValues {
+  return {
+    role: mobile.role?.value || '',
+    industry: mobile.industry?.value || '',
+    topic: mobile.topic?.value || '',
+    content_type: mobile.content_type?.value || '',
+    geography: mobile.geography?.value || '',
+    q: mobile.q?.value?.trim() || mobileSearchEl?.value?.trim() || '',
+  };
+}
+
+/** Set values on desktop elements */
+function setDesktopVals(desktop: MobileElements, vals: FilterValues) {
+  if (desktop.role) desktop.role.value = vals.role || '';
+  if (desktop.industry) desktop.industry.value = vals.industry || '';
+  if (desktop.topic) desktop.topic.value = vals.topic || '';
+  if (desktop.content_type) desktop.content_type.value = vals.content_type || '';
+  if (desktop.geography) desktop.geography.value = vals.geography || '';
+  if (desktop.q) desktop.q.value = vals.q || '';
+}
+
+/** Sync values to mobile elements */
+function syncToMobile(mobile: MobileElements, vals: FilterValues) {
+  if (mobile.role) mobile.role.value = vals.role || '';
+  if (mobile.industry) mobile.industry.value = vals.industry || '';
+  if (mobile.topic) mobile.topic.value = vals.topic || '';
+  if (mobile.content_type) mobile.content_type.value = vals.content_type || '';
+  if (mobile.geography) mobile.geography.value = vals.geography || '';
+  if (mobile.q) mobile.q.value = vals.q || '';
+}
+
+/** Clear all mobile filter values */
+function clearMobileVals(mobile: MobileElements) {
+  if (mobile.role) mobile.role.value = '';
+  if (mobile.industry) mobile.industry.value = '';
+  if (mobile.topic) mobile.topic.value = '';
+  if (mobile.content_type) mobile.content_type.value = '';
+  if (mobile.geography) mobile.geography.value = '';
+  if (mobile.q) mobile.q.value = '';
+}
+
+/** Count visible items in list */
+function countVisibleItems(list: HTMLElement): number {
+  return Array.from(list.children).filter((el) => !(el as HTMLElement).classList.contains('hidden'))
+    .length;
+}
+
+interface SheetElements {
+  openBtn: HTMLElement;
+  sheet: HTMLElement;
+  backdrop: HTMLElement | null;
+  closeBtn: HTMLElement | null;
+  mobileResultNumber: HTMLElement | null;
+}
+
+/** Get sheet DOM elements */
+function getSheetElements(): SheetElements | null {
+  const openBtn = document.getElementById('open-sheet');
+  const sheet = document.getElementById('filter-sheet');
+  if (!openBtn || !sheet) return null;
+
+  return {
+    openBtn,
+    sheet,
+    backdrop: document.getElementById('sheet-backdrop'),
+    closeBtn: document.getElementById('close-sheet'),
+    mobileResultNumber: document.getElementById('m-result-number'),
+  };
+}
+
+/** Create open sheet handler */
+function createOpenHandler(
+  sheet: HTMLElement,
+  mobile: MobileElements,
+  deps: MobileSheetDeps,
+  updateCount: (n: number) => void,
+) {
+  return () => {
+    const v = getVals(deps.filters, deps.qEl, deps.mobileSearchEl);
+    syncToMobile(mobile, v);
+    updateCount(countVisibleItems(deps.list));
+    sheet.classList.remove('hidden');
+    sheet.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+    mobile.role?.focus();
+  };
+}
+
+/** Create close sheet handler */
+function createCloseHandler(sheet: HTMLElement, openBtn: HTMLElement) {
+  return () => {
+    sheet.classList.add('hidden');
+    sheet.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+    openBtn.focus();
+  };
+}
+
+/** Setup sheet event listeners */
+function setupSheetListeners(els: SheetElements, openSheet: () => void, closeSheet: () => void) {
+  els.openBtn.addEventListener('click', openSheet);
+  els.closeBtn?.addEventListener('click', closeSheet);
+  els.backdrop?.addEventListener('click', closeSheet);
+  globalThis.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key === 'Escape' && !els.sheet.classList.contains('hidden')) closeSheet();
+  });
+}
+
+/** Setup mobile filter input handlers */
+function setupMobileInputHandlers(mobile: MobileElements, applyFromMobile: () => void) {
+  const debounced = createDebouncer();
+  Object.values(mobile).forEach((el) => {
+    if (el instanceof HTMLSelectElement) {
+      el.addEventListener('change', applyFromMobile);
+    } else if (el instanceof HTMLInputElement) {
+      el.addEventListener('input', () => debounced(applyFromMobile, false));
+    }
+  });
+}
+
+/** Create apply from mobile handler */
+function createApplyFromMobile(
+  mobile: MobileElements,
+  desktop: MobileElements,
+  deps: MobileSheetDeps,
+  updateCount: (n: number) => void,
+) {
+  return () => {
+    const vals = getMobileVals(mobile, deps.mobileSearchEl);
+    setDesktopVals(desktop, vals);
+    setVals(vals, deps.filters, deps.qEl, deps.mobileSearchEl);
+    deps.setCurrentPage(1);
+    updateCount(deps.apply(vals, true));
+    renderChipsSummary(vals, deps.chipsEl, deps.badgeEl, () => {});
+    saveToStorage(vals);
+  };
+}
+
+/** Setup clear and done button handlers */
+function setupClearDoneButtons(
+  mobile: MobileElements,
+  applyFromMobile: () => void,
+  closeSheet: () => void,
+) {
+  document.getElementById('m-clear')?.addEventListener('click', () => {
+    clearMobileVals(mobile);
+    applyFromMobile();
+  });
+  document.getElementById('m-done')?.addEventListener('click', closeSheet);
+}
+
+/** Setup mobile filter sheet */
+export function setupMobileSheet(deps: MobileSheetDeps) {
+  const els = getSheetElements();
+  if (!els) return;
+
+  const desktop = getDesktopElements();
+  const mobile = getMobileElements();
+  const updateCount = (n: number) => {
+    if (els.mobileResultNumber) els.mobileResultNumber.textContent = String(n);
+  };
+
+  const applyFromMobile = createApplyFromMobile(mobile, desktop, deps, updateCount);
+  const openSheet = createOpenHandler(els.sheet, mobile, deps, updateCount);
+  const closeSheet = createCloseHandler(els.sheet, els.openBtn);
+
+  setupSheetListeners(els, openSheet, closeSheet);
+  setupMobileInputHandlers(mobile, applyFromMobile);
+  setupClearDoneButtons(mobile, applyFromMobile, closeSheet);
+  renderChipsSummary(
+    getVals(deps.filters, deps.qEl, deps.mobileSearchEl),
+    deps.chipsEl,
+    deps.badgeEl,
+    () => {},
+  );
+}

--- a/apps/web/features/publications/publication-filters.ts
+++ b/apps/web/features/publications/publication-filters.ts
@@ -1,49 +1,15 @@
 import type { FilterValues } from './filters/types';
 import { indexData, applyFilters } from './filters/apply';
+import { getVals, setVals, updateQuery, readFromQuery } from './filters/storage';
+import { renderChipsSummary, updatePaginationUI } from './filters/ui';
+import { setupMobileSheet } from './filters/mobile-sheet';
+import { setupAdvancedFiltersToggle } from './filters/advanced-toggle';
 import {
-  getVals,
-  setVals,
-  updateQuery,
-  readFromQuery,
-  saveToStorage,
-  clearStorage,
-  saveAdvancedFiltersState,
-  getAdvancedFiltersState,
-} from './filters/storage';
-import {
-  addToSearchHistory,
-  renderSearchHistory,
-  syncSearchInputs,
-  createDebouncer,
-} from './filters/search';
-import {
-  renderChipsSummary,
-  updatePaginationUI,
-  showSearchSuggestions,
-  hideSearchSuggestions,
-  showSpinner,
-  hideSpinner,
-} from './filters/ui';
-
-interface DOMElements {
-  list: HTMLElement;
-  empty: HTMLElement | null;
-  clearBtn: HTMLElement | null;
-  countEl: HTMLElement | null;
-  qEl: HTMLInputElement | null;
-  mobileSearchEl: HTMLInputElement | null;
-  chipsEl: HTMLElement | null;
-  badgeEl: HTMLElement | null;
-  loadMoreBtn: HTMLButtonElement | null;
-  paginationCount: HTMLElement | null;
-  paginationContainer: HTMLElement | null;
-  searchSpinner: HTMLElement | null;
-  mobileSearchSpinner: HTMLElement | null;
-  searchSuggestions: HTMLElement | null;
-  mobileSearchSuggestions: HTMLElement | null;
-  searchHistory: HTMLElement | null;
-  mobileSearchHistory: HTMLElement | null;
-}
+  setupFilterChangeHandlers,
+  setupSearchHandlers,
+  setupClearButton,
+  setupLoadMoreButton,
+} from './filters/handlers';
 
 interface FilterElement {
   key: string;
@@ -57,7 +23,8 @@ interface FilterState {
   FuseCtor: any;
 }
 
-function getDOMElements(): DOMElements | null {
+/** Get all required DOM elements */
+function getDOMElements() {
   const list = document.getElementById('list');
   if (!list) return null;
 
@@ -82,13 +49,13 @@ function getDOMElements(): DOMElements | null {
   };
 }
 
+/** Get filter select elements from DOM */
 function getFilterElements(): FilterElement[] {
-  const filterElements = Array.from(
-    document.querySelectorAll<HTMLSelectElement>('select[id^="f-"]'),
-  );
-  return filterElements.map((el) => ({ key: el.id.replace(/^f-/, ''), el }));
+  const elements = document.querySelectorAll<HTMLSelectElement>('select[id^="f-"]');
+  return Array.from(elements).map((el) => ({ key: el.id.replace(/^f-/, ''), el }));
 }
 
+/** Load Fuse.js asynchronously */
 async function loadFuse() {
   try {
     const mod = await import('fuse.js');
@@ -98,10 +65,10 @@ async function loadFuse() {
   }
 }
 
-function createApplyFunction(
-  state: FilterState,
-  dom: DOMElements,
-): (vals?: FilterValues, resetPage?: boolean) => number {
+/** Create the apply filters function */
+function createApplyFunction(state: FilterState, dom: ReturnType<typeof getDOMElements>) {
+  if (!dom) return () => 0;
+
   return (vals = getVals(state.filters, dom.qEl, dom.mobileSearchEl), resetPage = false) => {
     if (resetPage) state.currentPage = 1;
 
@@ -114,8 +81,9 @@ function createApplyFunction(
     );
 
     if (dom.empty) dom.empty.classList.toggle('hidden', total !== 0);
-    if (dom.countEl && dom.list)
+    if (dom.countEl && dom.list) {
       dom.countEl.textContent = `Showing ${visible} of ${dom.list.children.length}`;
+    }
 
     updatePaginationUI(
       visible,
@@ -125,347 +93,87 @@ function createApplyFunction(
       dom.paginationContainer,
     );
     updateQuery(vals, state.currentPage);
-
     return visible;
   };
 }
 
-function setupFilterChangeHandlers(
+/** Initialize filter state from URL and render initial chips */
+function initializeFromURL(
   state: FilterState,
-  dom: DOMElements,
+  dom: ReturnType<typeof getDOMElements>,
   apply: (vals?: FilterValues, resetPage?: boolean) => number,
 ) {
-  state.filters.forEach(({ key, el }) => {
-    el.addEventListener('change', () => {
-      const vals = getVals(state.filters, dom.qEl, dom.mobileSearchEl);
-      saveToStorage(vals);
-      if (key === 'role') {
-        try {
-          localStorage.setItem('bfsi-persona-preference', vals.role || 'all');
-        } catch {}
-      }
-      apply(vals, true);
-      renderChipsSummary(vals, dom.chipsEl, dom.badgeEl, () => {});
-    });
-  });
-}
-
-function setupSearchHandlers(
-  state: FilterState,
-  dom: DOMElements,
-  apply: (vals?: FilterValues, resetPage?: boolean) => number,
-) {
-  const debounced = createDebouncer();
-
-  const handleSearchInput = (inputEl: HTMLInputElement | null) => {
-    if (!inputEl) return;
-    debounced(
-      () => {
-        const query = inputEl.value.trim();
-        syncSearchInputs(query, inputEl, dom.qEl, dom.mobileSearchEl);
-        if (query.length >= 2) addToSearchHistory(query);
-        const vals = getVals(state.filters, dom.qEl, dom.mobileSearchEl);
-        saveToStorage(vals);
-        apply(vals, true);
-        renderChipsSummary(vals, dom.chipsEl, dom.badgeEl, () => {});
-      },
-      true,
-      () => showSpinner(dom.searchSpinner, dom.mobileSearchSpinner),
-      () => hideSpinner(dom.searchSpinner, dom.mobileSearchSpinner),
-    );
-  };
-
-  // Desktop search
-  dom.qEl?.addEventListener('input', () => handleSearchInput(dom.qEl));
-  dom.qEl?.addEventListener('focus', () => {
-    showSearchSuggestions(
-      dom.searchSuggestions,
-      dom.searchHistory,
-      renderSearchHistory,
-      (query) => {
-        if (dom.qEl) dom.qEl.value = query;
-        syncSearchInputs(query, dom.qEl, dom.qEl, dom.mobileSearchEl);
-        hideSearchSuggestions(dom.searchSuggestions);
-        handleSearchInput(dom.qEl);
-      },
-    );
-  });
-  dom.qEl?.addEventListener('blur', () =>
-    setTimeout(() => hideSearchSuggestions(dom.searchSuggestions), 150),
-  );
-
-  // Mobile search
-  dom.mobileSearchEl?.addEventListener('input', () => handleSearchInput(dom.mobileSearchEl));
-  dom.mobileSearchEl?.addEventListener('focus', () => {
-    showSearchSuggestions(
-      dom.mobileSearchSuggestions,
-      dom.mobileSearchHistory,
-      renderSearchHistory,
-      (query) => {
-        if (dom.mobileSearchEl) dom.mobileSearchEl.value = query;
-        syncSearchInputs(query, dom.mobileSearchEl, dom.qEl, dom.mobileSearchEl);
-        hideSearchSuggestions(dom.mobileSearchSuggestions);
-        handleSearchInput(dom.mobileSearchEl);
-      },
-    );
-  });
-  dom.mobileSearchEl?.addEventListener('blur', () =>
-    setTimeout(() => hideSearchSuggestions(dom.mobileSearchSuggestions), 150),
-  );
-}
-
-function setupClearButton(
-  state: FilterState,
-  dom: DOMElements,
-  apply: (vals?: FilterValues, resetPage?: boolean) => number,
-) {
-  dom.clearBtn?.addEventListener('click', () => {
-    const cleared: FilterValues = {
-      role: 'all',
-      industry: '',
-      topic: '',
-      content_type: '',
-      geography: '',
-      q: '',
-    };
-    setVals(cleared, state.filters, dom.qEl, dom.mobileSearchEl);
-    clearStorage();
-    apply(getVals(state.filters, dom.qEl, dom.mobileSearchEl), true);
-    renderChipsSummary(
-      getVals(state.filters, dom.qEl, dom.mobileSearchEl),
-      dom.chipsEl,
-      dom.badgeEl,
-      () => {},
-    );
-  });
-}
-
-function setupLoadMoreButton(
-  state: FilterState,
-  dom: DOMElements,
-  apply: (vals?: FilterValues, resetPage?: boolean) => number,
-) {
-  dom.loadMoreBtn?.addEventListener('click', () => {
-    state.currentPage++;
-    apply(getVals(state.filters, dom.qEl, dom.mobileSearchEl), false);
-    const visibleItems = Array.from(dom.list.children).filter(
-      (el) => !(el as HTMLElement).classList.contains('hidden'),
-    );
-    const firstNewItem = visibleItems[(state.currentPage - 1) * 30];
-    if (firstNewItem)
-      (firstNewItem as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'start' });
-  });
-}
-
-function setupMobileSheet(
-  state: FilterState,
-  dom: DOMElements,
-  apply: (vals?: FilterValues, resetPage?: boolean) => number,
-) {
-  const openBtn = document.getElementById('open-sheet');
-  const sheet = document.getElementById('filter-sheet');
-  const backdrop = document.getElementById('sheet-backdrop');
-  const closeBtn = document.getElementById('close-sheet');
-  const mobileResultNumber = document.getElementById('m-result-number');
-
-  if (!openBtn || !sheet) return;
-
-  const desktop = {
-    q: document.getElementById('q') as HTMLInputElement | null,
-    role: document.getElementById('f-role') as HTMLSelectElement | null,
-    industry: document.getElementById('f-industry') as HTMLSelectElement | null,
-    topic: document.getElementById('f-topic') as HTMLSelectElement | null,
-    content_type: document.getElementById('f-content_type') as HTMLSelectElement | null,
-    geography: document.getElementById('f-geography') as HTMLSelectElement | null,
-  };
-
-  const mobile = {
-    q: document.getElementById('m-q') as HTMLInputElement | null,
-    role: document.getElementById('m-f-role') as HTMLSelectElement | null,
-    industry: document.getElementById('m-f-industry') as HTMLSelectElement | null,
-    topic: document.getElementById('m-f-topic') as HTMLSelectElement | null,
-    content_type: document.getElementById('m-f-content_type') as HTMLSelectElement | null,
-    geography: document.getElementById('m-f-geography') as HTMLSelectElement | null,
-  };
-
-  const getMobileVals = (): FilterValues => ({
-    role: mobile.role?.value || '',
-    industry: mobile.industry?.value || '',
-    topic: mobile.topic?.value || '',
-    content_type: mobile.content_type?.value || '',
-    geography: mobile.geography?.value || '',
-    q: mobile.q?.value?.trim() || dom.mobileSearchEl?.value?.trim() || '',
-  });
-
-  const setDesktopVals = (vals: FilterValues) => {
-    if (desktop.role) desktop.role.value = vals.role || '';
-    if (desktop.industry) desktop.industry.value = vals.industry || '';
-    if (desktop.topic) desktop.topic.value = vals.topic || '';
-    if (desktop.content_type) desktop.content_type.value = vals.content_type || '';
-    if (desktop.geography) desktop.geography.value = vals.geography || '';
-    if (desktop.q) desktop.q.value = vals.q || '';
-  };
-
-  const syncToMobile = () => {
-    const v = getVals(state.filters, dom.qEl, dom.mobileSearchEl);
-    if (mobile.role) mobile.role.value = v.role || '';
-    if (mobile.industry) mobile.industry.value = v.industry || '';
-    if (mobile.topic) mobile.topic.value = v.topic || '';
-    if (mobile.content_type) mobile.content_type.value = v.content_type || '';
-    if (mobile.geography) mobile.geography.value = v.geography || '';
-    if (mobile.q) mobile.q.value = v.q || '';
-  };
-
-  const updateMobileResultCount = (count: number) => {
-    if (mobileResultNumber) mobileResultNumber.textContent = String(count);
-  };
-
-  const applyFromMobile = () => {
-    const vals = getMobileVals();
-    setDesktopVals(vals);
-    setVals(vals, state.filters, dom.qEl, dom.mobileSearchEl);
-    state.currentPage = 1;
-    const visibleCount = apply(vals, true);
-    updateMobileResultCount(visibleCount);
-    renderChipsSummary(vals, dom.chipsEl, dom.badgeEl, () => {});
-    saveToStorage(vals);
-  };
-
-  const openSheet = () => {
-    syncToMobile();
-    const currentCount = Array.from(dom.list.children).filter(
-      (el) => !(el as HTMLElement).classList.contains('hidden'),
-    ).length;
-    updateMobileResultCount(currentCount);
-    sheet.classList.remove('hidden');
-    sheet.setAttribute('aria-hidden', 'false');
-    document.body.style.overflow = 'hidden';
-    mobile.role?.focus();
-  };
-
-  const closeSheet = () => {
-    sheet.classList.add('hidden');
-    sheet.setAttribute('aria-hidden', 'true');
-    document.body.style.overflow = '';
-    openBtn.focus();
-  };
-
-  openBtn.addEventListener('click', openSheet);
-  closeBtn?.addEventListener('click', closeSheet);
-  backdrop?.addEventListener('click', closeSheet);
-  globalThis.addEventListener('keydown', (e: KeyboardEvent) => {
-    if (e.key === 'Escape' && !sheet.classList.contains('hidden')) closeSheet();
-  });
-
-  const debounced = createDebouncer();
-  Object.values(mobile).forEach((el) => {
-    if (el instanceof HTMLSelectElement) {
-      el.addEventListener('change', applyFromMobile);
-    } else if (el instanceof HTMLInputElement) {
-      el.addEventListener('input', () => debounced(applyFromMobile, false));
-    }
-  });
-
-  document.getElementById('m-clear')?.addEventListener('click', () => {
-    if (mobile.role) mobile.role.value = '';
-    if (mobile.industry) mobile.industry.value = '';
-    if (mobile.topic) mobile.topic.value = '';
-    if (mobile.content_type) mobile.content_type.value = '';
-    if (mobile.geography) mobile.geography.value = '';
-    if (mobile.q) mobile.q.value = '';
-    applyFromMobile();
-  });
-
-  document.getElementById('m-done')?.addEventListener('click', closeSheet);
-  renderChipsSummary(
-    getVals(state.filters, dom.qEl, dom.mobileSearchEl),
-    dom.chipsEl,
-    dom.badgeEl,
-    () => {},
-  );
-}
-
-function setupAdvancedFiltersToggle() {
-  const toggleAdvancedBtn = document.getElementById('toggle-advanced-filters');
-  const advancedFilters = document.getElementById('advanced-filters');
-  const advancedIcon = document.getElementById('advanced-filters-icon');
-
-  if (!toggleAdvancedBtn || !advancedFilters || !advancedIcon) return;
-
-  const toggleAdvancedFilters = () => {
-    const isExpanded = toggleAdvancedBtn.getAttribute('aria-expanded') === 'true';
-    const newState = !isExpanded;
-    const buttonText = toggleAdvancedBtn.querySelector('span');
-
-    if (newState) {
-      advancedFilters.classList.remove('hidden');
-      advancedIcon.classList.add('rotate-90');
-      toggleAdvancedBtn.setAttribute('aria-expanded', 'true');
-      if (buttonText) buttonText.textContent = 'Fewer filters';
-    } else {
-      advancedFilters.classList.add('hidden');
-      advancedIcon.classList.remove('rotate-90');
-      toggleAdvancedBtn.setAttribute('aria-expanded', 'false');
-      if (buttonText) buttonText.textContent = 'More filters';
-    }
-
-    saveAdvancedFiltersState(newState);
-  };
-
-  // Restore saved state
-  if (getAdvancedFiltersState()) {
-    advancedFilters.classList.remove('hidden');
-    advancedIcon.classList.add('rotate-90');
-    toggleAdvancedBtn.setAttribute('aria-expanded', 'true');
-    const buttonText = toggleAdvancedBtn.querySelector('span');
-    if (buttonText) buttonText.textContent = 'Fewer filters';
-  }
-
-  toggleAdvancedBtn.addEventListener('click', toggleAdvancedFilters);
-}
-
-export default function initPublicationFilters() {
-  const dom = getDOMElements();
   if (!dom) return;
 
-  const filters = getFilterElements();
-  if (filters.length === 0) {
-    console.warn('No filters found in DOM');
-    return;
-  }
+  const { vals: initVals, page: initPage } = readFromQuery(state.filters);
+  state.currentPage = initPage;
+  setVals(initVals, state.filters, dom.qEl, dom.mobileSearchEl);
+  apply(initVals);
 
+  renderChipsSummary(initVals, dom.chipsEl, dom.badgeEl, (key) => {
+    const current = getVals(state.filters, dom.qEl, dom.mobileSearchEl);
+    current[key] = '';
+    setVals(current, state.filters, dom.qEl, dom.mobileSearchEl);
+    apply(current, true);
+    renderChipsSummary(current, dom.chipsEl, dom.badgeEl, () => {});
+  });
+}
+
+/** Create initial filter state */
+function createFilterState(
+  dom: NonNullable<ReturnType<typeof getDOMElements>>,
+  filters: FilterElement[],
+): FilterState {
   const state: FilterState = {
     filters,
     data: indexData(dom.list, filters),
     currentPage: 1,
     FuseCtor: null,
   };
-
-  // Load Fuse.js asynchronously
   loadFuse().then((fuse) => {
     state.FuseCtor = fuse;
   });
+  return state;
+}
 
+/** Create handler dependencies object */
+function createHandlerDeps(
+  dom: NonNullable<ReturnType<typeof getDOMElements>>,
+  state: FilterState,
+  apply: ReturnType<typeof createApplyFunction>,
+) {
+  return {
+    ...dom,
+    filters: state.filters,
+    apply,
+    getCurrentPage: () => state.currentPage,
+    setCurrentPage: (p: number) => {
+      state.currentPage = p;
+    },
+  };
+}
+
+/** Setup all event handlers */
+function setupAllHandlers(deps: ReturnType<typeof createHandlerDeps>) {
+  setupFilterChangeHandlers(deps);
+  setupSearchHandlers(deps);
+  setupClearButton(deps);
+  setupLoadMoreButton(deps);
+  setupMobileSheet(deps);
+  setupAdvancedFiltersToggle();
+}
+
+/** Main initialization function */
+export default function initPublicationFilters() {
+  const dom = getDOMElements();
+  if (!dom) return;
+
+  const filters = getFilterElements();
+  if (filters.length === 0) return console.warn('No filters found in DOM');
+
+  const state = createFilterState(dom, filters);
   const apply = createApplyFunction(state, dom);
 
-  // Initialize from URL query params
-  const { vals: initVals, page: initPage } = readFromQuery(filters);
-  state.currentPage = initPage;
-  setVals(initVals, filters, dom.qEl, dom.mobileSearchEl);
-  apply(initVals);
-  renderChipsSummary(initVals, dom.chipsEl, dom.badgeEl, (key) => {
-    const current = getVals(filters, dom.qEl, dom.mobileSearchEl);
-    current[key] = '';
-    setVals(current, filters, dom.qEl, dom.mobileSearchEl);
-    apply(current, true);
-    renderChipsSummary(current, dom.chipsEl, dom.badgeEl, () => {});
-  });
-
-  // Setup all event handlers
-  setupFilterChangeHandlers(state, dom, apply);
-  setupSearchHandlers(state, dom, apply);
-  setupClearButton(state, dom, apply);
-  setupLoadMoreButton(state, dom, apply);
-  setupMobileSheet(state, dom, apply);
-  setupAdvancedFiltersToggle();
+  initializeFromURL(state, dom, apply);
+  setupAllHandlers(createHandlerDeps(dom, state, apply));
 }


### PR DESCRIPTION
## Problem

`publication-filters.ts` was 472 lines with functions exceeding 30+ lines, violating quality guidelines.

## Solution

Split into 4 focused modules:

| File | Lines | Purpose |
|------|-------|---------|
| `mobile-sheet.ts` | 230 | Mobile filter sheet UI and interactions |
| `advanced-toggle.ts` | 56 | Advanced filters expand/collapse |
| `handlers.ts` | 174 | Filter/search/clear/load-more event handlers |
| `publication-filters.ts` | 164 | Main orchestration (was 472) |

## Function Size Summary

All functions are now **under 30 lines** (quality gate requirement).

Largest functions:
- `createApplyFunction()`: 30 lines
- `setupMobileSheet()`: 24 lines
- `getDOMElements()`: 24 lines

## Testing

- No behavioral changes, pure refactoring
- All existing functionality preserved
- Mobile sheet, search, filters, pagination all work as before