### PR TITLE
feat: add nightly quality metrics workflow

### DIFF
--- a/.github/workflows/nightly-quality.yml
+++ b/.github/workflows/nightly-quality.yml
@@ -1,0 +1,43 @@
+name: Nightly Quality Report
+
+on:
+  schedule:
+    - cron: '30 2 * * *' # daily at 02:30 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-quality
+  cancel-in-progress: false
+
+jobs:
+  quality-report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate quality reports
+        run: node scripts/ci/quality-report.cjs
+
+      - name: Commit quality reports
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add docs/architecture/quality/nightly-*.md
+          git diff --staged --quiet || git commit -m "docs: update nightly quality reports [skip ci]"
+          git push

--- a/docs/architecture/quality/nightly-large-files.md
+++ b/docs/architecture/quality/nightly-large-files.md
@@ -1,0 +1,18 @@
+# Large Files Report
+
+> Auto-generated on 2026-01-05 by nightly quality workflow
+
+Files exceeding size limits (source: 300 lines, test: 500 lines)
+
+## Summary
+
+- **Total large files:** 4
+
+## Files
+
+| File                                                 | Lines | Limit | Over by |
+| ---------------------------------------------------- | ----: | ----: | ------: |
+| `services/agent-api/tests/lib/sitemap.spec.js`       |   983 |   500 |    +483 |
+| `services/agent-api/tests/agents/improver.spec.js`   |   954 |   500 |    +454 |
+| `services/agent-api/tests/agents/scorer.spec.js`     |   723 |   500 |    +223 |
+| `services/agent-api/src/agents/discover-classics.js` |   309 |   300 |      +9 |

--- a/docs/architecture/quality/nightly-large-functions.md
+++ b/docs/architecture/quality/nightly-large-functions.md
@@ -1,0 +1,102 @@
+# Large Functions Report
+
+> Auto-generated on 2026-01-05 by nightly quality workflow
+
+Functions exceeding size limits (source: 30 lines, test: 50 lines)
+
+## Summary
+
+- **Total large functions:** 87
+- **Files affected:** 71
+
+## Functions
+
+| File                                                                                   | Function                       | Lines | Limit | Location |
+| -------------------------------------------------------------------------------------- | ------------------------------ | ----: | ----: | -------- |
+| `apps/admin/src/app/(dashboard)/evals/ab-tests/page.tsx`                               | `ABTestsPage()`                |   207 |    30 | L9-215   |
+| `apps/admin/src/app/(dashboard)/add/hooks/useAddArticle.ts`                            | `useAddArticle()`              |   201 |    30 | L8-208   |
+| `apps/admin/src/app/(dashboard)/agents/page.tsx`                                       | `AgentsPage()`                 |   152 |    30 | L11-162  |
+| `apps/admin/src/components/dashboard/DiscoveryControlCard.tsx`                         | `DiscoveryControlCard()`       |   142 |    30 | L12-153  |
+| `apps/web/features/publications/multi-select-filters.apply.ts`                         | `createApplyFiltersFunction()` |   135 |    30 | L19-153  |
+| `services/agent-api/src/lib/taxonomy-loader.js`                                        | `loadTaxonomies()`             |   132 |    30 | L31-162  |
+| `services/agent-api/src/agents/discover-classics.js`                                   | `runClassicsDiscovery()`       |   115 |    30 | L194-308 |
+| `services/agent-api/src/lib/scrapers.js`                                               | `scrapeWebsite()`              |   107 |    30 | L19-125  |
+| `apps/admin/src/app/(dashboard)/agents/hooks/usePrompts.ts`                            | `usePrompts()`                 |   104 |    30 | L8-111   |
+| `services/agent-api/src/scripts/backfill-summaries.js`                                 | `main()`                       |    99 |    30 | L20-118  |
+| `apps/admin/src/app/api/enrich-step/route.ts`                                          | `POST()`                       |    93 |    30 | L19-111  |
+| `services/agent-api/src/scripts/backfill-dates.js`                                     | `main()`                       |    92 |    30 | L20-111  |
+| `apps/admin/src/app/(auth)/login/page.tsx`                                             | `LoginPage()`                  |    90 |    30 | L7-96    |
+| `services/agent-api/src/agents/summarizer.js`                                          | `runSummarizer()`              |    90 |    30 | L195-284 |
+| `apps/admin/src/app/(dashboard)/agents/[agent]/page.tsx`                               | `AgentDetailPage()`            |    85 |    30 | L13-97   |
+| `services/agent-api/src/scripts/validate-agent-registry.js`                            | `main()`                       |    80 |    30 | L64-143  |
+| `apps/web/features/publications/multi-select-filters.impl.ts`                          | `initMultiSelectFilters()`     |    77 |    30 | L23-99   |
+| `apps/admin/src/components/ui/sidebar.tsx`                                             | `Sidebar()`                    |    73 |    30 | L53-125  |
+| `apps/admin/src/app/(dashboard)/agents/[agent]/hooks/usePromptActions.ts`              | `usePromptActions()`           |    72 |    30 | L4-75    |
+| `apps/admin/src/app/(dashboard)/missed/page.tsx`                                       | `MissedDiscoveryPage()`        |    71 |    30 | L9-79    |
+| `apps/web/features/publications/filters/apply.ts`                                      | `applyFilters()`               |    71 |    30 | L5-75    |
+| `services/agent-api/src/lib/prompt-eval.js`                                            | `runPromptEval()`              |    71 |    30 | L180-250 |
+| `apps/admin/src/app/(dashboard)/items/components/detail-panel/useKeyboardShortcuts.ts` | `useKeyboardShortcuts()`       |    69 |    30 | L16-84   |
+| `services/agent-api/src/lib/discovery-config.js`                                       | `loadDiscoveryConfig()`        |    69 |    30 | L35-103  |
+| `services/agent-api/tests/lib/pdf-extraction.test.js`                                  | `testPdfExtraction()`          |    69 |    50 | L17-85   |
+| `apps/admin/src/app/api/pipeline-status/route.ts`                                      | `GET()`                        |    66 |    30 | L6-71    |
+| `apps/web/lib/publications-data.ts`                                                    | `loadPublicationsData()`       |    66 |    30 | L94-159  |
+| `services/agent-api/src/cli.js`                                                        | `main()`                       |    61 |    30 | L33-93   |
+| `apps/web/pages/login.astro`                                                           | `if()`                         |    60 |    30 | L84-143  |
+| `services/agent-api/src/lib/tracing.js`                                                | `createTrace()`                |    59 |    30 | L67-125  |
+| `services/agent-api/src/lib/discovery-rss.js`                                          | `parseRSS()`                   |    57 |    30 | L40-96   |
+| `apps/admin/src/app/(dashboard)/items/search-bar.tsx`                                  | `SearchBar()`                  |    56 |    30 | L6-61    |
+| `services/agent-api/src/lib/embeddings.js`                                             | `buildReferenceEmbedding()`    |    52 |    30 | L114-165 |
+| `apps/admin/src/components/ui/sidebar/usePipelineActions.ts`                           | `usePipelineActions()`         |    51 |    30 | L5-55    |
+| `services/agent-api/src/scripts/backfill-tags.js`                                      | `main()`                       |    51 |    30 | L106-156 |
+| `services/agent-api/src/lib/llm.js`                                                    | `parseStructured()`            |    49 |    30 | L183-231 |
+| `services/agent-api/src/lib/llm.js`                                                    | `completeAnthropic()`          |    48 |    30 | L123-170 |
+| `apps/web/features/publications/filters/storage.ts`                                    | `readFromQuery()`              |    47 |    30 | L47-93   |
+| `apps/admin/src/app/(dashboard)/evals/head-to-head/hooks/useComparison.ts`             | `useComparison()`              |    46 |    30 | L23-68   |
+| `apps/web/features/publications/image-enhancement.ts`                                  | `enhanceImages()`              |    46 |    30 | L8-53    |
+| `services/agent-api/src/cli/commands/eval.js`                                          | `runEvalCmd()`                 |    46 |    30 | L15-60   |
+| `services/agent-api/src/cli/commands/health.js`                                        | `runQueueHealthCmd()`          |    46 |    30 | L11-56   |
+| `apps/admin/src/app/api/evals/head-to-head/route.ts`                                   | `POST()`                       |    45 |    30 | L8-52    |
+| `apps/admin/src/lib/supabase/middleware.ts`                                            | `updateSession()`              |    44 |    30 | L4-47    |
+| `services/agent-api/src/agents/discover-classics.js`                                   | `queuePaper()`                 |    44 |    30 | L122-165 |
+| `services/agent-api/src/lib/discovery-queue.js`                                        | `checkExists()`                |    44 |    30 | L34-77   |
+| `services/agent-api/src/lib/quality-scorer.js`                                         | `calculateQualityScore()`      |    44 |    30 | L79-122  |
+| `apps/admin/src/app/api/dashboard/stats/route.ts`                                      | `GET()`                        |    43 |    30 | L8-50    |
+| `apps/admin/src/app/api/test-prompt/route.ts`                                          | `POST()`                       |    43 |    30 | L8-50    |
+| `apps/web/components/BackToTopButton.astro`                                            | `if()`                         |    43 |    30 | L30-72   |
+| `services/agent-api/src/lib/vendor-loader.js`                                          | `loadVendors()`                |    42 |    30 | L17-58   |
+| `apps/web/lib/publications-data.ts`                                                    | `createValuesWithCounts()`     |    41 |    30 | L52-92   |
+| `services/agent-api/src/lib/discovery-scoring.js`                                      | `handleLlmScoring()`           |    41 |    30 | L117-157 |
+| `apps/admin/src/app/(dashboard)/add/handlers/validateForm.ts`                          | `validateForm()`               |    40 |    30 | L13-52   |
+| `apps/admin/src/app/(dashboard)/items/[id]/data-loaders.ts`                            | `getQueueItem()`               |    39 |    30 | L9-47    |
+| `apps/admin/src/app/api/entities/route.ts`                                             | `POST()`                       |    39 |    30 | L18-56   |
+| `apps/web/features/publications/multi-select-filters.handlers.ts`                      | `createCallbackCreators()`     |    39 |    30 | L139-177 |
+| `apps/web/pages/index.astro`                                                           | `enhanceImages()`              |    39 |    30 | L218-256 |
+| `apps/web/features/publications/filters/search.ts`                                     | `renderSearchHistory()`        |    38 |    30 | L24-61   |
+| `services/agent-api/src/agents/screener.js`                                            | `runRelevanceFilter()`         |    38 |    30 | L5-42    |
+| `services/agent-api/src/lib/discovery-queue.js`                                        | `insertToQueue()`              |    38 |    30 | L121-158 |
+| `services/agent-api/src/lib/discovery-scoring.js`                                      | `handleEmbeddingScoring()`     |    38 |    30 | L75-112  |
+| `apps/admin/src/app/(dashboard)/items/components/detail-panel/useDetailPanelData.ts`   | `useDetailPanelData()`         |    37 |    30 | L11-47   |
+| `apps/web/features/publications/card-expand.ts`                                        | `toggleCard()`                 |    37 |    30 | L6-42    |
+| `apps/web/features/publications/multi-filters/state.ts`                                | `loadFilters()`                |    37 |    30 | L53-89   |
+| `apps/admin/src/app/(dashboard)/agents/hooks/useResizablePanel.ts`                     | `useResizablePanel()`          |    36 |    30 | L5-40    |
+| `apps/admin/src/app/api/evals/llm-judge/route.ts`                                      | `POST()`                       |    36 |    30 | L7-42    |
+| `apps/web/features/publications/hierarchy-cascade.ts`                                  | `updateParentState()`          |    36 |    30 | L55-90   |
+| `services/agent-api/src/cli/utils.js`                                                  | `parseArgs()`                  |    36 |    30 | L12-47   |
+| `services/agent-api/src/lib/premium-handler.js`                                        | `buildPremiumPayload()`        |    36 |    30 | L132-167 |
+| `services/agent-api/src/lib/tracing.js`                                                | `traceLLMCall()`               |    36 |    30 | L139-174 |
+| `services/agent-api/src/lib/discovery-queue.js`                                        | `retryRejected()`              |    35 |    30 | L82-116  |
+| `apps/admin/src/app/(dashboard)/agents/[agent]/hooks/useAgentPrompts.ts`               | `useAgentPrompts()`            |    34 |    30 | L5-38    |
+| `apps/web/features/publications/hierarchy-cascade.ts`                                  | `initHierarchyCascade()`       |    34 |    30 | L10-43   |
+| `apps/web/pages/index.astro`                                                           | `initAudienceFilter()`         |    34 |    30 | L173-206 |
+| `services/agent-api/src/agents/orchestrator.js`                                        | `processQueue()`               |    34 |    30 | L129-162 |
+| `services/agent-api/src/lib/prompt-eval.js`                                            | `runExamples()`                |    34 |    30 | L113-146 |
+| `services/agent-api/src/routes/evals.js`                                               | `for()`                        |    34 |    30 | L144-177 |
+| `apps/admin/src/app/api/process-queue/route.ts`                                        | `POST()`                       |    33 |    30 | L6-38    |
+| `services/agent-api/src/agents/orchestrator.js`                                        | `enrichItem()`                 |    33 |    30 | L95-127  |
+| `services/agent-api/src/lib/discovery-scoring.js`                                      | `processCandidate()`           |    33 |    30 | L15-47   |
+| `apps/admin/src/app/api/queue-item/[id]/route.ts`                                      | `GET()`                        |    32 |    30 | L6-37    |
+| `services/agent-api/src/lib/premium-handler.js`                                        | `extractRssPreview()`          |    32 |    30 | L92-123  |
+| `services/agent-api/src/lib/quality-scorer.js`                                         | `enrichWithCitations()`        |    32 |    30 | L129-160 |
+| `apps/admin/src/components/ui/sidebar/useSidebarEffects.ts`                            | `useSidebarEffects()`          |    31 |    30 | L3-33    |
+| `services/agent-api/src/lib/llm.js`                                                    | `completeOpenAI()`             |    31 |    30 | L88-118  |
+| `services/agent-api/src/lib/prompt-eval.js`                                            | `createEvalRun()`              |    31 |    30 | L78-108  |

--- a/docs/architecture/quality/nightly-param-counts.md
+++ b/docs/architecture/quality/nightly-param-counts.md
@@ -1,0 +1,18 @@
+# High Parameter Count Report
+
+> Auto-generated on 2026-01-05 by nightly quality workflow
+
+Functions with >=6 parameters (blocking threshold)
+
+## Summary
+
+- **Total functions with >=6 params:** 3
+- **Files affected:** 2
+
+## Functions
+
+| File                                              | Function              | Params | Location |
+| ------------------------------------------------- | --------------------- | -----: | -------- |
+| `services/agent-api/src/lib/discovery-scoring.js` | `scoreCandidate()`    |      6 | L52-70   |
+| `services/agent-api/src/lib/discovery-scoring.js` | `processCandidates()` |      6 | L196-224 |
+| `services/agent-api/src/lib/pipeline-tracking.js` | `logFailure()`        |      6 | L179-192 |

--- a/docs/architecture/quality/nightly-summary.md
+++ b/docs/architecture/quality/nightly-summary.md
@@ -1,0 +1,22 @@
+# Quality Metrics Summary
+
+> Auto-generated on 2026-01-05 by nightly quality workflow
+
+## Overview
+
+| Metric                     | Count | Status |
+| -------------------------- | ----: | ------ |
+| Large files (>limit)       |     4 | ⚠️     |
+| Large functions (>limit)   |    87 | ⚠️     |
+| High param functions (>=6) |     3 | ⚠️     |
+| Total files scanned        |   530 |        |
+
+## Detailed Reports
+
+- [Large Files](./nightly-large-files.md)
+- [Large Functions](./nightly-large-functions.md)
+- [High Parameter Counts](./nightly-param-counts.md)
+
+## Trends
+
+_Historical trend tracking coming soon_

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "check:links": "node scripts/dev/check-links.mjs",
     "dump:schema": "node scripts/dev/dump-schema.mjs",
     "check:large-files": "node scripts/ci/check-large-files.cjs",
+    "quality:report": "node scripts/ci/quality-report.cjs",
     "publish:approved": "node scripts/ops/publish-approved.mjs",
     "lhci": "npx @lhci/cli@0.14.0 autorun --config=.lighthouserc.json",
     "prepare": "node -e \"try { require('husky').default() } catch (e) { if (e.code !== 'MODULE_NOT_FOUND') console.log(e) }\""

--- a/scripts/ci/quality-report.cjs
+++ b/scripts/ci/quality-report.cjs
@@ -1,0 +1,243 @@
+/**
+ * Quality Report Generator
+ *
+ * Scans the entire codebase and generates Markdown reports for:
+ * - Large files (>300 lines for source, >500 for tests)
+ * - Large functions (>30 lines for source, >50 for tests)
+ * - Functions with too many parameters (>=6)
+ *
+ * Output: docs/architecture/quality/nightly-*.md
+ *
+ * Usage: node scripts/ci/quality-report.cjs
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
+const { findUnits } = require('../lib/unit-detector.cjs');
+
+const LANGUAGE_LIMITS = {
+  js: { file: 300, unit: 30, unitExcellent: 15 },
+  ts: { file: 300, unit: 30, unitExcellent: 15 },
+  tsx: { file: 300, unit: 30, unitExcellent: 15 },
+  jsx: { file: 300, unit: 30, unitExcellent: 15 },
+  astro: { file: 300, unit: 30, unitExcellent: 15 },
+  default: { file: 300, unit: 30, unitExcellent: 15 },
+};
+
+const TEST_LIMITS = {
+  js: { file: 500, unit: 50, unitExcellent: 30 },
+  ts: { file: 500, unit: 50, unitExcellent: 30 },
+  tsx: { file: 500, unit: 50, unitExcellent: 30 },
+  jsx: { file: 500, unit: 50, unitExcellent: 30 },
+  default: { file: 500, unit: 50, unitExcellent: 30 },
+};
+
+const PARAM_LIMITS = { optimal: 3, warn: 5, block: 6, maxDestructuredKeys: 7 };
+const ALLOWED_EXT = new Set(['.ts', '.js', '.tsx', '.jsx', '.astro']);
+const ALLOWED_PREFIXES = ['apps/web/', 'apps/admin/src/', 'services/agent-api/'];
+const OUTPUT_DIR = 'docs/architecture/quality';
+
+function normalizePath(p) {
+  return p.replaceAll('\\', '/');
+}
+
+function isTestFile(filePath) {
+  const f = normalizePath(filePath);
+  return (
+    f.includes('__tests__/') || f.includes('.test.') || f.includes('.spec.') || /\/tests?\//.test(f)
+  );
+}
+
+function getLimits(filePath) {
+  const ext = path.extname(filePath).slice(1).toLowerCase();
+  const limits = isTestFile(filePath) ? TEST_LIMITS : LANGUAGE_LIMITS;
+  return limits[ext] || limits.default;
+}
+
+function matchesPattern(file) {
+  const f = normalizePath(file);
+  const ext = path.extname(f).toLowerCase();
+  if (!ALLOWED_EXT.has(ext)) return false;
+  if (
+    f.includes('dist/') ||
+    f.includes('build/') ||
+    f.includes('.astro/') ||
+    f.includes('node_modules/')
+  )
+    return false;
+  return ALLOWED_PREFIXES.some((prefix) => f.startsWith(prefix));
+}
+
+function getAllFiles() {
+  const output = execSync('git ls-files', { encoding: 'utf8' });
+  return output.trim().split('\n').filter(Boolean).filter(matchesPattern);
+}
+
+function analyzeFile(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+  const lineCount = lines.length;
+  const limits = getLimits(filePath);
+  const units = findUnits(content);
+
+  const unitsWithParams = units.map((u) => {
+    const paramCount = Number.isFinite(u.paramCount) ? u.paramCount : 0;
+    const destructuredKeysCount = Number.isFinite(u.destructuredKeysCount)
+      ? u.destructuredKeysCount
+      : 0;
+    const effectiveParamCount =
+      destructuredKeysCount > PARAM_LIMITS.maxDestructuredKeys ? destructuredKeysCount : paramCount;
+    return { ...u, paramCount, destructuredKeysCount, effectiveParamCount };
+  });
+
+  const largeUnits = unitsWithParams.filter((u) => u.length > limits.unit);
+  const largeParamUnits = unitsWithParams.filter(
+    (u) => u.effectiveParamCount >= PARAM_LIMITS.block,
+  );
+
+  return {
+    filePath,
+    lineCount,
+    limits,
+    units: { all: unitsWithParams, large: largeUnits, largeParams: largeParamUnits },
+    exceedsFileLimit: lineCount > limits.file,
+  };
+}
+
+function generateLargeFilesReport(results) {
+  const largeFiles = results
+    .filter((r) => r.exceedsFileLimit)
+    .sort((a, b) => b.lineCount - a.lineCount);
+  const date = new Date().toISOString().split('T')[0];
+
+  let md = `# Large Files Report\n\n`;
+  md += `> Auto-generated on ${date} by nightly quality workflow\n\n`;
+  md += `Files exceeding size limits (source: 300 lines, test: 500 lines)\n\n`;
+  md += `## Summary\n\n`;
+  md += `- **Total large files:** ${largeFiles.length}\n\n`;
+
+  if (largeFiles.length === 0) {
+    md += `✅ No files exceed size limits!\n`;
+  } else {
+    md += `## Files\n\n`;
+    md += `| File | Lines | Limit | Over by |\n`;
+    md += `|------|------:|------:|--------:|\n`;
+    for (const r of largeFiles) {
+      md += `| \`${r.filePath}\` | ${r.lineCount} | ${r.limits.file} | +${r.lineCount - r.limits.file} |\n`;
+    }
+  }
+
+  return md;
+}
+
+function generateLargeFunctionsReport(results) {
+  const filesWithLargeUnits = results.filter((r) => r.units.large.length > 0);
+  const allLargeUnits = filesWithLargeUnits.flatMap((r) =>
+    r.units.large.map((u) => ({ ...u, filePath: r.filePath, limits: r.limits })),
+  );
+  allLargeUnits.sort((a, b) => b.length - a.length);
+  const date = new Date().toISOString().split('T')[0];
+
+  let md = `# Large Functions Report\n\n`;
+  md += `> Auto-generated on ${date} by nightly quality workflow\n\n`;
+  md += `Functions exceeding size limits (source: 30 lines, test: 50 lines)\n\n`;
+  md += `## Summary\n\n`;
+  md += `- **Total large functions:** ${allLargeUnits.length}\n`;
+  md += `- **Files affected:** ${filesWithLargeUnits.length}\n\n`;
+
+  if (allLargeUnits.length === 0) {
+    md += `✅ No functions exceed size limits!\n`;
+  } else {
+    md += `## Functions\n\n`;
+    md += `| File | Function | Lines | Limit | Location |\n`;
+    md += `|------|----------|------:|------:|----------|\n`;
+    for (const u of allLargeUnits) {
+      md += `| \`${u.filePath}\` | \`${u.name}()\` | ${u.length} | ${u.limits.unit} | L${u.startLine}-${u.endLine} |\n`;
+    }
+  }
+
+  return md;
+}
+
+function generateParamCountsReport(results) {
+  const filesWithLargeParams = results.filter((r) => r.units.largeParams.length > 0);
+  const allLargeParamUnits = filesWithLargeParams.flatMap((r) =>
+    r.units.largeParams.map((u) => ({ ...u, filePath: r.filePath })),
+  );
+  allLargeParamUnits.sort((a, b) => b.effectiveParamCount - a.effectiveParamCount);
+  const date = new Date().toISOString().split('T')[0];
+
+  let md = `# High Parameter Count Report\n\n`;
+  md += `> Auto-generated on ${date} by nightly quality workflow\n\n`;
+  md += `Functions with >=6 parameters (blocking threshold)\n\n`;
+  md += `## Summary\n\n`;
+  md += `- **Total functions with >=6 params:** ${allLargeParamUnits.length}\n`;
+  md += `- **Files affected:** ${filesWithLargeParams.length}\n\n`;
+
+  if (allLargeParamUnits.length === 0) {
+    md += `✅ No functions exceed parameter limits!\n`;
+  } else {
+    md += `## Functions\n\n`;
+    md += `| File | Function | Params | Location |\n`;
+    md += `|------|----------|-------:|----------|\n`;
+    for (const u of allLargeParamUnits) {
+      const label =
+        u.destructuredKeysCount > PARAM_LIMITS.maxDestructuredKeys
+          ? `${u.effectiveParamCount} keys`
+          : `${u.effectiveParamCount}`;
+      md += `| \`${u.filePath}\` | \`${u.name}()\` | ${label} | L${u.startLine}-${u.endLine} |\n`;
+    }
+  }
+
+  return md;
+}
+
+function generateSummaryReport(results) {
+  const largeFiles = results.filter((r) => r.exceedsFileLimit);
+  const totalLargeUnits = results.reduce((acc, r) => acc + r.units.large.length, 0);
+  const totalLargeParams = results.reduce((acc, r) => acc + r.units.largeParams.length, 0);
+  const date = new Date().toISOString().split('T')[0];
+
+  let md = `# Quality Metrics Summary\n\n`;
+  md += `> Auto-generated on ${date} by nightly quality workflow\n\n`;
+  md += `## Overview\n\n`;
+  md += `| Metric | Count | Status |\n`;
+  md += `|--------|------:|--------|\n`;
+  md += `| Large files (>limit) | ${largeFiles.length} | ${largeFiles.length === 0 ? '✅' : '⚠️'} |\n`;
+  md += `| Large functions (>limit) | ${totalLargeUnits} | ${totalLargeUnits === 0 ? '✅' : '⚠️'} |\n`;
+  md += `| High param functions (>=6) | ${totalLargeParams} | ${totalLargeParams === 0 ? '✅' : '⚠️'} |\n`;
+  md += `| Total files scanned | ${results.length} | |\n\n`;
+  md += `## Detailed Reports\n\n`;
+  md += `- [Large Files](./nightly-large-files.md)\n`;
+  md += `- [Large Functions](./nightly-large-functions.md)\n`;
+  md += `- [High Parameter Counts](./nightly-param-counts.md)\n\n`;
+  md += `## Trends\n\n`;
+  md += `_Historical trend tracking coming soon_\n`;
+
+  return md;
+}
+
+function writeReport(filename, content) {
+  const filePath = path.join(OUTPUT_DIR, filename);
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf8');
+  console.log(`  ✅ ${filePath}`);
+}
+
+try {
+  console.log('📊 Generating Quality Reports...\n');
+  const files = getAllFiles();
+  console.log(`  Scanning ${files.length} files...\n`);
+
+  const results = files.map(analyzeFile);
+
+  writeReport('nightly-summary.md', generateSummaryReport(results));
+  writeReport('nightly-large-files.md', generateLargeFilesReport(results));
+  writeReport('nightly-large-functions.md', generateLargeFunctionsReport(results));
+  writeReport('nightly-param-counts.md', generateParamCountsReport(results));
+
+  console.log('\n✅ Quality reports generated successfully!\n');
+} catch (error) {
+  console.error('Error generating quality reports:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

No automated way to track and report quality metrics (large files, large functions, high parameter counts) across the codebase over time.

## Solution

Added a GitHub Actions scheduled workflow that runs nightly to scan the entire codebase and generate Markdown reports in `docs/architecture/quality/`.

### Components

1. **`scripts/ci/quality-report.cjs`** - Scans all tracked files and generates:
   - `nightly-summary.md` - Overview with counts and status
   - `nightly-large-files.md` - Files exceeding line limits
   - `nightly-large-functions.md` - Functions exceeding line limits
   - `nightly-param-counts.md` - Functions with >=6 parameters

2. **`.github/workflows/nightly-quality.yml`** - Scheduled workflow (02:30 UTC daily) that:
   - Runs the quality report script
   - Auto-commits updated reports to the repo

3. **`npm run quality:report`** - Manual script for local report generation

## Files Changed

- `scripts/ci/quality-report.cjs` - New quality report generator
- `.github/workflows/nightly-quality.yml` - New scheduled workflow
- `package.json` - Added `quality:report` npm script
- `docs/architecture/quality/nightly-*.md` - Generated reports (4 files)

## Verification

- Tested locally: `npm run quality:report` generates reports successfully
- Lint passed: `npm run lint`
