### PR TITLE
refactor(agent-api): split runner into helper modules

### DIFF
--- a/services/agent-api/src/lib/runner-db.js
+++ b/services/agent-api/src/lib/runner-db.js
@@ -1,0 +1,83 @@
+export async function insertRun(supabase, { agentName, promptConfig, context }) {
+  return supabase
+    .from('agent_run')
+    .insert({
+      agent_name: agentName,
+      stage: agentName,
+      prompt_version: promptConfig.version,
+      status: 'running',
+      started_at: new Date().toISOString(),
+      queue_id: context.queueId ?? null,
+      publication_id: context.publicationId || null,
+      agent_metadata: { queue_id: context.queueId },
+    })
+    .select()
+    .single();
+}
+
+export async function updateRunSuccess(supabase, runId, { durationMs, result }) {
+  return supabase
+    .from('agent_run')
+    .update({
+      status: 'success',
+      finished_at: new Date().toISOString(),
+      duration_ms: durationMs,
+      result,
+    })
+    .eq('id', runId);
+}
+
+export async function updateRunError(supabase, runId, { durationMs, errorMessage }) {
+  return supabase
+    .from('agent_run')
+    .update({
+      status: 'error',
+      finished_at: new Date().toISOString(),
+      duration_ms: durationMs,
+      error_message: errorMessage,
+    })
+    .eq('id', runId);
+}
+
+export async function insertStep(supabase, { runId, stepOrder, stepType, details }) {
+  return supabase
+    .from('agent_run_step')
+    .insert({
+      run_id: runId,
+      step_order: stepOrder,
+      step_type: stepType,
+      started_at: new Date().toISOString(),
+      status: 'running',
+      details,
+    })
+    .select()
+    .single();
+}
+
+export async function updateStep(supabase, stepId, { status, details }) {
+  return supabase
+    .from('agent_run_step')
+    .update({
+      finished_at: new Date().toISOString(),
+      status,
+      details,
+    })
+    .eq('id', stepId);
+}
+
+export async function insertMetric(supabase, { runId, name, value, metadata }) {
+  return supabase.from('agent_run_metric').insert({
+    run_id: runId,
+    metric_name: name,
+    metric_value: value,
+    metadata,
+  });
+}
+
+export async function fetchQueuePayload(supabase, queueId) {
+  return supabase.from('ingestion_queue').select('payload').eq('id', queueId).single();
+}
+
+export async function updateQueuePayload(supabase, queueId, payload) {
+  return supabase.from('ingestion_queue').update({ payload }).eq('id', queueId);
+}

--- a/services/agent-api/src/lib/runner-enrichment-meta.js
+++ b/services/agent-api/src/lib/runner-enrichment-meta.js
@@ -1,0 +1,54 @@
+import { fetchQueuePayload, updateQueuePayload } from './runner-db.js';
+
+function getEnrichmentStepKey(agentName) {
+  const agentToStep = {
+    summarizer: 'summarize',
+    tagger: 'tag',
+    'thumbnail-generator': 'thumbnail',
+  };
+
+  return agentToStep[agentName];
+}
+
+function buildMetaEntry(promptConfig, llmModel) {
+  return {
+    prompt_version_id: promptConfig.id,
+    prompt_version: promptConfig.version,
+    llm_model: llmModel || promptConfig.model_id || 'unknown',
+    processed_at: new Date().toISOString(),
+  };
+}
+
+function mergePayload(existingPayload, stepKey, metaEntry) {
+  const existingMeta = existingPayload?.enrichment_meta || {};
+
+  return {
+    ...existingPayload,
+    enrichment_meta: {
+      ...existingMeta,
+      [stepKey]: metaEntry,
+    },
+  };
+}
+
+export async function writeEnrichmentMetaToQueue({
+  supabase,
+  agentName,
+  queueId,
+  promptConfig,
+  llmModel,
+}) {
+  const stepKey = getEnrichmentStepKey(agentName);
+  if (!stepKey) return { skipped: true };
+
+  const { data: item, error: fetchError } = await fetchQueuePayload(supabase, queueId);
+  if (fetchError) return { error: fetchError };
+
+  const metaEntry = buildMetaEntry(promptConfig, llmModel);
+  const updatedPayload = mergePayload(item.payload, stepKey, metaEntry);
+
+  const { error: updateError } = await updateQueuePayload(supabase, queueId, updatedPayload);
+  if (updateError) return { error: updateError };
+
+  return { stepKey };
+}

--- a/services/agent-api/src/lib/runner-execution.js
+++ b/services/agent-api/src/lib/runner-execution.js
@@ -1,0 +1,32 @@
+import { createTrace, isTracingEnabled } from './tracing.js';
+
+export async function createTraceIfEnabled({ agentName, promptConfig, queueId }) {
+  if (!isTracingEnabled()) return null;
+
+  return createTrace({
+    name: agentName,
+    runType: 'chain',
+    inputs: {
+      prompt: promptConfig.prompt_text?.substring(0, 500),
+      context: { queueId },
+    },
+    queueId,
+  });
+}
+
+export function buildTools({ runner, context, promptConfig, llm, openai }) {
+  return {
+    openai,
+    supabase: runner.supabase,
+    llm,
+    model: promptConfig.model_id,
+    promptConfig,
+    startStep: (type, details) => runner.startStep(type, details),
+    finishStepSuccess: (id, details) => runner.finishStepSuccess(id, details),
+    finishStepError: (id, msg) => runner.finishStepError(id, msg),
+    addMetric: (name, value, meta) => runner.addMetric(name, value, meta),
+    traceLLM: (opts) => runner.traceLLMCall(opts),
+    trace: runner.trace,
+    context,
+  };
+}

--- a/services/agent-api/src/lib/runner-run.js
+++ b/services/agent-api/src/lib/runner-run.js
@@ -1,0 +1,75 @@
+import { updateRunError, updateRunSuccess } from './runner-db.js';
+import { buildTools, createTraceIfEnabled } from './runner-execution.js';
+
+function logOpenAIAvailability(agentName, openaiClient) {
+  console.log(`🔍 [${agentName}] OpenAI client available:`, !!openaiClient);
+  if (!openaiClient) {
+    console.error(`❌ [${agentName}] OpenAI client is undefined! Check OPENAI_API_KEY env var.`);
+  }
+}
+
+async function endTrace(trace, result) {
+  if (!trace) return;
+  await trace.end({ result: result?.parsed || result });
+}
+
+async function writeEnrichmentMetaIfNeeded(runner, context, promptConfig, usage) {
+  if (!context.queueId || context.skipEnrichmentMeta) return;
+  await runner.writeEnrichmentMeta(context.queueId, promptConfig, usage?.model);
+}
+
+async function addUsageMetricsIfPresent(runner, usage) {
+  if (!usage) return;
+  await runner.addMetric('tokens_total', usage.total_tokens, usage);
+  await runner.addMetric('tokens_prompt', usage.prompt_tokens);
+  await runner.addMetric('tokens_completion', usage.completion_tokens);
+}
+
+async function finalizeSuccess(runner, context, promptConfig, { startTime, result }) {
+  const durationMs = Date.now() - startTime;
+
+  if (runner.runId) {
+    await updateRunSuccess(runner.supabase, runner.runId, { durationMs, result });
+    await addUsageMetricsIfPresent(runner, result.usage);
+    await writeEnrichmentMetaIfNeeded(runner, context, promptConfig, result.usage);
+  }
+
+  await endTrace(runner.trace, result);
+
+  console.log(`✅ [${runner.agentName}] Completed in ${durationMs}ms`);
+  return result;
+}
+
+async function finalizeError(runner, startTime, err) {
+  const durationMs = Date.now() - startTime;
+  const errorMessage = err?.message;
+
+  console.error(`❌ [${runner.agentName}] Failed:`, errorMessage);
+
+  if (runner.runId) {
+    await updateRunError(runner.supabase, runner.runId, { durationMs, errorMessage });
+  }
+
+  throw err;
+}
+
+export async function runAgentLogic({ runner, context, promptConfig, logicFn, llm, openaiClient }) {
+  runner.trace = await createTraceIfEnabled({
+    agentName: runner.agentName,
+    promptConfig,
+    queueId: context.queueId,
+  });
+
+  logOpenAIAvailability(runner.agentName, openaiClient);
+
+  const tools = buildTools({ runner, context, promptConfig, llm, openai: openaiClient });
+  const startTime = Date.now();
+
+  try {
+    const result = await logicFn(context, promptConfig.prompt_text, tools);
+    return await finalizeSuccess(runner, context, promptConfig, { startTime, result });
+  } catch (error) {
+    const err = /** @type {any} */ (error);
+    return await finalizeError(runner, startTime, err);
+  }
+}

--- a/services/agent-api/src/lib/runner.js
+++ b/services/agent-api/src/lib/runner.js
@@ -1,10 +1,16 @@
 import process from 'node:process';
 import { createClient } from '@supabase/supabase-js';
-import { createTrace, traceLLMCall, isTracingEnabled } from './tracing.js';
+import { traceLLMCall } from './tracing.js';
 import * as llm from './llm.js';
+import { insertRun, insertStep, updateStep, insertMetric } from './runner-db.js';
+import { writeEnrichmentMetaToQueue } from './runner-enrichment-meta.js';
+import { runAgentLogic } from './runner-run.js';
 
 // Shared Supabase client
-const supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+const supabase = createClient(
+  process.env.PUBLIC_SUPABASE_URL ?? '',
+  process.env.SUPABASE_SERVICE_KEY ?? '',
+);
 
 export class AgentRunner {
   constructor(agentName) {
@@ -29,18 +35,12 @@ export class AgentRunner {
     if (!this.runId) return null;
 
     this.stepOrder++;
-    const { data, error } = await this.supabase
-      .from('agent_run_step')
-      .insert({
-        run_id: this.runId,
-        step_order: this.stepOrder,
-        step_type: stepType,
-        started_at: new Date().toISOString(),
-        status: 'running',
-        details,
-      })
-      .select()
-      .single();
+    const { data, error } = await insertStep(this.supabase, {
+      runId: this.runId,
+      stepOrder: this.stepOrder,
+      stepType,
+      details,
+    });
 
     if (error) {
       console.warn(`⚠️ Failed to start step: ${error.message}`);
@@ -58,14 +58,7 @@ export class AgentRunner {
   async finishStepSuccess(stepId, details = {}) {
     if (!stepId) return;
 
-    await this.supabase
-      .from('agent_run_step')
-      .update({
-        finished_at: new Date().toISOString(),
-        status: 'success',
-        details,
-      })
-      .eq('id', stepId);
+    await updateStep(this.supabase, stepId, { status: 'success', details });
   }
 
   /**
@@ -76,14 +69,7 @@ export class AgentRunner {
   async finishStepError(stepId, errorMsg) {
     if (!stepId) return;
 
-    await this.supabase
-      .from('agent_run_step')
-      .update({
-        finished_at: new Date().toISOString(),
-        status: 'error',
-        details: { error: errorMsg },
-      })
-      .eq('id', stepId);
+    await updateStep(this.supabase, stepId, { status: 'error', details: { error: errorMsg } });
   }
 
   /**
@@ -95,12 +81,7 @@ export class AgentRunner {
   async addMetric(name, value, metadata = {}) {
     if (!this.runId) return;
 
-    await this.supabase.from('agent_run_metric').insert({
-      run_id: this.runId,
-      metric_name: name,
-      metric_value: value,
-      metadata,
-    });
+    await insertMetric(this.supabase, { runId: this.runId, name, value, metadata });
   }
 
   /**
@@ -138,120 +119,23 @@ export class AgentRunner {
 
     const promptConfig = await this.loadPromptConfig(context);
 
-    // 2. Log Run Start
-    const { data: runLog, error: runError } = await this.supabase
-      .from('agent_run')
-      .insert({
-        agent_name: this.agentName,
-        stage: this.agentName, // For compatibility with old schema
-        prompt_version: promptConfig.version,
-        status: 'running',
-        started_at: new Date().toISOString(),
-        queue_id: context.queueId ?? null,
-        publication_id: context.publicationId || null,
-        agent_metadata: { queue_id: context.queueId },
-      })
-      .select()
-      .single();
+    const { data: runLog, error: runError } = await insertRun(this.supabase, {
+      agentName: this.agentName,
+      promptConfig,
+      context,
+    });
 
     if (runError) console.error('⚠️ Failed to log run start:', runError);
 
     this.runId = runLog?.id;
-    const startTime = Date.now();
-
-    try {
-      // 2.5 Create LangSmith trace if enabled
-      if (isTracingEnabled()) {
-        this.trace = await createTrace({
-          name: this.agentName,
-          runType: 'chain',
-          inputs: {
-            prompt: promptConfig.prompt_text?.substring(0, 500),
-            context: { queueId: context.queueId },
-          },
-          queueId: context.queueId,
-        });
-      }
-
-      // 3. Execute Logic with step helpers available via tools
-      // DEBUG: Check if openai client is available
-      const openaiClient = this.openai;
-      console.log(`🔍 [${this.agentName}] OpenAI client available:`, !!openaiClient);
-      if (!openaiClient) {
-        console.error(
-          `❌ [${this.agentName}] OpenAI client is undefined! Check OPENAI_API_KEY env var.`,
-        );
-      }
-      const result = await logicFn(context, promptConfig.prompt_text, {
-        openai: openaiClient,
-        supabase: this.supabase,
-        // LLM abstraction layer - model from prompt_version
-        llm,
-        model: promptConfig.model_id,
-        promptConfig,
-        // Step helpers for granular logging
-        startStep: (type, details) => this.startStep(type, details),
-        finishStepSuccess: (id, details) => this.finishStepSuccess(id, details),
-        finishStepError: (id, msg) => this.finishStepError(id, msg),
-        addMetric: (name, value, meta) => this.addMetric(name, value, meta),
-        // LangSmith tracing
-        traceLLM: (opts) => this.traceLLMCall(opts),
-        trace: this.trace,
-      });
-
-      // 4. Log Success
-      const duration = Date.now() - startTime;
-      if (this.runId) {
-        await this.supabase
-          .from('agent_run')
-          .update({
-            status: 'success',
-            finished_at: new Date().toISOString(),
-            duration_ms: duration,
-            result: result,
-          })
-          .eq('id', this.runId);
-
-        // Log token usage metrics if available
-        if (result.usage) {
-          await this.addMetric('tokens_total', result.usage.total_tokens, result.usage);
-          await this.addMetric('tokens_prompt', result.usage.prompt_tokens);
-          await this.addMetric('tokens_completion', result.usage.completion_tokens);
-        }
-
-        // Write enrichment_meta to queue item payload for version tracking
-        // Skip if this is a head-to-head comparison (skipEnrichmentMeta flag)
-        if (context.queueId && !context.skipEnrichmentMeta) {
-          await this.writeEnrichmentMeta(context.queueId, promptConfig, result.usage?.model);
-        }
-      }
-
-      // End LangSmith trace
-      if (this.trace) {
-        await this.trace.end({ result: result?.parsed || result });
-      }
-
-      console.log(`✅ [${this.agentName}] Completed in ${duration}ms`);
-      return result;
-    } catch (error) {
-      // 5. Log Failure
-      console.error(`❌ [${this.agentName}] Failed:`, error.message);
-      const duration = Date.now() - startTime;
-
-      if (this.runId) {
-        await this.supabase
-          .from('agent_run')
-          .update({
-            status: 'error',
-            finished_at: new Date().toISOString(),
-            duration_ms: duration,
-            error_message: error.message,
-          })
-          .eq('id', this.runId);
-      }
-
-      throw error;
-    }
+    return runAgentLogic({
+      runner: this,
+      context,
+      promptConfig,
+      logicFn,
+      llm,
+      openaiClient: this.openai,
+    });
   }
 
   /**
@@ -259,13 +143,7 @@ export class AgentRunner {
    * @param {object} options - LLM call details
    */
   async traceLLMCall(options) {
-    if (!isTracingEnabled()) return;
-
-    await traceLLMCall({
-      ...options,
-      queueId: options.queueId,
-      parentRunId: this.trace?.id,
-    });
+    await traceLLMCall({ ...options, queueId: options.queueId, parentRunId: this.trace?.id });
   }
 
   /**
@@ -276,60 +154,19 @@ export class AgentRunner {
    * @param {string} llmModel - LLM model used (from result.usage.model)
    */
   async writeEnrichmentMeta(queueId, promptConfig, llmModel) {
-    // Map agent names to enrichment step keys
-    const agentToStep = {
-      summarizer: 'summarize',
-      tagger: 'tag',
-      'thumbnail-generator': 'thumbnail',
-    };
-
-    const stepKey = agentToStep[this.agentName];
-    if (!stepKey) {
-      // Not an enrichment agent, skip
-      return;
-    }
-
     try {
-      // Fetch current payload
-      const { data: item, error: fetchError } = await this.supabase
-        .from('ingestion_queue')
-        .select('payload')
-        .eq('id', queueId)
-        .single();
+      const res = await writeEnrichmentMetaToQueue({
+        supabase: this.supabase,
+        agentName: this.agentName,
+        queueId,
+        promptConfig,
+        llmModel,
+      });
 
-      if (fetchError) {
-        console.warn(`⚠️ Failed to fetch queue item for enrichment_meta: ${fetchError.message}`);
-        return;
-      }
-
-      // Build enrichment_meta entry
-      const metaEntry = {
-        prompt_version_id: promptConfig.id,
-        prompt_version: promptConfig.version,
-        llm_model: llmModel || promptConfig.model_id || 'unknown',
-        processed_at: new Date().toISOString(),
-      };
-
-      // Merge with existing payload
-      const existingMeta = item.payload?.enrichment_meta || {};
-      const updatedPayload = {
-        ...item.payload,
-        enrichment_meta: {
-          ...existingMeta,
-          [stepKey]: metaEntry,
-        },
-      };
-
-      // Update queue item
-      const { error: updateError } = await this.supabase
-        .from('ingestion_queue')
-        .update({ payload: updatedPayload })
-        .eq('id', queueId);
-
-      if (updateError) {
-        console.warn(`⚠️ Failed to update enrichment_meta: ${updateError.message}`);
-      } else {
-        console.log(`📝 [${this.agentName}] Wrote enrichment_meta.${stepKey} to queue item`);
+      if (res?.stepKey) {
+        console.log(`📝 [${this.agentName}] Wrote enrichment_meta.${res.stepKey} to queue item`);
+      } else if (res?.error) {
+        console.warn(`⚠️ Failed to update enrichment_meta: ${res.error.message}`);
       }
     } catch (err) {
       console.warn(`⚠️ Error writing enrichment_meta: ${err.message}`);


### PR DESCRIPTION
## Problem

services/agent-api/src/lib/runner.js was large and contained multiple responsibilities (DB writes, step tracking, tracing setup, enrichment_meta writes, and run orchestration), making it hard to maintain and violating our file/function size targets.

## Root Cause

Runner logic grew organically in one module instead of being composed from small helpers.

## Solution

Split runner into focused helper modules and keep runner.js small:
- runner-db.js: DB operations for runs, steps, metrics, queue payload
- runner-enrichment-meta.js: enrichment_meta merge/write
- runner-execution.js: trace creation and tools construction
- runner-run.js: run execution flow and success/error finalization

runner.js now delegates to these helpers while keeping behavior and public API unchanged.

## Files Changed
- services/agent-api/src/lib/runner.js
- services/agent-api/src/lib/runner-db.js
- services/agent-api/src/lib/runner-enrichment-meta.js
- services/agent-api/src/lib/runner-execution.js
- services/agent-api/src/lib/runner-run.js