### PR TITLE
refactor(admin): split item actions helpers

### DIFF
--- a/apps/admin/src/app/(dashboard)/items/actions.ts
+++ b/apps/admin/src/app/(dashboard)/items/actions.ts
@@ -2,43 +2,29 @@
 
 import { createClient, createServiceRoleClient } from '@/lib/supabase/server';
 import { revalidatePath } from 'next/cache';
-import {
-  upsertPublication,
-  insertTaxonomyTags,
-  preparePublicationData,
-} from './lib/publication-helpers';
+import { getStatusCode, getStatusCodes } from './lib/actions-status';
+import { coercePayload, fetchQueueItem, mergePayload, updateQueueItem } from './lib/actions-queue';
+import { bulkApproveItems, bulkReenrichItems, bulkRejectItems } from './lib/actions-bulk';
+import { hasAnyTaxonomyTags } from './lib/actions-validate';
+import { approveQueueItem } from './lib/actions-approve';
 
 export async function updatePublishedDateAction(itemId: string, publishedDate: string) {
   const supabase = createServiceRoleClient();
 
-  // Fetch current payload
-  const { data: currentItem, error: fetchError } = await supabase
-    .from('ingestion_queue')
-    .select('payload')
-    .eq('id', itemId)
-    .single();
-
-  if (fetchError || !currentItem) {
+  const { data: currentItem, error: fetchError } = await fetchQueueItem(
+    supabase,
+    itemId,
+    'payload',
+  );
+  if (fetchError || !currentItem)
     return { success: false as const, error: fetchError?.message || 'Failed to fetch item' };
-  }
 
-  const currentPayload = (currentItem.payload || {}) as Record<string, unknown>;
-  const updatedPayload = {
-    ...currentPayload,
-    published_at: publishedDate,
-  };
-
-  // Update with service role to bypass RLS
-  const { error: updateError } = await supabase
-    .from('ingestion_queue')
-    .update({
-      payload: updatedPayload,
-    })
-    .eq('id', itemId);
-
-  if (updateError) {
-    return { success: false as const, error: updateError.message };
-  }
+  const currentPayload = coercePayload(currentItem.payload);
+  const updatedPayload = mergePayload(currentPayload, { published_at: publishedDate });
+  const { error: updateError } = await updateQueueItem(supabase, itemId, {
+    payload: updatedPayload,
+  });
+  if (updateError) return { success: false as const, error: updateError.message };
 
   revalidatePath(`/items/${itemId}`);
   return { success: true as const };
@@ -47,45 +33,26 @@ export async function updatePublishedDateAction(itemId: string, publishedDate: s
 export async function moveToReviewAction(itemId: string) {
   const supabase = createServiceRoleClient();
 
-  // Fetch item to validate enrichment is complete
-  const { data: item, error: fetchError } = await supabase
-    .from('ingestion_queue')
-    .select('payload, status_code')
-    .eq('id', itemId)
-    .single();
-
-  if (fetchError || !item) {
+  const { data: item, error: fetchError } = await fetchQueueItem(
+    supabase,
+    itemId,
+    'payload, status_code',
+  );
+  if (fetchError || !item)
     return { success: false as const, error: fetchError?.message || 'Failed to fetch item' };
-  }
 
-  const payload = item.payload || {};
-
-  // Validate that tagging has been completed
-  const hasAudiences = payload.audience_scores && Object.keys(payload.audience_scores).length > 0;
-  const hasGeographies =
-    Array.isArray(payload.geography_codes) && payload.geography_codes.length > 0;
-  const hasIndustries = Array.isArray(payload.industry_codes) && payload.industry_codes.length > 0;
-  const hasTopics = Array.isArray(payload.topic_codes) && payload.topic_codes.length > 0;
-
-  const hasAnyTags = hasAudiences || hasGeographies || hasIndustries || hasTopics;
-
-  if (!hasAnyTags) {
+  const payload = coercePayload(item.payload);
+  if (!hasAnyTaxonomyTags(payload)) {
     return {
       success: false as const,
       error:
-        'Item has not been tagged yet. Please run enrichment first or move to status 220 (to_tag) instead.',
+        'Item has not been tagged yet. Please run enrichment first or move to "to_tag" instead.',
     };
   }
 
-  // Update status to PENDING_REVIEW (300) with service role to bypass RLS
-  const { error } = await supabase
-    .from('ingestion_queue')
-    .update({ status_code: 300 })
-    .eq('id', itemId);
-
-  if (error) {
-    return { success: false as const, error: error.message };
-  }
+  const pendingReviewCode = await getStatusCode(supabase, 'pending_review');
+  const { error } = await updateQueueItem(supabase, itemId, { status_code: pendingReviewCode });
+  if (error) return { success: false as const, error: error.message };
 
   revalidatePath(`/items/${itemId}`);
   return { success: true as const };
@@ -107,53 +74,21 @@ async function getCurrentUserId(): Promise<string | null> {
 export async function approveQueueItemAction(queueId: string, editedTitle?: string) {
   const supabase = createServiceRoleClient();
 
-  const { data: item, error: fetchError } = await supabase
-    .from('ingestion_queue')
-    .select('id, url, payload')
-    .eq('id', queueId)
-    .single();
-
-  if (fetchError || !item) {
-    return { success: false as const, error: fetchError?.message || 'Failed to fetch item' };
-  }
-
-  const payload = (item.payload || {}) as Record<string, unknown>;
-  const title = editedTitle?.trim() || (payload.title as string) || 'Untitled';
-
-  const pubData = preparePublicationData(item, title);
-  const pubResult = await upsertPublication(supabase, pubData);
-
-  if (!pubResult.success) {
-    return { success: false as const, error: pubResult.error };
-  }
-
-  const { publicationId } = pubResult;
-
-  const taxonomyResult = await insertTaxonomyTags(supabase, publicationId, payload);
-  if (!taxonomyResult.success) {
-    return { success: false as const, error: taxonomyResult.error };
-  }
-
-  // Update queue item status & persist edited title back into payload
-  const newPayload = editedTitle?.trim() ? { ...payload, title } : payload;
+  const publishedCode = await getStatusCode(supabase, 'published');
   const reviewedBy = await getCurrentUserId();
-  const { error: updateError } = await supabase
-    .from('ingestion_queue')
-    .update({
-      status_code: 400,
-      payload: newPayload,
-      reviewed_by: reviewedBy,
-      reviewed_at: new Date().toISOString(),
-    })
-    .eq('id', item.id);
 
-  if (updateError) {
-    return { success: false as const, error: updateError.message };
-  }
+  const result = await approveQueueItem({
+    supabase,
+    queueId,
+    editedTitle,
+    publishedCode,
+    reviewedBy,
+  });
+  if (!result.success) return { success: false as const, error: result.error };
 
   revalidatePath('/items');
   revalidatePath('/published');
-  return { success: true as const, publicationId };
+  return { success: true as const, publicationId: result.publicationId };
 }
 
 export async function bulkReenrichAction(
@@ -163,58 +98,12 @@ export async function bulkReenrichAction(
     const supabase = createServiceRoleClient();
     const userId = await getCurrentUserId();
 
-    // For each item, cancel old run and create new one
-    for (const queueId of ids) {
-      // Cancel any running pipeline_run for this item
-      await supabase
-        .from('pipeline_run')
-        .update({ status: 'cancelled', completed_at: new Date().toISOString() })
-        .eq('queue_id', queueId)
-        .eq('status', 'running');
-
-      // Create new pipeline_run with trigger='re-enrich'
-      const { data: newRun } = await supabase
-        .from('pipeline_run')
-        .insert({
-          queue_id: queueId,
-          trigger: 're-enrich',
-          status: 'running',
-          created_by: userId || 'system',
-        })
-        .select('id')
-        .single();
-
-      // Update ingestion_queue with new current_run_id and reset status
-      // Also reset failure tracking for DLQ items (KB-268)
-      await supabase
-        .from('ingestion_queue')
-        .update({
-          status_code: 200, // 200 = PENDING_ENRICHMENT
-          current_run_id: newRun?.id || null,
-          failure_count: 0,
-          last_failed_step: null,
-        })
-        .eq('id', queueId);
-    }
-
-    // Note: We don't check for errors on pipeline_run operations
-    // because the table might not exist in older environments
-
-    // Trigger processing
-    const agentApiUrl = process.env.AGENT_API_URL || 'https://bfsi-insights.onrender.com';
-    const agentApiKey = process.env.AGENT_API_KEY;
-
-    // Trigger processing in background (don't await - let items move to "Queued" immediately)
-    if (agentApiKey) {
-      fetch(`${agentApiUrl}/api/agents/process-queue`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-API-Key': agentApiKey,
-        },
-        body: JSON.stringify({ limit: 20, includeThumbnail: true }),
-      }).catch((err) => console.error('Background process-queue failed:', err));
-    }
+    const codes = await getStatusCodes(supabase, ['pending_enrichment', 'published', 'rejected']);
+    await bulkReenrichItems(supabase, ids, userId, {
+      pending_enrichment: codes.pending_enrichment,
+      published: codes.published,
+      rejected: codes.rejected,
+    });
 
     revalidatePath('/items');
     return { success: true, queued: ids.length };
@@ -226,29 +115,10 @@ export async function bulkReenrichAction(
 export async function bulkRejectAction(ids: string[], reason: string) {
   const supabase = createServiceRoleClient();
 
-  // Get current items to preserve payload
-  const { data: items } = await supabase
-    .from('ingestion_queue')
-    .select('id, payload')
-    .in('id', ids);
-
-  if (!items) {
-    return { success: false, error: 'Failed to fetch items' };
-  }
-
-  // Update each with rejection reason in payload
   const reviewedBy = await getCurrentUserId();
-  for (const item of items) {
-    await supabase
-      .from('ingestion_queue')
-      .update({
-        status_code: 540, // 540 = REJECTED
-        payload: { ...item.payload, rejection_reason: reason },
-        reviewed_by: reviewedBy,
-        reviewed_at: new Date().toISOString(),
-      })
-      .eq('id', item.id);
-  }
+  const rejectedCode = await getStatusCode(supabase, 'rejected');
+  const result = await bulkRejectItems(supabase, ids, reason, reviewedBy, rejectedCode);
+  if (!result.success) return result;
 
   revalidatePath('/items');
   return { success: true, count: ids.length };
@@ -257,46 +127,10 @@ export async function bulkRejectAction(ids: string[], reason: string) {
 export async function bulkApproveAction(ids: string[]) {
   const supabase = createServiceRoleClient();
 
-  // Get items with payload
-  const { data: items } = await supabase
-    .from('ingestion_queue')
-    .select('id, url, payload')
-    .in('id', ids);
-
-  if (!items) {
-    return { success: false, error: 'Failed to fetch items' };
-  }
-
-  for (const item of items) {
-    const payload = (item.payload || {}) as Record<string, unknown>;
-    const title = (payload.title as string) || 'Untitled';
-
-    const pubData = preparePublicationData(item, title);
-    const pubResult = await upsertPublication(supabase, pubData);
-
-    if (!pubResult.success) {
-      console.error('Failed to upsert publication:', pubResult.error);
-      return { success: false, error: pubResult.error };
-    }
-
-    const { publicationId } = pubResult;
-
-    const taxonomyResult = await insertTaxonomyTags(supabase, publicationId, payload);
-    if (!taxonomyResult.success) {
-      console.error('Failed to insert taxonomy tags:', taxonomyResult.error);
-      return { success: false, error: taxonomyResult.error };
-    }
-
-    const reviewedBy = await getCurrentUserId();
-    await supabase
-      .from('ingestion_queue')
-      .update({
-        status_code: 400,
-        reviewed_by: reviewedBy,
-        reviewed_at: new Date().toISOString(),
-      })
-      .eq('id', item.id);
-  }
+  const reviewedBy = await getCurrentUserId();
+  const publishedCode = await getStatusCode(supabase, 'published');
+  const result = await bulkApproveItems(supabase, ids, reviewedBy, publishedCode);
+  if (!result.success) return result;
 
   revalidatePath('/items');
   revalidatePath('/published');

--- a/apps/admin/src/app/(dashboard)/items/lib/actions-approve.ts
+++ b/apps/admin/src/app/(dashboard)/items/lib/actions-approve.ts
@@ -1,0 +1,92 @@
+import { createServiceRoleClient } from '@/lib/supabase/server';
+import { coercePayload, updateQueueItem } from './actions-queue';
+import {
+  insertTaxonomyTags,
+  preparePublicationData,
+  upsertPublication,
+} from './publication-helpers';
+
+type Supabase = ReturnType<typeof createServiceRoleClient>;
+
+type QueueRow = {
+  id: string;
+  url: string;
+  payload: unknown;
+};
+
+type ApproveResult = { success: true; publicationId: string } | { success: false; error: string };
+
+type ApproveArgs = {
+  supabase: Supabase;
+  queueId: string;
+  editedTitle?: string;
+  publishedCode: number;
+  reviewedBy: string | null;
+};
+
+async function fetchQueueRow(supabase: Supabase, queueId: string) {
+  return supabase.from('ingestion_queue').select('id, url, payload').eq('id', queueId).single();
+}
+
+function computeTitle(payload: Record<string, unknown>, editedTitle?: string) {
+  return editedTitle?.trim() || (payload.title as string) || 'Untitled';
+}
+
+async function publishAndTag(
+  supabase: Supabase,
+  row: QueueRow,
+  payload: Record<string, unknown>,
+  title: string,
+) {
+  const pubData = preparePublicationData({ url: row.url, payload }, title);
+  const pubResult = await upsertPublication(supabase, pubData);
+  if (!pubResult.success) return pubResult;
+
+  const taxonomyResult = await insertTaxonomyTags(supabase, pubResult.publicationId, payload);
+  if (!taxonomyResult.success) return taxonomyResult;
+
+  return pubResult;
+}
+
+async function markQueueItemPublished(opts: {
+  supabase: Supabase;
+  row: QueueRow;
+  publishedCode: number;
+  reviewedBy: string | null;
+  payload: Record<string, unknown>;
+}) {
+  return updateQueueItem(opts.supabase, opts.row.id, {
+    status_code: opts.publishedCode,
+    payload: opts.payload,
+    reviewed_by: opts.reviewedBy,
+    reviewed_at: new Date().toISOString(),
+  });
+}
+
+async function approveQueueItemImpl(args: ApproveArgs): Promise<ApproveResult> {
+  const { data: item, error: fetchError } = await fetchQueueRow(args.supabase, args.queueId);
+  if (fetchError || !item)
+    return { success: false, error: fetchError?.message || 'Failed to fetch item' };
+
+  const row = item as QueueRow;
+  const payload = coercePayload(row.payload);
+  const title = computeTitle(payload, args.editedTitle);
+
+  const pubResult = await publishAndTag(args.supabase, row, payload, title);
+  if (!pubResult.success) return { success: false, error: pubResult.error };
+
+  const updatedPayload = args.editedTitle?.trim() ? { ...payload, title } : payload;
+  const { error: updateError } = await markQueueItemPublished({
+    supabase: args.supabase,
+    row,
+    publishedCode: args.publishedCode,
+    reviewedBy: args.reviewedBy,
+    payload: updatedPayload,
+  });
+  if (updateError) return { success: false, error: updateError.message };
+  return { success: true, publicationId: pubResult.publicationId };
+}
+
+export async function approveQueueItem(args: ApproveArgs): Promise<ApproveResult> {
+  return approveQueueItemImpl(args);
+}

--- a/apps/admin/src/app/(dashboard)/items/lib/actions-bulk.ts
+++ b/apps/admin/src/app/(dashboard)/items/lib/actions-bulk.ts
@@ -1,0 +1,145 @@
+import process from 'node:process';
+import { createServiceRoleClient } from '@/lib/supabase/server';
+import {
+  insertTaxonomyTags,
+  preparePublicationData,
+  upsertPublication,
+} from './publication-helpers';
+import { coercePayload, updateQueueItem } from './actions-queue';
+
+type Supabase = ReturnType<typeof createServiceRoleClient>;
+
+type BulkResult = { success: true; count: number } | { success: false; error: string };
+
+type StatusCodes = {
+  pending_enrichment: number;
+  published: number;
+  rejected: number;
+};
+
+async function cancelRunningPipeline(supabase: Supabase, queueId: string) {
+  await supabase
+    .from('pipeline_run')
+    .update({ status: 'cancelled', completed_at: new Date().toISOString() })
+    .eq('queue_id', queueId)
+    .eq('status', 'running');
+}
+
+async function createPipelineRun(supabase: Supabase, queueId: string, createdBy: string | null) {
+  const { data } = await supabase
+    .from('pipeline_run')
+    .insert({
+      queue_id: queueId,
+      trigger: 're-enrich',
+      status: 'running',
+      created_by: createdBy || 'system',
+    })
+    .select('id')
+    .single();
+
+  return data?.id ?? null;
+}
+
+async function triggerAgentApiQueue() {
+  const agentApiUrl = process.env.AGENT_API_URL || 'https://bfsi-insights.onrender.com';
+  const agentApiKey = process.env.AGENT_API_KEY;
+  if (!agentApiKey) return;
+
+  fetch(`${agentApiUrl}/api/agents/process-queue`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-API-Key': agentApiKey },
+    body: JSON.stringify({ limit: 20, includeThumbnail: true }),
+  }).catch((err) => console.error('Background process-queue failed:', err));
+}
+
+export async function bulkRejectItems(
+  supabase: Supabase,
+  ids: string[],
+  reason: string,
+  reviewedBy: string | null,
+  rejectedCode: number,
+): Promise<BulkResult> {
+  const { data: items } = await supabase
+    .from('ingestion_queue')
+    .select('id, payload')
+    .in('id', ids);
+  if (!items) return { success: false, error: 'Failed to fetch items' };
+
+  for (const item of items) {
+    await updateQueueItem(supabase, item.id, {
+      status_code: rejectedCode,
+      payload: { ...item.payload, rejection_reason: reason },
+      reviewed_by: reviewedBy,
+      reviewed_at: new Date().toISOString(),
+    });
+  }
+
+  return { success: true, count: ids.length };
+}
+
+export async function bulkApproveItems(
+  supabase: Supabase,
+  ids: string[],
+  reviewedBy: string | null,
+  publishedCode: number,
+): Promise<BulkResult> {
+  const { data: items } = await supabase
+    .from('ingestion_queue')
+    .select('id, url, payload')
+    .in('id', ids);
+  if (!items) return { success: false, error: 'Failed to fetch items' };
+
+  for (const item of items) {
+    const result = await approveOneItem(supabase, item, reviewedBy, publishedCode);
+    if (!result.success) return result;
+  }
+
+  return { success: true, count: ids.length };
+}
+
+async function approveOneItem(
+  supabase: Supabase,
+  item: { id: string; url: string; payload: unknown },
+  reviewedBy: string | null,
+  publishedCode: number,
+): Promise<{ success: true } | { success: false; error: string }> {
+  const payload = coercePayload(item.payload);
+  const title = (payload.title as string) || 'Untitled';
+
+  const pubData = preparePublicationData({ url: item.url, payload }, title);
+  const pubResult = await upsertPublication(supabase, pubData);
+  if (!pubResult.success) return { success: false, error: pubResult.error };
+
+  const taxonomyResult = await insertTaxonomyTags(supabase, pubResult.publicationId, payload);
+  if (!taxonomyResult.success) return { success: false, error: taxonomyResult.error };
+
+  await updateQueueItem(supabase, item.id, {
+    status_code: publishedCode,
+    reviewed_by: reviewedBy,
+    reviewed_at: new Date().toISOString(),
+  });
+
+  return { success: true };
+}
+
+export async function bulkReenrichItems(
+  supabase: Supabase,
+  ids: string[],
+  userId: string | null,
+  statusCodes: StatusCodes,
+) {
+  for (const queueId of ids) {
+    await cancelRunningPipeline(supabase, queueId);
+    const newRunId = await createPipelineRun(supabase, queueId, userId);
+
+    await updateQueueItem(supabase, queueId, {
+      status_code: statusCodes.pending_enrichment,
+      current_run_id: newRunId,
+      failure_count: 0,
+      last_failed_step: null,
+    });
+  }
+
+  await triggerAgentApiQueue();
+  return { success: true as const, queued: ids.length };
+}

--- a/apps/admin/src/app/(dashboard)/items/lib/actions-queue.ts
+++ b/apps/admin/src/app/(dashboard)/items/lib/actions-queue.ts
@@ -1,0 +1,23 @@
+import { createServiceRoleClient } from '@/lib/supabase/server';
+
+type Supabase = ReturnType<typeof createServiceRoleClient>;
+
+export async function fetchQueueItem<T extends string>(supabase: Supabase, id: string, select: T) {
+  return supabase.from('ingestion_queue').select(select).eq('id', id).single();
+}
+
+export async function updateQueueItem(
+  supabase: Supabase,
+  id: string,
+  patch: Record<string, unknown>,
+) {
+  return supabase.from('ingestion_queue').update(patch).eq('id', id);
+}
+
+export function coercePayload(payload: unknown): Record<string, unknown> {
+  return (payload ?? {}) as Record<string, unknown>;
+}
+
+export function mergePayload(payload: Record<string, unknown>, patch: Record<string, unknown>) {
+  return { ...payload, ...patch };
+}

--- a/apps/admin/src/app/(dashboard)/items/lib/actions-status.ts
+++ b/apps/admin/src/app/(dashboard)/items/lib/actions-status.ts
@@ -1,0 +1,41 @@
+import { createServiceRoleClient } from '@/lib/supabase/server';
+
+type Supabase = ReturnType<typeof createServiceRoleClient>;
+
+type StatusRow = {
+  code: number;
+  name: string;
+};
+
+export async function getStatusCode(supabase: Supabase, name: string): Promise<number> {
+  const { data, error } = await supabase
+    .from('status_lookup')
+    .select('code')
+    .eq('name', name)
+    .single();
+  if (error || !data) throw new Error(`Status code not found: ${name}`);
+  return data.code;
+}
+
+export async function getStatusCodes(
+  supabase: Supabase,
+  names: string[],
+): Promise<Record<string, number>> {
+  const { data, error } = await supabase
+    .from('status_lookup')
+    .select('code, name')
+    .in('name', names);
+  if (error || !data)
+    throw new Error(`Failed to load status codes: ${error?.message ?? 'no data returned'}`);
+
+  const codes: Record<string, number> = {};
+  for (const row of data as StatusRow[]) {
+    codes[row.name] = row.code;
+  }
+
+  for (const name of names) {
+    if (!codes[name]) throw new Error(`Status code not found: ${name}`);
+  }
+
+  return codes;
+}

--- a/apps/admin/src/app/(dashboard)/items/lib/actions-validate.ts
+++ b/apps/admin/src/app/(dashboard)/items/lib/actions-validate.ts
@@ -1,0 +1,18 @@
+export function hasAnyTaxonomyTags(payload: Record<string, unknown>) {
+  const audienceScores = payload.audience_scores;
+  const hasAudiences =
+    !!audienceScores &&
+    typeof audienceScores === 'object' &&
+    Object.keys(audienceScores).length > 0;
+
+  const geos = payload.geography_codes;
+  const hasGeographies = Array.isArray(geos) && geos.length > 0;
+
+  const industries = payload.industry_codes;
+  const hasIndustries = Array.isArray(industries) && industries.length > 0;
+
+  const topics = payload.topic_codes;
+  const hasTopics = Array.isArray(topics) && topics.length > 0;
+
+  return hasAudiences || hasGeographies || hasIndustries || hasTopics;
+}


### PR DESCRIPTION
## Problem

apps/admin/src/app/(dashboard)/items/actions.ts was ~318 lines with several large server actions and repeated Supabase/status update logic.

## Root Cause

Item actions accumulated in a single file rather than being decomposed into focused helpers.

## Solution

Extracted focused helper modules and made actions.ts a thin layer:
- actions-status.ts: load status_code values from status_lookup (no hardcoded codes)
- actions-queue.ts: ingestion_queue fetch/update + payload helpers
- actions-validate.ts: tagging validation
- actions-approve.ts: queue item approve flow
- actions-bulk.ts: bulk approve/reject/reenrich flows

Kept behavior unchanged and verified admin lint passes.

## Files Changed
- apps/admin/src/app/(dashboard)/items/actions.ts
- apps/admin/src/app/(dashboard)/items/lib/actions-approve.ts
- apps/admin/src/app/(dashboard)/items/lib/actions-bulk.ts
- apps/admin/src/app/(dashboard)/items/lib/actions-queue.ts
- apps/admin/src/app/(dashboard)/items/lib/actions-status.ts
- apps/admin/src/app/(dashboard)/items/lib/actions-validate.ts