### PR TITLE
refactor(evals): extract helpers to reduce file from 377 to 232 lines

### DIFF
--- a/services/agent-api/src/lib/evals-config.js
+++ b/services/agent-api/src/lib/evals-config.js
@@ -1,0 +1,23 @@
+/**
+ * Evals Configuration
+ *
+ * Shared clients and configuration for the evals framework.
+ */
+
+import process from 'node:process';
+import { createClient } from '@supabase/supabase-js';
+import OpenAI from 'openai';
+
+export const supabase = createClient(
+  process.env.PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_KEY,
+);
+
+let openai = null;
+
+export function getOpenAI() {
+  if (!openai) {
+    openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  }
+  return openai;
+}

--- a/services/agent-api/src/lib/evals-db.js
+++ b/services/agent-api/src/lib/evals-db.js
@@ -1,0 +1,73 @@
+/**
+ * Evals Database Operations
+ *
+ * Functions for storing and retrieving eval data from Supabase.
+ */
+
+import { supabase } from './evals-config.js';
+
+/** Fetch golden examples for an agent */
+export async function fetchGoldenExamples(agentName, goldenSetName, limit) {
+  let query = supabase.from('eval_golden_set').select('*').eq('agent_name', agentName).limit(limit);
+  if (goldenSetName) query = query.eq('name', goldenSetName);
+  return query;
+}
+
+/** Get current prompt version for an agent */
+export async function getPromptVersion(agentName) {
+  const { data } = await supabase
+    .from('prompt_version')
+    .select('version')
+    .eq('agent_name', agentName)
+    .eq('stage', 'PRD')
+    .single();
+  return data?.version || 'unknown';
+}
+
+/** Create a new eval run */
+export async function createEvalRun(runData) {
+  const { data } = await supabase.from('eval_run').insert(runData).select().single();
+  return data;
+}
+
+/** Update eval run with results */
+export async function updateEvalRun(runId, updateData) {
+  return supabase
+    .from('eval_run')
+    .update({ ...updateData, finished_at: new Date().toISOString() })
+    .eq('id', runId);
+}
+
+/** Store eval result */
+export async function storeEvalResult(resultData) {
+  return supabase.from('eval_result').insert(resultData);
+}
+
+/** Add golden example */
+export async function addGoldenExample(agentName, name, input, expectedOutput, createdBy = null) {
+  const { data, error } = await supabase
+    .from('eval_golden_set')
+    .insert({
+      agent_name: agentName,
+      name,
+      input,
+      expected_output: expectedOutput,
+      created_by: createdBy,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+/** Get eval history */
+export async function getEvalHistory(agentName, limit = 10) {
+  const { data, error } = await supabase
+    .from('eval_run')
+    .select('*')
+    .eq('agent_name', agentName)
+    .order('started_at', { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return data;
+}

--- a/services/agent-api/src/lib/evals-judge.js
+++ b/services/agent-api/src/lib/evals-judge.js
@@ -1,0 +1,48 @@
+/**
+ * Evals LLM Judge Functions
+ *
+ * Functions for using LLM-as-judge to evaluate outputs.
+ */
+
+import { getOpenAI } from './evals-config.js';
+
+/** Build judge system prompt */
+function buildJudgePrompt(criteria) {
+  return `You are an evaluation judge. Score the output on ${criteria}.
+Return JSON: { "score": 0.0-1.0, "reasoning": "brief explanation" }`;
+}
+
+/** Build compare system prompt */
+function buildComparePrompt() {
+  return `Compare two outputs for the same input. Which is better?
+Return JSON: { "winner": "a" or "b" or "tie", "reasoning": "brief explanation" }`;
+}
+
+/** Call LLM for judgment */
+async function callLLMJudge(model, systemContent, userContent) {
+  const client = getOpenAI();
+  const response = await client.chat.completions.create({
+    model,
+    messages: [
+      { role: 'system', content: systemContent },
+      { role: 'user', content: userContent },
+    ],
+    response_format: { type: 'json_object' },
+    temperature: 0.1,
+  });
+  return JSON.parse(response.choices[0].message.content);
+}
+
+/** Judge output quality with LLM */
+export async function judgeWithLLM(input, output, criteria, model) {
+  const systemContent = buildJudgePrompt(criteria);
+  const userContent = `Input: ${JSON.stringify(input)}\n\nOutput: ${JSON.stringify(output)}`;
+  return callLLMJudge(model, systemContent, userContent);
+}
+
+/** Compare two outputs with LLM */
+export async function compareWithLLM(input, outputA, outputB, model) {
+  const systemContent = buildComparePrompt();
+  const userContent = `Input: ${JSON.stringify(input)}\n\nOutput A: ${JSON.stringify(outputA)}\n\nOutput B: ${JSON.stringify(outputB)}`;
+  return callLLMJudge(model, systemContent, userContent);
+}


### PR DESCRIPTION
## Problem

`evals.js` was 377 lines with large functions exceeding 30+ lines, violating quality guidelines.

## Solution

Split into 4 focused modules:

| File | Lines | Purpose |
|------|-------|---------|
| `evals-config.js` | 23 | Supabase/OpenAI clients |
| `evals-db.js` | 73 | Database operations |
| `evals-judge.js` | 48 | LLM judge functions |
| `evals.js` | 232 | Main eval functions (was 377) |

## Function Size Summary

All functions are now **under 30 lines** (quality gate requirement).

Largest functions:
- `runABTest()`: 30 lines
- `runGoldenEval()`: 26 lines
- `runLLMJudgeEval()`: 25 lines

## Testing

- No behavioral changes, pure refactoring
- All existing functionality preserved
- Exports maintained for backwards compatibility