### PR TITLE
refactor: split DiscoveryControlCard

### DIFF
--- a/apps/admin/src/components/dashboard/DiscoveryControlCard.tsx
+++ b/apps/admin/src/components/dashboard/DiscoveryControlCard.tsx
@@ -1,153 +1,22 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import { DashboardCard } from './DashboardCard';
-
-interface DiscoveryStatus {
-  enabled: boolean;
-  pendingCount: number;
-  sourceCount: number;
-}
+import { DiscoveryControlCardView } from './DiscoveryControlCardView';
+import { useDiscoveryControl } from './useDiscoveryControl';
 
 export function DiscoveryControlCard() {
-  const [status, setStatus] = useState<DiscoveryStatus | null>(null);
-  const [processing, setProcessing] = useState(false);
-  const [toggling, setToggling] = useState(false);
-  const [batchSize, setBatchSize] = useState(50);
-  const [result, setResult] = useState<{ found: number; new: number } | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchStatus = useCallback(async () => {
-    try {
-      const res = await fetch('/api/discovery/status');
-      if (!res.ok) return;
-      const data = await res.json();
-      setStatus(data);
-    } catch {
-      // Ignore fetch errors
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchStatus();
-  }, [fetchStatus]);
-
-  const toggleDiscovery = async () => {
-    if (!status) return;
-    setToggling(true);
-    setError(null);
-    try {
-      const res = await fetch('/api/discovery/toggle', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ enabled: !status.enabled }),
-      });
-      if (!res.ok) {
-        const data = await res.json();
-        setError(data.error || 'Failed to toggle');
-        return;
-      }
-      await fetchStatus();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setToggling(false);
-    }
-  };
-
-  const runBatch = async () => {
-    setProcessing(true);
-    setError(null);
-    setResult(null);
-    try {
-      const res = await fetch('/api/discovery/run', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ limit: batchSize }),
-      });
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error || 'Failed to run discovery');
-        return;
-      }
-      setResult({ found: data.found, new: data.new });
-      await fetchStatus();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setProcessing(false);
-    }
-  };
+  const model = useDiscoveryControl();
 
   return (
-    <DashboardCard title="Discovery" badge={`${status?.sourceCount || 0} sources`} color="violet">
-      <div className="space-y-4">
-        {/* Toggle Switch */}
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm text-neutral-300">Automatic Discovery</p>
-            <p className="text-xs text-neutral-500">Nightly discovery runs</p>
-          </div>
-          <button
-            onClick={toggleDiscovery}
-            disabled={toggling || !status}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-              status?.enabled ? 'bg-emerald-600' : 'bg-neutral-700'
-            } ${toggling ? 'opacity-50' : ''}`}
-          >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                status?.enabled ? 'translate-x-6' : 'translate-x-1'
-              }`}
-            />
-          </button>
-        </div>
-
-        {/* Status indicator */}
-        <div className="flex items-center gap-2 text-xs">
-          <div
-            className={`h-2 w-2 rounded-full ${
-              status?.enabled ? 'bg-emerald-400 animate-pulse' : 'bg-neutral-600'
-            }`}
-          />
-          <span className={status?.enabled ? 'text-emerald-400' : 'text-neutral-500'}>
-            {status?.enabled ? 'Discovery active' : 'Discovery paused'}
-          </span>
-        </div>
-
-        {/* Manual Run Controls */}
-        <div className="pt-3 border-t border-neutral-800">
-          <p className="text-xs text-neutral-500 mb-2">Manual Run</p>
-          <div className="flex items-center gap-2">
-            <select
-              value={batchSize}
-              onChange={(e) => setBatchSize(Number(e.target.value))}
-              className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-sm text-white"
-            >
-              <option value={1}>1 item</option>
-              <option value={10}>10 items</option>
-              <option value={25}>25 items</option>
-              <option value={50}>50 items</option>
-              <option value={100}>100 items</option>
-            </select>
-
-            <button
-              onClick={runBatch}
-              disabled={processing}
-              className="flex-1 px-3 py-1.5 bg-violet-600 hover:bg-violet-700 disabled:bg-neutral-700 disabled:text-neutral-500 text-white text-sm rounded transition-colors"
-            >
-              {processing ? 'Running...' : 'Run Discovery'}
-            </button>
-          </div>
-
-          {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
-          {result && (
-            <p className="text-xs text-violet-400 mt-2">
-              Found {result.found}, added {result.new} new items
-            </p>
-          )}
-        </div>
-      </div>
-    </DashboardCard>
+    <DiscoveryControlCardView
+      status={model.status}
+      toggling={model.toggling}
+      processing={model.processing}
+      batchSize={model.batchSize}
+      onChangeBatchSize={model.setBatchSize}
+      onToggle={model.toggleDiscovery}
+      onRun={model.runBatch}
+      error={model.error}
+      result={model.result}
+    />
   );
 }

--- a/apps/admin/src/components/dashboard/DiscoveryControlCardView.tsx
+++ b/apps/admin/src/components/dashboard/DiscoveryControlCardView.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { DashboardCard } from './DashboardCard';
+
+interface DiscoveryStatus {
+  enabled: boolean;
+  pendingCount: number;
+  sourceCount: number;
+}
+
+interface RunResult {
+  found: number;
+  new: number;
+}
+
+interface DiscoveryControlCardViewProps {
+  status: DiscoveryStatus | null;
+  toggling: boolean;
+  processing: boolean;
+  batchSize: number;
+  onChangeBatchSize: (value: number) => void;
+  onToggle: () => void;
+  onRun: () => void;
+  error: string | null;
+  result: RunResult | null;
+}
+
+function ToggleSection({
+  status,
+  toggling,
+  onToggle,
+}: Readonly<{
+  status: DiscoveryStatus | null;
+  toggling: boolean;
+  onToggle: () => void;
+}>) {
+  const toggleClassName = `relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+    status?.enabled ? 'bg-emerald-600' : 'bg-neutral-700'
+  } ${toggling ? 'opacity-50' : ''}`;
+
+  const knobClassName = `inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+    status?.enabled ? 'translate-x-6' : 'translate-x-1'
+  }`;
+
+  return (
+    <div className="flex items-center justify-between">
+      <ToggleLabel />
+      <button onClick={onToggle} disabled={toggling || !status} className={toggleClassName}>
+        <span className={knobClassName} />
+      </button>
+    </div>
+  );
+}
+
+function ToggleLabel() {
+  return (
+    <div>
+      <p className="text-sm text-neutral-300">Automatic Discovery</p>
+      <p className="text-xs text-neutral-500">Nightly discovery runs</p>
+    </div>
+  );
+}
+
+function StatusIndicator({ status }: Readonly<{ status: DiscoveryStatus | null }>) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <div
+        className={`h-2 w-2 rounded-full ${
+          status?.enabled ? 'bg-emerald-400 animate-pulse' : 'bg-neutral-600'
+        }`}
+      />
+      <span className={status?.enabled ? 'text-emerald-400' : 'text-neutral-500'}>
+        {status?.enabled ? 'Discovery active' : 'Discovery paused'}
+      </span>
+    </div>
+  );
+}
+
+function BatchSelect({
+  value,
+  onChange,
+}: Readonly<{ value: number; onChange: (value: number) => void }>) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+      className="bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-sm text-white"
+    >
+      <option value={1}>1 item</option>
+      <option value={10}>10 items</option>
+      <option value={25}>25 items</option>
+      <option value={50}>50 items</option>
+      <option value={100}>100 items</option>
+    </select>
+  );
+}
+
+function ManualRunSection({
+  batchSize,
+  onChangeBatchSize,
+  processing,
+  onRun,
+  error,
+  result,
+}: Readonly<{
+  batchSize: number;
+  onChangeBatchSize: (value: number) => void;
+  processing: boolean;
+  onRun: () => void;
+  error: string | null;
+  result: RunResult | null;
+}>) {
+  return (
+    <div className="pt-3 border-t border-neutral-800">
+      <p className="text-xs text-neutral-500 mb-2">Manual Run</p>
+      <ManualRunControls
+        batchSize={batchSize}
+        onChangeBatchSize={onChangeBatchSize}
+        processing={processing}
+        onRun={onRun}
+      />
+      <ManualRunFeedback error={error} result={result} />
+    </div>
+  );
+}
+
+function ManualRunControls({
+  batchSize,
+  onChangeBatchSize,
+  processing,
+  onRun,
+}: Readonly<{
+  batchSize: number;
+  onChangeBatchSize: (value: number) => void;
+  processing: boolean;
+  onRun: () => void;
+}>) {
+  return (
+    <div className="flex items-center gap-2">
+      <BatchSelect value={batchSize} onChange={onChangeBatchSize} />
+      <RunButton processing={processing} onRun={onRun} />
+    </div>
+  );
+}
+
+function RunButton({ processing, onRun }: Readonly<{ processing: boolean; onRun: () => void }>) {
+  return (
+    <button
+      onClick={onRun}
+      disabled={processing}
+      className="flex-1 px-3 py-1.5 bg-violet-600 hover:bg-violet-700 disabled:bg-neutral-700 disabled:text-neutral-500 text-white text-sm rounded transition-colors"
+    >
+      {processing ? 'Running...' : 'Run Discovery'}
+    </button>
+  );
+}
+
+function ManualRunFeedback({
+  error,
+  result,
+}: Readonly<{ error: string | null; result: RunResult | null }>) {
+  return (
+    <>
+      {error && <p className="text-xs text-red-400 mt-2">{error}</p>}
+      {result && (
+        <p className="text-xs text-violet-400 mt-2">
+          Found {result.found}, added {result.new} new items
+        </p>
+      )}
+    </>
+  );
+}
+
+export function DiscoveryControlCardView({
+  status,
+  toggling,
+  processing,
+  batchSize,
+  onChangeBatchSize,
+  onToggle,
+  onRun,
+  error,
+  result,
+}: Readonly<DiscoveryControlCardViewProps>) {
+  return (
+    <DashboardCard title="Discovery" badge={`${status?.sourceCount || 0} sources`} color="violet">
+      <div className="space-y-4">
+        <ToggleSection status={status} toggling={toggling} onToggle={onToggle} />
+        <StatusIndicator status={status} />
+        <ManualRunSection
+          batchSize={batchSize}
+          onChangeBatchSize={onChangeBatchSize}
+          processing={processing}
+          onRun={onRun}
+          error={error}
+          result={result}
+        />
+      </div>
+    </DashboardCard>
+  );
+}

--- a/apps/admin/src/components/dashboard/useDiscoveryControl.ts
+++ b/apps/admin/src/components/dashboard/useDiscoveryControl.ts
@@ -1,0 +1,193 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+interface DiscoveryStatus {
+  enabled: boolean;
+  pendingCount: number;
+  sourceCount: number;
+}
+
+interface RunResult {
+  found: number;
+  new: number;
+}
+
+function useBatchSizeState() {
+  const [batchSize, setBatchSize] = useState(50);
+  return { batchSize, setBatchSize };
+}
+
+function useRunResultState() {
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  return { result, setResult, error, setError };
+}
+
+function useStatusState() {
+  const [status, setStatus] = useState<DiscoveryStatus | null>(null);
+  return { status, setStatus };
+}
+
+function useBusyState() {
+  const [processing, setProcessing] = useState(false);
+  const [toggling, setToggling] = useState(false);
+  return { processing, setProcessing, toggling, setToggling };
+}
+
+function normalizeError(err: unknown) {
+  return err instanceof Error ? err.message : 'Unknown error';
+}
+
+async function fetchJson(url: string, init?: RequestInit) {
+  const res = await fetch(url, init);
+  const data = await res.json().catch(() => ({}));
+  return { res, data };
+}
+
+async function postToggle(enabled: boolean) {
+  return fetchJson('/api/discovery/toggle', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+  });
+}
+
+async function postRun(limit: number) {
+  return fetchJson('/api/discovery/run', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ limit }),
+  });
+}
+
+async function runDiscoveryBatch(limit: number) {
+  const { res, data } = await postRun(limit);
+  if (!res.ok) {
+    return { error: (data as { error?: string }).error || 'Failed to run discovery' };
+  }
+  const parsed = data as { found: number; new: number };
+  return { result: { found: parsed.found, new: parsed.new } };
+}
+
+function useFetchStatus(setStatus: (value: DiscoveryStatus | null) => void) {
+  const fetchStatus = useCallback(async () => {
+    try {
+      const { res, data } = await fetchJson('/api/discovery/status');
+      if (!res.ok) return;
+      setStatus(data as DiscoveryStatus);
+    } catch {
+      // ignore
+    }
+  }, [setStatus]);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  return fetchStatus;
+}
+
+function useToggleDiscovery(opts: {
+  status: DiscoveryStatus | null;
+  setToggling: (v: boolean) => void;
+  setError: (v: string | null) => void;
+  fetchStatus: () => Promise<void>;
+}) {
+  const { status, setToggling, setError, fetchStatus } = opts;
+  return useCallback(async () => {
+    if (!status) return;
+
+    setToggling(true);
+    setError(null);
+
+    try {
+      const { res, data } = await postToggle(!status.enabled);
+
+      if (!res.ok) {
+        setError((data as { error?: string }).error || 'Failed to toggle');
+        return;
+      }
+
+      await fetchStatus();
+    } catch (err) {
+      setError(normalizeError(err));
+    } finally {
+      setToggling(false);
+    }
+  }, [fetchStatus, setError, setToggling, status]);
+}
+
+function useRunBatch(opts: {
+  batchSize: number;
+  setProcessing: (v: boolean) => void;
+  setError: (v: string | null) => void;
+  setResult: (v: RunResult | null) => void;
+  fetchStatus: () => Promise<void>;
+}) {
+  const { batchSize, setProcessing, setError, setResult, fetchStatus } = opts;
+
+  return useCallback(async () => {
+    setProcessing(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const out = await runDiscoveryBatch(batchSize);
+      if (out.error) {
+        setError(out.error);
+        return;
+      }
+      if (out.result) setResult(out.result);
+      await fetchStatus();
+    } catch (err) {
+      setError(normalizeError(err));
+    } finally {
+      setProcessing(false);
+    }
+  }, [batchSize, fetchStatus, setError, setProcessing, setResult]);
+}
+
+function useDiscoveryControlState() {
+  const statusState = useStatusState();
+  const busy = useBusyState();
+  const batch = useBatchSizeState();
+  const run = useRunResultState();
+  return { statusState, busy, batch, run };
+}
+
+function useDiscoveryControlActions(state: ReturnType<typeof useDiscoveryControlState>) {
+  const fetchStatus = useFetchStatus(state.statusState.setStatus);
+  const toggleDiscovery = useToggleDiscovery({
+    status: state.statusState.status,
+    setToggling: state.busy.setToggling,
+    setError: state.run.setError,
+    fetchStatus,
+  });
+  const runBatch = useRunBatch({
+    batchSize: state.batch.batchSize,
+    setProcessing: state.busy.setProcessing,
+    setError: state.run.setError,
+    setResult: state.run.setResult,
+    fetchStatus,
+  });
+  return { fetchStatus, toggleDiscovery, runBatch };
+}
+
+export function useDiscoveryControl() {
+  const state = useDiscoveryControlState();
+  const actions = useDiscoveryControlActions(state);
+
+  return {
+    status: state.statusState.status,
+    processing: state.busy.processing,
+    toggling: state.busy.toggling,
+    batchSize: state.batch.batchSize,
+    setBatchSize: state.batch.setBatchSize,
+    result: state.run.result,
+    error: state.run.error,
+    fetchStatus: actions.fetchStatus,
+    toggleDiscovery: actions.toggleDiscovery,
+    runBatch: actions.runBatch,
+  };
+}


### PR DESCRIPTION
## Problem

`apps/admin/src/components/dashboard/DiscoveryControlCard.tsx` contained state management, API calls, and all UI rendering in one file, making it harder to maintain and violating our quality gate function-size thresholds.

## Root Cause

The component mixed data-fetching and UI composition directly inside `DiscoveryControlCard`, resulting in large functions.

## Solution

Split DiscoveryControl into:

- `useDiscoveryControl` for state + API calls
- `DiscoveryControlCardView` for rendering (with small subcomponents)
- `DiscoveryControlCard` as a thin wrapper

All touched functions are now under the quality gate max of 30 lines, with parameter counts below 6.

## Files Changed
- `apps/admin/src/components/dashboard/DiscoveryControlCard.tsx` - thin wrapper
- `apps/admin/src/components/dashboard/useDiscoveryControl.ts` - extracted hook
- `apps/admin/src/components/dashboard/DiscoveryControlCardView.tsx` - extracted view

## Verification
- `npm run lint -w apps/admin`
- pre-commit quality gate passed
