### PR TITLE
refactor(tagger): extract helpers to reduce file from 379 to 68 lines

### DIFF
--- a/services/agent-api/src/agents/tagger-config.js
+++ b/services/agent-api/src/agents/tagger-config.js
@@ -1,0 +1,57 @@
+/**
+ * Tagger Agent Configuration
+ *
+ * Supabase client and caching utilities for the tagger agent.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+// Lazy initialization to avoid crash on import when env vars aren't set
+let supabase = null;
+
+export function getSupabase() {
+  if (!supabase) {
+    supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  }
+  return supabase;
+}
+
+// Cache for audiences
+let cachedAudiences = null;
+
+/**
+ * Load audiences from kb_audience table
+ * KB-207: Single source of truth - load from DB, not hardcoded
+ */
+export async function getAudiences() {
+  if (cachedAudiences) return cachedAudiences;
+
+  const { data, error } = await getSupabase()
+    .from('kb_audience')
+    .select('code, name, description')
+    .order('sort_order');
+
+  if (error || !data || data.length === 0) {
+    throw new Error(
+      'CRITICAL: No audiences found in kb_audience table. ' +
+        'Run migrations to seed audience data. ' +
+        `DB error: ${error?.message || 'No data returned'}`,
+    );
+  }
+
+  cachedAudiences = data;
+  return cachedAudiences;
+}
+
+/** Check if TLD matches a geography code */
+export async function getGeographyFromTld(tld) {
+  if (!tld) return null;
+
+  const { data } = await getSupabase()
+    .from('kb_geography')
+    .select('code, name')
+    .eq('code', tld)
+    .single();
+
+  return data;
+}

--- a/services/agent-api/src/agents/tagger-prompt.js
+++ b/services/agent-api/src/agents/tagger-prompt.js
@@ -1,0 +1,83 @@
+/**
+ * Tagger Prompt Builder
+ *
+ * Functions for building prompts and context for the tagger agent.
+ */
+
+import { getGeographyFromTld } from './tagger-config.js';
+
+/** Extract TLD from URL */
+export function extractTld(url) {
+  if (!url) return '';
+  const domainMatch = url.match(/\.([a-z]{2,3})(?:\/|$)/i);
+  return domainMatch ? domainMatch[1].toLowerCase() : '';
+}
+
+/** Build geography hint from TLD */
+export async function buildCountryTldHint(url) {
+  const tld = extractTld(url);
+  const geoWithTld = await getGeographyFromTld(tld);
+
+  if (!geoWithTld) return '';
+
+  return `\nNOTE: Source domain ends in .${tld} - this strongly suggests ${geoWithTld.code.toUpperCase()} (${geoWithTld.name}) as a primary geography.`;
+}
+
+/** Build context data for prompt injection */
+export function buildContextData(payload, taxonomies, vendorData, countryTldHint) {
+  return {
+    title: payload.title,
+    summary: payload.summary?.short || payload.description || '',
+    url: payload.url || '',
+    countryTldHint,
+    industries: taxonomies.industries,
+    topics: taxonomies.topics,
+    geographies: taxonomies.geographies,
+    useCases: taxonomies.useCases,
+    capabilities: taxonomies.capabilities,
+    regulators: taxonomies.regulators,
+    regulations: taxonomies.regulations,
+    obligations: taxonomies.obligations,
+    processes: taxonomies.processes,
+    vendors: vendorData.formatted,
+  };
+}
+
+/** Replace placeholders in prompt template with context data */
+export function buildSystemPrompt(promptTemplate, contextData) {
+  let systemPrompt = promptTemplate;
+  for (const [key, value] of Object.entries(contextData)) {
+    const placeholder = `{{${key}}}`;
+    systemPrompt = systemPrompt.replaceAll(placeholder, value || '');
+  }
+  return systemPrompt;
+}
+
+/** Build user content message */
+export function buildUserContent(payload) {
+  const url = payload.url || '';
+  return `TITLE: ${payload.title}
+SUMMARY: ${payload.summary?.short || payload.description || ''}
+URL: ${url}`;
+}
+
+/** Log debug info about prompt */
+export function logPromptDebug(promptTemplate, content, systemPrompt) {
+  const hasKeeInSystemPrompt = promptTemplate?.includes('Kee Platforms');
+  const hasKeeInUserContent = content.includes('Kee Platforms');
+  console.log(
+    `🔍 [tagger] Prompt debug: Kee in system=${hasKeeInSystemPrompt}, Kee in user=${hasKeeInUserContent}`,
+  );
+  console.log(`🔍 [tagger] System prompt length: ${systemPrompt?.length || 0} chars`);
+}
+
+/** Log debug info about topic validation */
+export function logTopicDebug(rawTopics, validatedTopics, validCodes) {
+  console.log('🔍 [tagger] Raw LLM topic_codes:', JSON.stringify(rawTopics));
+  console.log('🔍 [tagger] topic_codes type:', typeof rawTopics);
+  console.log('🔍 [tagger] topic_codes isArray:', Array.isArray(rawTopics));
+  console.log('🔍 [tagger] validCodes.topics:', Array.from(validCodes.topics));
+  console.log('🔍 [tagger] Before validation:', JSON.stringify(rawTopics));
+  console.log('🔍 [tagger] After validation:', JSON.stringify(validatedTopics));
+  console.log('🔍 [tagger] validCodes.topics size:', validCodes.topics?.size || 0);
+}

--- a/services/agent-api/src/agents/tagger-schema.js
+++ b/services/agent-api/src/agents/tagger-schema.js
@@ -1,0 +1,106 @@
+/**
+ * Tagger Schema Builder
+ *
+ * Builds the Zod schema for the tagger agent dynamically from database.
+ */
+
+import { z } from 'zod';
+import { getAudiences } from './tagger-config.js';
+
+/** Tagged item with confidence score */
+export const TaggedCode = z.object({
+  code: z.string().describe('The taxonomy code'),
+  confidence: z.number().min(0).max(1).describe('Confidence score 0-1 for this specific tag'),
+});
+
+// Cache for schema
+let cachedTaggingSchema = null;
+
+/** Build taxonomy fields schema */
+function buildTaxonomyFields() {
+  return {
+    industry_codes: z
+      .array(TaggedCode)
+      .describe(
+        'BFSI industry codes with confidence (include L1 parent and L2 sub-category if applicable)',
+      ),
+    topic_codes: z
+      .array(TaggedCode)
+      .describe('Topic codes with confidence (include L1 parent and L2 sub-topic if applicable)'),
+    geography_codes: z
+      .array(TaggedCode)
+      .describe('Geography codes with confidence (e.g., "global", "eu", "uk", "us")'),
+    use_case_codes: z
+      .array(TaggedCode)
+      .describe('AI use case codes with confidence (empty array if not AI-related)'),
+    capability_codes: z
+      .array(TaggedCode)
+      .describe('AI capability codes with confidence (empty array if not AI-related)'),
+    regulator_codes: z
+      .array(TaggedCode)
+      .describe('Regulator codes with confidence (empty array if not regulatory)'),
+    regulation_codes: z
+      .array(z.string())
+      .describe('Regulation codes if specific regulations mentioned (empty array if none)'),
+    process_codes: z
+      .array(TaggedCode)
+      .describe('BFSI process codes with confidence - include parent codes for hierarchy'),
+  };
+}
+
+/** Build entity fields schema */
+function buildEntityFields() {
+  return {
+    organization_names: z
+      .array(z.string())
+      .describe('BFSI organizations mentioned (banks, insurers, asset managers)'),
+    vendor_names: z.array(z.string()).describe('AI/tech vendors mentioned'),
+  };
+}
+
+/** Build audience scores schema dynamically from database */
+async function buildAudienceScoresSchema() {
+  const audiences = await getAudiences();
+  const audienceScoresShape = {};
+
+  for (const audience of audiences) {
+    audienceScoresShape[audience.code] = z
+      .number()
+      .min(0)
+      .max(1)
+      .describe(`Relevance for ${audience.name}: ${audience.description}`);
+  }
+
+  return z.object(audienceScoresShape).describe('Relevance scores (0-1) per audience type');
+}
+
+/** Build metadata fields schema */
+function buildMetadataFields() {
+  return {
+    overall_confidence: z
+      .number()
+      .min(0)
+      .max(1)
+      .describe('Overall confidence in classification 0-1'),
+    reasoning: z.string().describe('Brief explanation of classification choices'),
+  };
+}
+
+/**
+ * Build Zod schema dynamically based on audiences from database
+ * KB-207: Schema reflects current audience definitions, not hardcoded
+ */
+export async function getTaggingSchema() {
+  if (cachedTaggingSchema) return cachedTaggingSchema;
+
+  const audienceScores = await buildAudienceScoresSchema();
+
+  cachedTaggingSchema = z.object({
+    ...buildTaxonomyFields(),
+    ...buildEntityFields(),
+    audience_scores: audienceScores,
+    ...buildMetadataFields(),
+  });
+
+  return cachedTaggingSchema;
+}

--- a/services/agent-api/src/agents/tagger-validation.js
+++ b/services/agent-api/src/agents/tagger-validation.js
@@ -1,0 +1,121 @@
+/**
+ * Tagger Validation Utilities
+ *
+ * Functions for validating and processing tagged results.
+ */
+
+const L1_CATEGORIES = new Set(['banking', 'financial-services', 'insurance']);
+
+/** Extract code from item (handles both string and object formats) */
+function getCode(item) {
+  return typeof item === 'string' ? item : item.code;
+}
+
+/** Extract confidence from item */
+function getConfidence(item) {
+  return typeof item === 'object' ? item.confidence || 0 : 0;
+}
+
+/**
+ * Filter tagged codes to only include valid taxonomy codes
+ * Logs warnings for invalid codes (LLM hallucinations)
+ */
+export function validateCodes(taggedItems, validSet, categoryName) {
+  if (!taggedItems || !Array.isArray(taggedItems)) return [];
+
+  const nonNullItems = taggedItems.filter((item) => item != null);
+  if (nonNullItems.length === 0) {
+    console.warn(`   ⚠️ All ${categoryName} codes were null/undefined`);
+    return [];
+  }
+
+  const validated = [];
+  for (const item of nonNullItems) {
+    const code = getCode(item);
+    if (validSet.has(code)) {
+      validated.push(item);
+    } else {
+      console.warn(`   ⚠️ Invalid ${categoryName} code rejected: "${code}"`);
+    }
+  }
+  return validated;
+}
+
+/** Find L1 industry codes from list */
+function findL1Codes(industryCodes) {
+  return industryCodes.filter((item) => L1_CATEGORIES.has(getCode(item)));
+}
+
+/** Sort L1 codes by confidence descending */
+function sortByConfidence(codes) {
+  return [...codes].sort((a, b) => getConfidence(b) - getConfidence(a));
+}
+
+/**
+ * Enforce mutual exclusivity for B/FS/I L1 industry categories
+ * If multiple L1s are tagged, keep only the highest confidence one
+ */
+export function enforceIndustryMutualExclusivity(industryCodes) {
+  if (!industryCodes || !Array.isArray(industryCodes)) return [];
+
+  const l1Codes = findL1Codes(industryCodes);
+  if (l1Codes.length <= 1) return industryCodes;
+
+  const sorted = sortByConfidence(l1Codes);
+  const keepCode = getCode(sorted[0]);
+  const removeCodes = sorted.slice(1).map(getCode);
+
+  console.warn(
+    `   ⚠️ Industry mutual exclusivity: keeping "${keepCode}", removing [${removeCodes.join(', ')}]`,
+  );
+
+  return industryCodes.filter((item) => !removeCodes.includes(getCode(item)));
+}
+
+/**
+ * Conditionally validate based on behavior_type from taxonomy_config
+ * GUARDRAIL: Validate against taxonomy list (reject LLM hallucinations)
+ * EXPANDABLE: Pass through as-is (LLM can propose new entries)
+ */
+export function conditionalValidate(codes, validSet, slug, categoryName, behaviorTypes) {
+  const behavior = behaviorTypes.get(slug);
+  if (behavior === 'expandable') {
+    return codes || [];
+  }
+  return validateCodes(codes, validSet, categoryName);
+}
+
+/** Validate all taxonomy codes from result */
+function validateAllCodes(result, validCodes, behaviorTypes) {
+  const cv = (codes, set, slug, name) => conditionalValidate(codes, set, slug, name, behaviorTypes);
+  const industries = enforceIndustryMutualExclusivity(
+    cv(result.industry_codes, validCodes.industries, 'industry', 'industry'),
+  );
+
+  return {
+    industry_codes: industries,
+    topic_codes: cv(result.topic_codes, validCodes.topics, 'topic', 'topic'),
+    geography_codes: cv(result.geography_codes, validCodes.geographies, 'geography', 'geography'),
+    use_case_codes: cv(result.use_case_codes, validCodes.useCases, 'use_case', 'use_case'),
+    capability_codes: cv(
+      result.capability_codes,
+      validCodes.capabilities,
+      'capability',
+      'capability',
+    ),
+    regulator_codes: cv(result.regulator_codes, validCodes.regulators, 'regulator', 'regulator'),
+    regulation_codes: cv(
+      result.regulation_codes,
+      validCodes.regulations,
+      'regulation',
+      'regulation',
+    ),
+    process_codes: cv(result.process_codes, validCodes.processes, 'process', 'process'),
+  };
+}
+
+/** Build validated result from raw LLM output */
+export function buildValidatedResult(result, validCodes, behaviorTypes, usage) {
+  const validatedCodes = validateAllCodes(result, validCodes, behaviorTypes);
+  return { ...result, ...validatedCodes, usage };
+}


### PR DESCRIPTION
## Problem

`tagger.js` was 379 lines with large functions exceeding 30+ lines, violating quality guidelines.

## Solution

Split into 5 focused modules:

| File | Lines | Purpose |
|------|-------|---------|
| `tagger-config.js` | 57 | Supabase client, audience loading |
| `tagger-schema.js` | 106 | Zod schema builder |
| `tagger-validation.js` | 111 | Code validation, mutual exclusivity |
| `tagger-prompt.js` | 83 | Prompt building, debug logging |
| `tagger.js` | 68 | Main orchestration (was 379) |

## Function Size Summary

All functions are now **under 30 lines** (quality gate requirement).

Largest functions:
- `buildTaxonomyFields()`: 30 lines
- `validateAllCodes()`: 27 lines
- `validateCodes()`: 20 lines

## Testing

- No behavioral changes, pure refactoring
- All existing functionality preserved
- Exports maintained for backwards compatibility