### PR TITLE
refactor(improver): extract helpers to reduce file from 405 to 126 lines

### DIFF
--- a/services/agent-api/src/agents/improver-classify.js
+++ b/services/agent-api/src/agents/improver-classify.js
@@ -1,0 +1,146 @@
+/**
+ * Improver Classification Logic
+ *
+ * Functions to classify why a URL was missed.
+ * KB-214: User Feedback Reinforcement System - Phase 2
+ */
+
+import {
+  extractDomain,
+  isSourceTracked,
+  checkIngestionHistory,
+  daysBetween,
+} from './improver-config.js';
+
+/** Build result for invalid URL */
+function buildInvalidUrlResult() {
+  return { category: 'crawl_failed', details: { reason: 'Invalid URL format' } };
+}
+
+/** Build result for untracked source */
+function buildUntrackedResult(domain) {
+  return {
+    category: 'source_not_tracked',
+    details: { domain, suggestion: `Add ${domain} to kb_source` },
+  };
+}
+
+/** Build result when source lacks discovery methods */
+function buildNoDiscoveryMethodResult(domain, sourceSlug) {
+  return {
+    category: 'crawl_failed',
+    details: {
+      domain,
+      source_slug: sourceSlug,
+      reason: 'Source has no RSS, sitemap, or scraper configured',
+    },
+  };
+}
+
+/** Build result for missing URL pattern */
+function buildPatternMissingResult(domain, source, url) {
+  return {
+    category: 'pattern_missing',
+    details: {
+      domain,
+      source_slug: source.slug,
+      url_path: new URL(url).pathname,
+      has_rss: !!source.rss_feed,
+      has_sitemap: !!source.sitemap_url,
+      has_scraper: !!source.scraper_config,
+    },
+  };
+}
+
+/** Build result for filter rejection */
+function buildFilterRejectedResult(domain, sourceSlug, payload) {
+  return {
+    category: 'filter_rejected',
+    details: {
+      domain,
+      source_slug: sourceSlug,
+      rejection_reason: payload?.rejection_reason,
+      relevance_scores: payload?.relevance_scores,
+    },
+  };
+}
+
+/** Build result for slow discovery */
+function buildTooSlowResult(domain, sourceSlug, daysLate, discoveredAt) {
+  return {
+    category: 'too_slow',
+    details: { domain, source_slug: sourceSlug, days_late: daysLate, discovered_at: discoveredAt },
+  };
+}
+
+/** Build result for crawl failure */
+function buildCrawlFailedResult(domain, sourceSlug, error) {
+  return {
+    category: 'crawl_failed',
+    details: { domain, source_slug: sourceSlug, error: error || 'Unknown error' },
+  };
+}
+
+/** Build result for pattern mismatch */
+function buildPatternWrongResult(domain, sourceSlug, statusCode) {
+  return {
+    category: 'pattern_wrong',
+    details: { domain, source_slug: sourceSlug, status_code: statusCode },
+  };
+}
+
+/** Classify when source is tracked but URL not in queue */
+function classifyMissingFromQueue(domain, source, url) {
+  const hasRss = !!source.rss_feed;
+  const hasSitemap = !!source.sitemap_url;
+  const hasScraper = !!source.scraper_config;
+
+  if (!hasRss && !hasSitemap && !hasScraper) {
+    return buildNoDiscoveryMethodResult(domain, source.slug);
+  }
+  return buildPatternMissingResult(domain, source, url);
+}
+
+/** Classify based on ingestion record status */
+function classifyFromIngestionRecord(domain, source, record, submittedAt) {
+  const statusCode = record.status_code;
+
+  // Filter rejection
+  if (statusCode === 540 || statusCode === 530) {
+    return buildFilterRejectedResult(domain, source.slug, record.payload);
+  }
+
+  // Too slow
+  if (record.discovered_at && submittedAt) {
+    const daysLate = daysBetween(record.discovered_at, submittedAt);
+    if (daysLate > 3) {
+      return buildTooSlowResult(domain, source.slug, daysLate, record.discovered_at);
+    }
+  }
+
+  // Crawl failed
+  if (statusCode === 500) {
+    return buildCrawlFailedResult(domain, source.slug, record.payload?.rejection_reason);
+  }
+
+  // Default: pattern wrong
+  return buildPatternWrongResult(domain, source.slug, statusCode);
+}
+
+/** Classify why we missed this URL */
+export async function classifyMiss(missedItem) {
+  const domain = extractDomain(missedItem.url);
+  if (!domain) return buildInvalidUrlResult();
+
+  const source = await isSourceTracked(domain);
+  if (!source) return buildUntrackedResult(domain);
+
+  const urlNorm = missedItem.url_norm || missedItem.url.toLowerCase();
+  const ingestionRecord = await checkIngestionHistory(urlNorm);
+
+  if (!ingestionRecord) {
+    return classifyMissingFromQueue(domain, source, missedItem.url);
+  }
+
+  return classifyFromIngestionRecord(domain, source, ingestionRecord, missedItem.submitted_at);
+}

--- a/services/agent-api/src/agents/improver-config.js
+++ b/services/agent-api/src/agents/improver-config.js
@@ -1,0 +1,71 @@
+/**
+ * Improver Agent Configuration
+ *
+ * Constants and utility functions for the improver agent.
+ * KB-214: User Feedback Reinforcement System - Phase 2
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import process from 'node:process';
+
+// Lazy-load Supabase client
+let supabase = null;
+
+export function getSupabase() {
+  if (!supabase) {
+    supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  }
+  return supabase;
+}
+
+/** Miss categories with descriptions */
+export const MISS_CATEGORIES = {
+  source_not_tracked: 'Domain is not in our kb_source table',
+  pattern_missing: 'Source is tracked but URL pattern not covered',
+  pattern_wrong: 'Pattern exists but did not match this URL',
+  filter_rejected: 'Found but scored below threshold',
+  crawl_failed: 'Technical failure (JS rendering, paywall, etc)',
+  too_slow: 'Found it but days after publication',
+  link_not_followed: 'Was linked from a page we crawled',
+  dynamic_content: 'Content is JS-rendered, not in static HTML',
+};
+
+/** Extract domain from URL */
+export function extractDomain(url) {
+  try {
+    const urlObj = new URL(url);
+    return urlObj.hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+/** Calculate days between two dates */
+export function daysBetween(date1, date2) {
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+  const diffTime = Math.abs(d2 - d1);
+  return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+}
+
+/** Check if a domain is tracked in kb_source */
+export async function isSourceTracked(domain) {
+  const { data } = await getSupabase()
+    .from('kb_source')
+    .select('slug, name, enabled, rss_feed, sitemap_url, scraper_config')
+    .ilike('domain', `%${domain}%`)
+    .limit(1);
+
+  return data?.[0] || null;
+}
+
+/** Check if URL was ever in ingestion_queue */
+export async function checkIngestionHistory(urlNorm) {
+  const { data } = await getSupabase()
+    .from('ingestion_queue')
+    .select('id, status_code, payload, discovered_at, created_at')
+    .eq('url_norm', urlNorm)
+    .limit(1);
+
+  return data?.[0] || null;
+}

--- a/services/agent-api/src/agents/improver-report.js
+++ b/services/agent-api/src/agents/improver-report.js
@@ -1,0 +1,103 @@
+/**
+ * Improver Report Generation
+ *
+ * Functions to generate improvement reports from missed discoveries.
+ * KB-214: User Feedback Reinforcement System - Phase 2
+ */
+
+import { getSupabase } from './improver-config.js';
+
+/** Get miss category counts */
+async function getCategoryCounts() {
+  const { data } = await getSupabase()
+    .from('missed_discovery')
+    .select('miss_category')
+    .not('miss_category', 'is', null);
+
+  const counts = {};
+  for (const item of data || []) {
+    counts[item.miss_category] = (counts[item.miss_category] || 0) + 1;
+  }
+  return counts;
+}
+
+/** Get missed domains for untracked sources */
+async function getMissedDomains() {
+  const { data } = await getSupabase()
+    .from('missed_discovery')
+    .select('source_domain, submitter_urgency, why_valuable')
+    .eq('miss_category', 'source_not_tracked')
+    .eq('resolution_status', 'pending');
+
+  return data || [];
+}
+
+/** Aggregate domain statistics */
+function aggregateDomainStats(missedDomains) {
+  const domainCounts = {};
+
+  for (const item of missedDomains) {
+    if (!item.source_domain) continue;
+
+    if (!domainCounts[item.source_domain]) {
+      domainCounts[item.source_domain] = { count: 0, urgencies: [], samples: [] };
+    }
+
+    const stats = domainCounts[item.source_domain];
+    stats.count++;
+    if (item.submitter_urgency) stats.urgencies.push(item.submitter_urgency);
+    if (item.why_valuable && stats.samples.length < 2) stats.samples.push(item.why_valuable);
+  }
+
+  return domainCounts;
+}
+
+/** Get top missed domains sorted by count */
+function getTopMissedDomains(domainCounts, limit = 10) {
+  return Object.entries(domainCounts)
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, limit)
+    .map(([domain, data]) => ({
+      domain,
+      miss_count: data.count,
+      has_critical: data.urgencies.includes('critical'),
+      has_important: data.urgencies.includes('important'),
+      sample_reasons: data.samples,
+    }));
+}
+
+/** Get filter rejection details */
+async function getFilterRejections() {
+  const { data } = await getSupabase()
+    .from('missed_discovery')
+    .select('miss_details, why_valuable')
+    .eq('miss_category', 'filter_rejected')
+    .eq('resolution_status', 'pending')
+    .limit(10);
+
+  return (data || []).map((r) => ({
+    scores: r.miss_details?.relevance_scores,
+    rejection_reason: r.miss_details?.rejection_reason,
+    why_valuable: r.why_valuable,
+  }));
+}
+
+/** Generate aggregated improvement suggestions */
+export async function generateImprovementReport() {
+  const counts = await getCategoryCounts();
+  const missedDomains = await getMissedDomains();
+  const domainStats = aggregateDomainStats(missedDomains);
+  const filterRejections = await getFilterRejections();
+
+  return {
+    generated_at: new Date().toISOString(),
+    summary: {
+      total_pending: Object.values(counts).reduce((a, b) => a + b, 0),
+      by_category: counts,
+    },
+    suggestions: {
+      add_sources: getTopMissedDomains(domainStats),
+      tune_filter: filterRejections,
+    },
+  };
+}

--- a/services/agent-api/src/agents/improver.js
+++ b/services/agent-api/src/agents/improver.js
@@ -9,249 +9,39 @@
  * Pipeline: missed_discovery → classify → analyze → suggest improvements
  */
 
-import { createClient } from '@supabase/supabase-js';
-import process from 'node:process';
+import { getSupabase, extractDomain, daysBetween, MISS_CATEGORIES } from './improver-config.js';
+import { classifyMiss } from './improver-classify.js';
+import { generateImprovementReport } from './improver-report.js';
 
-// Lazy-load clients
-let supabase = null;
-
-function getSupabase() {
-  if (!supabase) {
-    supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
-  }
-  return supabase;
-}
-
-/**
- * Miss categories with descriptions
- */
-const MISS_CATEGORIES = {
-  source_not_tracked: 'Domain is not in our kb_source table',
-  pattern_missing: 'Source is tracked but URL pattern not covered',
-  pattern_wrong: 'Pattern exists but did not match this URL',
-  filter_rejected: 'Found but scored below threshold',
-  crawl_failed: 'Technical failure (JS rendering, paywall, etc)',
-  too_slow: 'Found it but days after publication',
-  link_not_followed: 'Was linked from a page we crawled',
-  dynamic_content: 'Content is JS-rendered, not in static HTML',
-};
-
-/**
- * Extract domain from URL
- */
-function extractDomain(url) {
-  try {
-    const urlObj = new URL(url);
-    return urlObj.hostname.replace(/^www\./, '');
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Calculate days between two dates
- */
-function daysBetween(date1, date2) {
-  const d1 = new Date(date1);
-  const d2 = new Date(date2);
-  const diffTime = Math.abs(d2 - d1);
-  return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-}
-
-/**
- * Check if a domain is tracked in kb_source
- */
-async function isSourceTracked(domain) {
-  const { data } = await getSupabase()
-    .from('kb_source')
-    .select('slug, name, enabled, rss_feed, sitemap_url, scraper_config')
-    .ilike('domain', `%${domain}%`)
-    .limit(1);
-
-  if (data && data.length > 0) {
-    return data[0];
-  }
-  return null;
-}
-
-/**
- * Check if URL was ever in ingestion_queue
- */
-async function checkIngestionHistory(urlNorm) {
-  // KB-237: Removed text status field, use status_code only
-  const { data } = await getSupabase()
-    .from('ingestion_queue')
-    .select('id, status_code, payload, discovered_at, created_at')
-    .eq('url_norm', urlNorm)
-    .limit(1);
-
-  if (data && data.length > 0) {
-    return data[0];
-  }
-  return null;
-}
-
-/**
- * Classify why we missed this URL
- */
-async function classifyMiss(missedItem) {
-  const domain = extractDomain(missedItem.url);
-  if (!domain) {
-    return {
-      category: 'crawl_failed',
-      details: { reason: 'Invalid URL format' },
-    };
-  }
-
-  // Check if source is tracked
-  const source = await isSourceTracked(domain);
-
-  if (!source) {
-    return {
-      category: 'source_not_tracked',
-      details: {
-        domain,
-        suggestion: `Add ${domain} to kb_source`,
-      },
-    };
-  }
-
-  // Source is tracked - check if we ever saw this URL
-  const urlNorm = missedItem.url_norm || missedItem.url.toLowerCase();
-  const ingestionRecord = await checkIngestionHistory(urlNorm);
-
-  if (!ingestionRecord) {
-    // We track the source but never saw this URL
-    // Could be pattern issue, crawl failure, or dynamic content
-    const hasRss = !!source.rss_feed;
-    const hasSitemap = !!source.sitemap_url;
-    const hasScraper = !!source.scraper_config;
-
-    if (!hasRss && !hasSitemap && !hasScraper) {
-      return {
-        category: 'crawl_failed',
-        details: {
-          domain,
-          source_slug: source.slug,
-          reason: 'Source has no RSS, sitemap, or scraper configured',
-        },
-      };
-    }
-
-    return {
-      category: 'pattern_missing',
-      details: {
-        domain,
-        source_slug: source.slug,
-        url_path: new URL(missedItem.url).pathname,
-        has_rss: hasRss,
-        has_sitemap: hasSitemap,
-        has_scraper: hasScraper,
-      },
-    };
-  }
-
-  // We found the URL in ingestion_queue
-  const statusCode = ingestionRecord.status_code;
-
-  // Check if it was rejected by filter
-  if (statusCode === 540 || statusCode === 530) {
-    return {
-      category: 'filter_rejected',
-      details: {
-        domain,
-        source_slug: source.slug,
-        rejection_reason: ingestionRecord.payload?.rejection_reason,
-        relevance_scores: ingestionRecord.payload?.relevance_scores,
-      },
-    };
-  }
-
-  // Check if it was found but too slow
-  if (ingestionRecord.discovered_at && missedItem.submitted_at) {
-    const daysLate = daysBetween(ingestionRecord.discovered_at, missedItem.submitted_at);
-    if (daysLate > 3) {
-      return {
-        category: 'too_slow',
-        details: {
-          domain,
-          source_slug: source.slug,
-          days_late: daysLate,
-          discovered_at: ingestionRecord.discovered_at,
-        },
-      };
-    }
-  }
-
-  // Check for failed status
-  if (statusCode === 500) {
-    return {
-      category: 'crawl_failed',
-      details: {
-        domain,
-        source_slug: source.slug,
-        error: ingestionRecord.payload?.rejection_reason || 'Unknown error',
-      },
-    };
-  }
-
-  // Default: we found it but something else happened
-  return {
-    category: 'pattern_wrong',
-    details: {
-      domain,
-      source_slug: source.slug,
-      status_code: statusCode,
-    },
-  };
-}
-
-/**
- * Process a single missed discovery item
- */
-export async function analyzeMissedDiscovery(missedId) {
-  const sb = getSupabase();
-
-  // Fetch the missed discovery
-  const { data: missed, error } = await sb
+/** Fetch a missed discovery by ID */
+async function fetchMissedDiscovery(missedId) {
+  const { data, error } = await getSupabase()
     .from('missed_discovery')
     .select('*')
     .eq('id', missedId)
     .single();
 
-  if (error || !missed) {
-    const errorMsg = error ? error.message : 'Not found';
-    return { success: false, error: errorMsg };
-  }
+  return { data, error };
+}
 
-  // Skip if already classified
-  if (missed.miss_category) {
-    return { success: true, skipped: true, category: missed.miss_category };
-  }
+/** Calculate days late from publication date */
+async function calculateDaysLate(missed) {
+  if (!missed.submitted_at) return null;
 
-  // Classify the miss
-  const classification = await classifyMiss(missed);
+  const urlNorm = missed.url_norm || missed.url.toLowerCase();
+  const { data } = await getSupabase()
+    .from('ingestion_queue')
+    .select('payload')
+    .eq('url_norm', urlNorm)
+    .limit(1);
 
-  // Calculate days_late if we have publication date
-  let daysLate = null;
-  if (missed.submitted_at) {
-    // Try to get publication date from ingestion_queue if we have it
-    const urlNorm = missed.url_norm || missed.url.toLowerCase();
-    const { data: ingestion } = await sb
-      .from('ingestion_queue')
-      .select('payload')
-      .eq('url_norm', urlNorm)
-      .limit(1);
+  const publishedAt = data?.[0]?.payload?.published_at;
+  return publishedAt ? daysBetween(publishedAt, missed.submitted_at) : null;
+}
 
-    const firstIngestion = ingestion?.[0];
-    const publishedAt = firstIngestion?.payload?.published_at;
-    if (publishedAt) {
-      daysLate = daysBetween(publishedAt, missed.submitted_at);
-    }
-  }
-
-  // Update the missed discovery record
-  const { error: updateError } = await sb
+/** Update missed discovery with classification */
+async function updateMissedRecord(missedId, classification, missed, daysLate) {
+  const { error } = await getSupabase()
     .from('missed_discovery')
     .update({
       miss_category: classification.category,
@@ -261,6 +51,25 @@ export async function analyzeMissedDiscovery(missedId) {
       existing_source_slug: classification.details?.source_slug || null,
     })
     .eq('id', missedId);
+
+  return error;
+}
+
+/** Process a single missed discovery item */
+export async function analyzeMissedDiscovery(missedId) {
+  const { data: missed, error } = await fetchMissedDiscovery(missedId);
+
+  if (error || !missed) {
+    return { success: false, error: error?.message || 'Not found' };
+  }
+
+  if (missed.miss_category) {
+    return { success: true, skipped: true, category: missed.miss_category };
+  }
+
+  const classification = await classifyMiss(missed);
+  const daysLate = await calculateDaysLate(missed);
+  const updateError = await updateMissedRecord(missedId, classification, missed, daysLate);
 
   if (updateError) {
     return { success: false, error: updateError.message };
@@ -274,32 +83,26 @@ export async function analyzeMissedDiscovery(missedId) {
   };
 }
 
-/**
- * Process all unclassified missed discoveries
- */
-export async function analyzeAllPendingMisses() {
-  const sb = getSupabase();
-
-  // Fetch all unclassified missed discoveries
-  const { data: pending, error } = await sb
+/** Fetch pending missed discoveries */
+async function fetchPendingMisses() {
+  const { data, error } = await getSupabase()
     .from('missed_discovery')
     .select('id, url')
     .is('miss_category', null)
     .order('submitted_at', { ascending: true })
     .limit(50);
 
-  if (error) {
-    return { success: false, error: error.message };
-  }
+  return { data, error };
+}
 
-  if (!pending || pending.length === 0) {
-    return { success: true, processed: 0 };
-  }
+/** Process all unclassified missed discoveries */
+export async function analyzeAllPendingMisses() {
+  const { data: pending, error } = await fetchPendingMisses();
 
-  const results = {
-    processed: 0,
-    categories: {},
-  };
+  if (error) return { success: false, error: error.message };
+  if (!pending?.length) return { success: true, processed: 0 };
+
+  const results = { processed: 0, categories: {} };
 
   for (const item of pending) {
     const result = await analyzeMissedDiscovery(item.id);
@@ -312,89 +115,8 @@ export async function analyzeAllPendingMisses() {
   return { success: true, ...results };
 }
 
-/**
- * Generate aggregated improvement suggestions
- */
-export async function generateImprovementReport() {
-  const sb = getSupabase();
-
-  // Get miss category counts
-  const { data: categoryCounts } = await sb
-    .from('missed_discovery')
-    .select('miss_category')
-    .not('miss_category', 'is', null);
-
-  // Count by category
-  const counts = {};
-  for (const item of categoryCounts || []) {
-    counts[item.miss_category] = (counts[item.miss_category] || 0) + 1;
-  }
-
-  // Get top missed domains (source_not_tracked)
-  const { data: missedDomains } = await sb
-    .from('missed_discovery')
-    .select('source_domain, submitter_urgency, why_valuable')
-    .eq('miss_category', 'source_not_tracked')
-    .eq('resolution_status', 'pending');
-
-  // Aggregate by domain
-  const domainCounts = {};
-  for (const item of missedDomains || []) {
-    if (!item.source_domain) continue;
-    if (!domainCounts[item.source_domain]) {
-      domainCounts[item.source_domain] = {
-        count: 0,
-        urgencies: [],
-        samples: [],
-      };
-    }
-    domainCounts[item.source_domain].count++;
-    if (item.submitter_urgency) {
-      domainCounts[item.source_domain].urgencies.push(item.submitter_urgency);
-    }
-    if (item.why_valuable && domainCounts[item.source_domain].samples.length < 2) {
-      domainCounts[item.source_domain].samples.push(item.why_valuable);
-    }
-  }
-
-  // Sort by count
-  const topMissedDomains = Object.entries(domainCounts)
-    .sort((a, b) => b[1].count - a[1].count)
-    .slice(0, 10)
-    .map(([domain, data]) => ({
-      domain,
-      miss_count: data.count,
-      has_critical: data.urgencies.includes('critical'),
-      has_important: data.urgencies.includes('important'),
-      sample_reasons: data.samples,
-    }));
-
-  // Get filter rejection details
-  const { data: filterRejections } = await sb
-    .from('missed_discovery')
-    .select('miss_details, why_valuable')
-    .eq('miss_category', 'filter_rejected')
-    .eq('resolution_status', 'pending')
-    .limit(10);
-
-  const report = {
-    generated_at: new Date().toISOString(),
-    summary: {
-      total_pending: Object.values(counts).reduce((a, b) => a + b, 0),
-      by_category: counts,
-    },
-    suggestions: {
-      add_sources: topMissedDomains,
-      tune_filter: (filterRejections || []).map((r) => ({
-        scores: r.miss_details?.relevance_scores,
-        rejection_reason: r.miss_details?.rejection_reason,
-        why_valuable: r.why_valuable,
-      })),
-    },
-  };
-
-  return report;
-}
+// Re-export from modules
+export { generateImprovementReport };
 
 export default {
   analyzeMissedDiscovery,


### PR DESCRIPTION
## Problem

`improver.js` was 405 lines with functions exceeding 30+ lines, violating quality guidelines.

## Solution

Split into 4 focused modules:

| File | Lines | Purpose |
|------|-------|---------|
| `improver-config.js` | 71 | Constants, MISS_CATEGORIES, DB helpers |
| `improver-classify.js` | 141 | Miss classification logic |
| `improver-report.js` | 103 | Report generation |
| `improver.js` | 126 | Main orchestration (was 405) |

## Function Size Summary

All functions are now **under 30 lines** (quality gate requirement).

Largest functions:
- `analyzeMissedDiscovery()`: 26 lines
- `classifyFromIngestionRecord()`: 24 lines
- `aggregateDomainStats()`: 18 lines

## Testing

- No behavioral changes, pure refactoring
- All existing functionality preserved
- Exports maintained for backwards compatibility