### PR TITLE
refactor: split admin A/B tests page

### DIFF
--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-header.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-header.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+interface AbTestsHeaderProps {
+  onCreate: () => void;
+}
+
+export function AbTestsHeader({ onCreate }: Readonly<AbTestsHeaderProps>) {
+  return (
+    <header className="mb-6 flex items-center justify-between">
+      <div>
+        <h1 className="text-2xl font-bold text-white">A/B Testing</h1>
+        <p className="mt-1 text-sm text-neutral-400">
+          Compare prompt versions with traffic splitting
+        </p>
+      </div>
+      <button
+        onClick={onCreate}
+        className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500"
+      >
+        + New Test
+      </button>
+    </header>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-modals.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-modals.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import type { PromptABTest, PromptVersion } from '@/types/database';
+import { CreateTestModal } from './create-test-modal';
+import { TestDetailModal } from './test-detail-modal';
+
+interface AbTestsModalsProps {
+  showCreateModal: boolean;
+  agents: string[];
+  prompts: PromptVersion[];
+  selectedTest: PromptABTest | null;
+  onCloseCreate: () => void;
+  onCreated: () => void;
+  onCloseSelected: () => void;
+  onUpdated: () => void;
+}
+
+export function AbTestsModals({
+  showCreateModal,
+  agents,
+  prompts,
+  selectedTest,
+  onCloseCreate,
+  onCreated,
+  onCloseSelected,
+  onUpdated,
+}: Readonly<AbTestsModalsProps>) {
+  return (
+    <>
+      {showCreateModal && (
+        <CreateTestModal
+          agents={agents}
+          prompts={prompts}
+          onClose={onCloseCreate}
+          onCreated={onCreated}
+        />
+      )}
+
+      {selectedTest && (
+        <TestDetailModal test={selectedTest} onClose={onCloseSelected} onUpdate={onUpdated} />
+      )}
+    </>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-stats.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-stats.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import type { PromptABTest } from '@/types/database';
+
+interface AbTestsStatsProps {
+  tests: PromptABTest[];
+}
+
+function StatCard({
+  label,
+  value,
+  valueClassName,
+}: {
+  label: string;
+  value: string | number;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="rounded-lg bg-neutral-800/50 p-4 text-center">
+      <div className={valueClassName || 'text-2xl font-bold text-white'}>{value}</div>
+      <div className="text-xs text-neutral-500">{label}</div>
+    </div>
+  );
+}
+
+export function AbTestsStats({ tests }: Readonly<AbTestsStatsProps>) {
+  const running = tests.filter((t) => t.status === 'running').length;
+  const completed = tests.filter((t) => t.status === 'completed').length;
+  const items = tests.reduce((sum, t) => sum + (t.items_processed || 0), 0);
+
+  return (
+    <div className="grid grid-cols-4 gap-4 mb-6">
+      <StatCard label="Total Tests" value={tests.length} />
+      <StatCard
+        label="Running"
+        value={running}
+        valueClassName="text-2xl font-bold text-emerald-400"
+      />
+      <StatCard
+        label="Completed"
+        value={completed}
+        valueClassName="text-2xl font-bold text-sky-400"
+      />
+      <StatCard
+        label="Items Tested"
+        value={items}
+        valueClassName="text-2xl font-bold text-amber-400"
+      />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-table.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-table.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import type { PromptABTest } from '@/types/database';
+
+interface AbTestsTableProps {
+  tests: PromptABTest[];
+  onSelect: (test: PromptABTest) => void;
+}
+
+function getStatusColor(status: string) {
+  const colors: Record<string, string> = {
+    draft: 'bg-neutral-500/20 text-neutral-300',
+    running: 'bg-emerald-500/20 text-emerald-300',
+    paused: 'bg-amber-500/20 text-amber-300',
+    completed: 'bg-sky-500/20 text-sky-300',
+    cancelled: 'bg-red-500/20 text-red-300',
+  };
+  return colors[status] || colors.draft;
+}
+
+function formatTestName(test: PromptABTest) {
+  return test.name || `Test ${test.id.slice(0, 8)}`;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString();
+}
+
+function ProgressBar({ processed, sampleSize }: { processed: number; sampleSize: number }) {
+  const ratio = sampleSize > 0 ? processed / sampleSize : 0;
+  const width = Math.max(0, Math.min(100, ratio * 100));
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-2 bg-neutral-700 rounded-full overflow-hidden">
+        <div className="h-full bg-sky-500" style={{ width: `${width}%` }} />
+      </div>
+      <span className="text-xs text-neutral-400">
+        {processed}/{sampleSize}
+      </span>
+    </div>
+  );
+}
+
+function WinnerCell({ winner }: { winner: PromptABTest['winner'] }) {
+  if (!winner) return <span className="text-neutral-500">-</span>;
+  const className = winner === 'a' ? 'text-emerald-400' : 'text-amber-400';
+  return <span className={`font-medium ${className}`}>Variant {winner.toUpperCase()}</span>;
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-12 text-center">
+      <p className="text-neutral-400">No A/B tests yet</p>
+      <p className="text-sm text-neutral-600 mt-1">Create a test to compare two prompt versions</p>
+    </div>
+  );
+}
+
+function TableHeader() {
+  return (
+    <thead className="bg-neutral-900">
+      <tr className="text-left text-xs font-medium uppercase tracking-wider text-neutral-400">
+        <th className="px-4 py-3">Test</th>
+        <th className="px-4 py-3">Agent</th>
+        <th className="px-4 py-3">Variants</th>
+        <th className="px-4 py-3">Progress</th>
+        <th className="px-4 py-3">Status</th>
+        <th className="px-4 py-3">Winner</th>
+        <th className="px-4 py-3">Actions</th>
+      </tr>
+    </thead>
+  );
+}
+
+function VariantsCell({ test }: { test: PromptABTest }) {
+  return (
+    <td className="px-4 py-3">
+      <div className="text-xs">
+        <span className="text-emerald-400">A:</span> {test.variant_a_version}
+      </div>
+      <div className="text-xs">
+        <span className="text-amber-400">B:</span> {test.variant_b_version}
+      </div>
+    </td>
+  );
+}
+
+function TestInfoCell({ test }: { test: PromptABTest }) {
+  return (
+    <td className="px-4 py-3">
+      <div className="font-medium text-white">{formatTestName(test)}</div>
+      <div className="text-xs text-neutral-500">{formatDate(test.created_at)}</div>
+    </td>
+  );
+}
+
+function ProgressCell({ test }: { test: PromptABTest }) {
+  return (
+    <td className="px-4 py-3">
+      <ProgressBar processed={test.items_processed || 0} sampleSize={test.sample_size} />
+    </td>
+  );
+}
+
+function StatusCell({ status }: { status: string }) {
+  return (
+    <td className="px-4 py-3">
+      <span className={`rounded-full px-2 py-0.5 text-xs ${getStatusColor(status)}`}>{status}</span>
+    </td>
+  );
+}
+
+function ActionCell({ onClick }: { onClick: () => void }) {
+  return (
+    <td className="px-4 py-3">
+      <button onClick={onClick} className="text-sky-400 hover:text-sky-300 text-sm">
+        View
+      </button>
+    </td>
+  );
+}
+
+function TestRow({
+  test,
+  onSelect,
+}: {
+  test: PromptABTest;
+  onSelect: (test: PromptABTest) => void;
+}) {
+  return (
+    <tr key={test.id} className="hover:bg-neutral-800/50">
+      <TestInfoCell test={test} />
+      <td className="px-4 py-3 text-neutral-300">{test.agent_name}</td>
+      <VariantsCell test={test} />
+      <ProgressCell test={test} />
+      <StatusCell status={test.status} />
+      <td className="px-4 py-3">
+        <WinnerCell winner={test.winner} />
+      </td>
+      <ActionCell onClick={() => onSelect(test)} />
+    </tr>
+  );
+}
+
+export function AbTestsTable({ tests, onSelect }: Readonly<AbTestsTableProps>) {
+  if (tests.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="rounded-xl border border-neutral-800 overflow-hidden">
+      <table className="w-full">
+        <TableHeader />
+        <tbody className="divide-y divide-neutral-800">
+          {tests.map((test) => (
+            <TestRow key={test.id} test={test} onSelect={onSelect} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/page.tsx
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/page.tsx
@@ -1,215 +1,95 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
-import { createClient } from '@/lib/supabase/client';
-import type { PromptABTest, PromptVersion } from '@/types/database';
-import { CreateTestModal } from './create-test-modal';
-import { TestDetailModal } from './test-detail-modal';
+import { AbTestsHeader } from './ab-tests-header';
+import { AbTestsStats } from './ab-tests-stats';
+import { AbTestsTable } from './ab-tests-table';
+import { AbTestsModals } from './ab-tests-modals';
+import { useAbTestsData } from './use-ab-tests-data';
+import { useAbTestsPageState } from './use-ab-tests-page-state';
 
-export default function ABTestsPage() {
-  const [tests, setTests] = useState<PromptABTest[]>([]);
-  const [prompts, setPrompts] = useState<PromptVersion[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [showCreateModal, setShowCreateModal] = useState(false);
-  const [selectedTest, setSelectedTest] = useState<PromptABTest | null>(null);
+function LoadingState() {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <div className="text-neutral-400">Loading A/B tests...</div>
+    </div>
+  );
+}
 
-  const supabase = createClient();
+function useReloadHandlers(opts: {
+  reload: () => Promise<void>;
+  closeCreate: () => void;
+  clearSelected: () => void;
+}) {
+  const { reload, closeCreate, clearSelected } = opts;
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
-
-    const [testsRes, promptsRes] = await Promise.all([
-      supabase.from('prompt_ab_test').select('*').order('created_at', { ascending: false }),
-      supabase.from('prompt_version').select('*').order('agent_name'),
-    ]);
-
-    if (!testsRes.error) setTests(testsRes.data || []);
-    if (!promptsRes.error) setPrompts(promptsRes.data || []);
-
-    setLoading(false);
-  }, [supabase]);
-
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
-
-  const getStatusColor = (status: string) => {
-    const colors: Record<string, string> = {
-      draft: 'bg-neutral-500/20 text-neutral-300',
-      running: 'bg-emerald-500/20 text-emerald-300',
-      paused: 'bg-amber-500/20 text-amber-300',
-      completed: 'bg-sky-500/20 text-sky-300',
-      cancelled: 'bg-red-500/20 text-red-300',
-    };
-    return colors[status] || colors.draft;
+  const onCreated = async () => {
+    closeCreate();
+    await reload();
   };
 
-  const agents = [...new Set(prompts.map((p) => p.agent_name))];
+  const onUpdated = async () => {
+    clearSelected();
+    await reload();
+  };
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-neutral-400">Loading A/B tests...</div>
-      </div>
-    );
-  }
+  return { onCreated, onUpdated };
+}
+
+function useAbTestsPageController(opts: { reload: () => Promise<void> }) {
+  const pageState = useAbTestsPageState();
+  const handlers = useReloadHandlers({
+    reload: opts.reload,
+    closeCreate: pageState.closeCreate,
+    clearSelected: pageState.clearSelected,
+  });
+
+  const onCreated = () => {
+    handlers.onCreated().catch(() => {});
+  };
+  const onUpdated = () => {
+    handlers.onUpdated().catch(() => {});
+  };
+
+  return { pageState, onCreated, onUpdated };
+}
+
+function AbTestsMain({
+  tests,
+  onCreate,
+  onSelect,
+}: Readonly<{
+  tests: ReturnType<typeof useAbTestsData>['tests'];
+  onCreate: () => void;
+  onSelect: (test: ReturnType<typeof useAbTestsData>['tests'][number]) => void;
+}>) {
+  return (
+    <>
+      <AbTestsHeader onCreate={onCreate} />
+      <AbTestsStats tests={tests} />
+      <AbTestsTable tests={tests} onSelect={onSelect} />
+    </>
+  );
+}
+
+export default function ABTestsPage() {
+  const { tests, prompts, loading, agents, reload } = useAbTestsData();
+  const { pageState, onCreated, onUpdated } = useAbTestsPageController({ reload });
+
+  if (loading) return <LoadingState />;
 
   return (
-    <div>
-      {/* Header */}
-      <header className="mb-6 flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-white">A/B Testing</h1>
-          <p className="mt-1 text-sm text-neutral-400">
-            Compare prompt versions with traffic splitting
-          </p>
-        </div>
-        <button
-          onClick={() => setShowCreateModal(true)}
-          className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500"
-        >
-          + New Test
-        </button>
-      </header>
-
-      {/* Stats */}
-      <div className="grid grid-cols-4 gap-4 mb-6">
-        <div className="rounded-lg bg-neutral-800/50 p-4 text-center">
-          <div className="text-2xl font-bold text-white">{tests.length}</div>
-          <div className="text-xs text-neutral-500">Total Tests</div>
-        </div>
-        <div className="rounded-lg bg-neutral-800/50 p-4 text-center">
-          <div className="text-2xl font-bold text-emerald-400">
-            {tests.filter((t) => t.status === 'running').length}
-          </div>
-          <div className="text-xs text-neutral-500">Running</div>
-        </div>
-        <div className="rounded-lg bg-neutral-800/50 p-4 text-center">
-          <div className="text-2xl font-bold text-sky-400">
-            {tests.filter((t) => t.status === 'completed').length}
-          </div>
-          <div className="text-xs text-neutral-500">Completed</div>
-        </div>
-        <div className="rounded-lg bg-neutral-800/50 p-4 text-center">
-          <div className="text-2xl font-bold text-amber-400">
-            {tests.reduce((sum, t) => sum + (t.items_processed || 0), 0)}
-          </div>
-          <div className="text-xs text-neutral-500">Items Tested</div>
-        </div>
-      </div>
-
-      {/* Tests List */}
-      {tests.length === 0 ? (
-        <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 p-12 text-center">
-          <p className="text-neutral-400">No A/B tests yet</p>
-          <p className="text-sm text-neutral-600 mt-1">
-            Create a test to compare two prompt versions
-          </p>
-        </div>
-      ) : (
-        <div className="rounded-xl border border-neutral-800 overflow-hidden">
-          <table className="w-full">
-            <thead className="bg-neutral-900">
-              <tr className="text-left text-xs font-medium uppercase tracking-wider text-neutral-400">
-                <th className="px-4 py-3">Test</th>
-                <th className="px-4 py-3">Agent</th>
-                <th className="px-4 py-3">Variants</th>
-                <th className="px-4 py-3">Progress</th>
-                <th className="px-4 py-3">Status</th>
-                <th className="px-4 py-3">Winner</th>
-                <th className="px-4 py-3">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-neutral-800">
-              {tests.map((test) => (
-                <tr key={test.id} className="hover:bg-neutral-800/50">
-                  <td className="px-4 py-3">
-                    <div className="font-medium text-white">
-                      {test.name || `Test ${test.id.slice(0, 8)}`}
-                    </div>
-                    <div className="text-xs text-neutral-500">
-                      {new Date(test.created_at).toLocaleDateString()}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-neutral-300">{test.agent_name}</td>
-                  <td className="px-4 py-3">
-                    <div className="text-xs">
-                      <span className="text-emerald-400">A:</span> {test.variant_a_version}
-                    </div>
-                    <div className="text-xs">
-                      <span className="text-amber-400">B:</span> {test.variant_b_version}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <div className="flex-1 h-2 bg-neutral-700 rounded-full overflow-hidden">
-                        <div
-                          className="h-full bg-sky-500"
-                          style={{ width: `${(test.items_processed / test.sample_size) * 100}%` }}
-                        />
-                      </div>
-                      <span className="text-xs text-neutral-400">
-                        {test.items_processed}/{test.sample_size}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`rounded-full px-2 py-0.5 text-xs ${getStatusColor(test.status)}`}
-                    >
-                      {test.status}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    {test.winner ? (
-                      <span
-                        className={`font-medium ${test.winner === 'a' ? 'text-emerald-400' : 'text-amber-400'}`}
-                      >
-                        Variant {test.winner.toUpperCase()}
-                      </span>
-                    ) : (
-                      <span className="text-neutral-500">-</span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3">
-                    <button
-                      onClick={() => setSelectedTest(test)}
-                      className="text-sky-400 hover:text-sky-300 text-sm"
-                    >
-                      View
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {/* Create Modal */}
-      {showCreateModal && (
-        <CreateTestModal
-          agents={agents}
-          prompts={prompts}
-          onClose={() => setShowCreateModal(false)}
-          onCreated={() => {
-            setShowCreateModal(false);
-            loadData();
-          }}
-        />
-      )}
-
-      {/* Detail Modal */}
-      {selectedTest && (
-        <TestDetailModal
-          test={selectedTest}
-          onClose={() => setSelectedTest(null)}
-          onUpdate={() => {
-            setSelectedTest(null);
-            loadData();
-          }}
-        />
-      )}
-    </div>
+    <>
+      <AbTestsMain tests={tests} onCreate={pageState.openCreate} onSelect={pageState.selectTest} />
+      <AbTestsModals
+        showCreateModal={pageState.showCreateModal}
+        agents={agents}
+        prompts={prompts}
+        selectedTest={pageState.selectedTest}
+        onCloseCreate={pageState.closeCreate}
+        onCreated={onCreated}
+        onCloseSelected={pageState.clearSelected}
+        onUpdated={onUpdated}
+      />
+    </>
   );
 }

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/use-ab-tests-data.ts
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/use-ab-tests-data.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { PromptABTest, PromptVersion } from '@/types/database';
+
+export interface AbTestsDataState {
+  tests: PromptABTest[];
+  prompts: PromptVersion[];
+  loading: boolean;
+  agents: string[];
+  reload: () => Promise<void>;
+}
+
+function useSupabaseClient() {
+  return useMemo(() => createClient(), []);
+}
+
+function useAgents(prompts: PromptVersion[]) {
+  return useMemo(() => {
+    return [...new Set(prompts.map((p) => p.agent_name))];
+  }, [prompts]);
+}
+
+function useAbTestsState() {
+  const [tests, setTests] = useState<PromptABTest[]>([]);
+  const [prompts, setPrompts] = useState<PromptVersion[]>([]);
+  const [loading, setLoading] = useState(true);
+  return { tests, setTests, prompts, setPrompts, loading, setLoading };
+}
+
+function useReloadData(opts: {
+  supabase: ReturnType<typeof createClient>;
+  setLoading: (value: boolean) => void;
+  setTests: (tests: PromptABTest[]) => void;
+  setPrompts: (prompts: PromptVersion[]) => void;
+}) {
+  const { supabase, setLoading, setTests, setPrompts } = opts;
+
+  return useCallback(async () => {
+    setLoading(true);
+
+    const [testsRes, promptsRes] = await Promise.all([
+      supabase.from('prompt_ab_test').select('*').order('created_at', { ascending: false }),
+      supabase.from('prompt_version').select('*').order('agent_name'),
+    ]);
+
+    if (!testsRes.error) setTests(testsRes.data || []);
+    if (!promptsRes.error) setPrompts(promptsRes.data || []);
+
+    setLoading(false);
+  }, [setLoading, setPrompts, setTests, supabase]);
+}
+
+export function useAbTestsData(): AbTestsDataState {
+  const state = useAbTestsState();
+  const supabase = useSupabaseClient();
+  const reload = useReloadData({
+    supabase,
+    setLoading: state.setLoading,
+    setTests: state.setTests,
+    setPrompts: state.setPrompts,
+  });
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const agents = useAgents(state.prompts);
+
+  return {
+    tests: state.tests,
+    prompts: state.prompts,
+    loading: state.loading,
+    agents,
+    reload,
+  };
+}

--- a/apps/admin/src/app/(dashboard)/evals/ab-tests/use-ab-tests-page-state.ts
+++ b/apps/admin/src/app/(dashboard)/evals/ab-tests/use-ab-tests-page-state.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { PromptABTest } from '@/types/database';
+
+export interface AbTestsPageState {
+  showCreateModal: boolean;
+  selectedTest: PromptABTest | null;
+  openCreate: () => void;
+  closeCreate: () => void;
+  selectTest: (test: PromptABTest) => void;
+  clearSelected: () => void;
+}
+
+export function useAbTestsPageState(): AbTestsPageState {
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [selectedTest, setSelectedTest] = useState<PromptABTest | null>(null);
+
+  const openCreate = useCallback(() => setShowCreateModal(true), []);
+  const closeCreate = useCallback(() => setShowCreateModal(false), []);
+  const selectTest = useCallback((test: PromptABTest) => setSelectedTest(test), []);
+  const clearSelected = useCallback(() => setSelectedTest(null), []);
+
+  return {
+    showCreateModal,
+    selectedTest,
+    openCreate,
+    closeCreate,
+    selectTest,
+    clearSelected,
+  };
+}


### PR DESCRIPTION
## Problem

`apps/admin/src/app/(dashboard)/evals/ab-tests/page.tsx` exceeded code size guidelines and was difficult to maintain (single large component with embedded table + modal wiring).

## Root Cause

The page mixed data loading, UI rendering, and modal state management in one component, producing large functions and a large file.

## Solution

Split the A/B tests page into small focused modules:

- Extracted data loading into `useAbTestsData`
- Extracted UI into `AbTestsHeader`, `AbTestsStats`, `AbTestsTable`
- Extracted modal wiring into `AbTestsModals`
- Extracted local modal selection state into `useAbTestsPageState`

All touched functions are now <30 lines and parameter counts remain below 6.

## Files Changed
- `apps/admin/src/app/(dashboard)/evals/ab-tests/page.tsx` - Thin wrapper page
- `apps/admin/src/app/(dashboard)/evals/ab-tests/use-ab-tests-data.ts` - Data loading hook
- `apps/admin/src/app/(dashboard)/evals/ab-tests/use-ab-tests-page-state.ts` - Local UI state hook
- `apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-header.tsx` - Header component
- `apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-stats.tsx` - Stats cards component
- `apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-table.tsx` - Table component + row/cell subcomponents
- `apps/admin/src/app/(dashboard)/evals/ab-tests/ab-tests-modals.tsx` - Modal wrapper component

## Verification
- `npm run lint -w apps/admin`
- Quality gate (pre-commit) passed
