### PR TITLE
refactor: reduce duplicated lines in status grids

### DIFF
--- a/apps/admin/src/app/(dashboard)/add/hooks/useAddArticle.ts
+++ b/apps/admin/src/app/(dashboard)/add/hooks/useAddArticle.ts
@@ -59,6 +59,35 @@ type AddArticleFormState = ReturnType<typeof useInputState> &
   ReturnType<typeof useCommentState> &
   ReturnType<typeof useSuggestedAudiencesState>;
 
+type EditPromptFieldsDeps = {
+  setUrl: (value: string) => void;
+  setSubmitterName: (value: string) => void;
+  setSubmitterAudience: (value: string) => void;
+  setSubmitterChannel: (value: string) => void;
+  setSubmitterUrgency: (value: string) => void;
+  setWhyValuable: (value: string) => void;
+};
+
+type EditPromptUiDeps = {
+  setEditingId: (id: string | null) => void;
+  setActiveTab: (value: 'add' | 'list') => void;
+  setStatus: (value: SubmissionStatus) => void;
+  setMessage: (value: string) => void;
+};
+
+type EditItemDeps = EditPromptFieldsDeps & EditPromptUiDeps;
+
+type CancelEditDeps = {
+  setEditingId: (id: string | null) => void;
+  resetForm: () => void;
+  setSubmitterChannel: (value: string) => void;
+  setSubmitterUrgency: (value: string) => void;
+  setStatus: (value: SubmissionStatus) => void;
+  setMessage: (value: string) => void;
+};
+
+type EditActionsDeps = EditItemDeps & CancelEditDeps;
+
 function useSubmissionState() {
   const [status, setStatus] = useState<SubmissionStatus>('idle');
   const [message, setMessage] = useState('');
@@ -106,36 +135,13 @@ function useAudienceToggle(opts: {
   };
 }
 
-function useEditActions(opts: {
-  setEditingId: (id: string | null) => void;
-  setUrl: (value: string) => void;
-  setSubmitterName: (value: string) => void;
-  setSubmitterAudience: (value: string) => void;
-  setSubmitterChannel: (value: string) => void;
-  setSubmitterUrgency: (value: string) => void;
-  setWhyValuable: (value: string) => void;
-  setActiveTab: (value: 'add' | 'list') => void;
-  setStatus: (value: SubmissionStatus) => void;
-  setMessage: (value: string) => void;
-  resetForm: () => void;
-}) {
+function useEditActions(opts: EditActionsDeps) {
   const editItem = useEditItem(opts);
   const cancelEdit = useCancelEdit(opts);
   return { editItem, cancelEdit };
 }
 
-function useEditItem(opts: {
-  setEditingId: (id: string | null) => void;
-  setUrl: (value: string) => void;
-  setSubmitterName: (value: string) => void;
-  setSubmitterAudience: (value: string) => void;
-  setSubmitterChannel: (value: string) => void;
-  setSubmitterUrgency: (value: string) => void;
-  setWhyValuable: (value: string) => void;
-  setActiveTab: (value: 'add' | 'list') => void;
-  setStatus: (value: SubmissionStatus) => void;
-  setMessage: (value: string) => void;
-}) {
+function useEditItem(opts: EditItemDeps) {
   return (item: MissedDiscovery) => {
     opts.setEditingId(item.id);
     opts.setUrl(item.url);
@@ -150,14 +156,7 @@ function useEditItem(opts: {
   };
 }
 
-function useCancelEdit(opts: {
-  setEditingId: (id: string | null) => void;
-  resetForm: () => void;
-  setSubmitterChannel: (value: string) => void;
-  setSubmitterUrgency: (value: string) => void;
-  setStatus: (value: SubmissionStatus) => void;
-  setMessage: (value: string) => void;
-}) {
+function useCancelEdit(opts: CancelEditDeps) {
   return () => {
     opts.setEditingId(null);
     opts.resetForm();

--- a/apps/admin/src/components/dashboard/PipelineStatusGrid.tsx
+++ b/apps/admin/src/components/dashboard/PipelineStatusGrid.tsx
@@ -1,50 +1,15 @@
 'use client';
 
-import { useState } from 'react';
-// Simple chevron icons
-const ChevronDown = ({ size = 16 }: { size?: number }) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-  >
-    <path d="M6 9l6 6 6-6" />
-  </svg>
-);
-
-const ChevronRight = ({ size = 16 }: { size?: number }) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-  >
-    <path d="M9 18l6-6-6-6" />
-  </svg>
-);
 import { cn } from '@/lib/utils';
 import { StatusPill } from '@/components/ui/status-pill';
-
-interface StatusCode {
-  code: number;
-  name: string;
-  count: number;
-}
-
-interface CategoryData {
-  category: string;
-  label: string;
-  color: string;
-  bgColor: string;
-  borderColor: string;
-  statuses: StatusCode[];
-  total: number;
-}
+import {
+  buildStatusCategories,
+  ExpandableCategoryHeader,
+  STATUS_CATEGORY_CONFIG,
+  type CategoryData,
+  type StatusCategoryKey,
+} from '@/components/dashboard/status-grid-common';
+import { useStatusGridExpansion } from '@/components/dashboard/use-status-grid-expansion';
 
 interface PipelineStatusGridProps {
   statusData: {
@@ -54,76 +19,20 @@ interface PipelineStatusGridProps {
     count: number;
   }[];
 }
-
-const CATEGORY_CONFIG: Record<
-  string,
-  { label: string; color: string; bgColor: string; borderColor: string }
-> = {
-  discovery: {
-    label: 'Discovery',
-    color: 'text-violet-400',
-    bgColor: 'bg-violet-500/10',
-    borderColor: 'border-violet-500/30',
-  },
-  enrichment: {
-    label: 'Enrichment',
-    color: 'text-cyan-400',
-    bgColor: 'bg-cyan-500/10',
-    borderColor: 'border-cyan-500/30',
-  },
-  review: {
-    label: 'Review',
-    color: 'text-amber-400',
-    bgColor: 'bg-amber-500/10',
-    borderColor: 'border-amber-500/30',
-  },
-  published: {
-    label: 'Published',
-    color: 'text-emerald-400',
-    bgColor: 'bg-emerald-500/10',
-    borderColor: 'border-emerald-500/30',
-  },
-  terminal: {
-    label: 'Terminal',
-    color: 'text-neutral-400',
-    bgColor: 'bg-neutral-500/10',
-    borderColor: 'border-neutral-500/30',
-  },
-};
-
-const CATEGORY_ORDER = ['discovery', 'enrichment', 'review', 'published', 'terminal'];
+const CATEGORY_ORDER: StatusCategoryKey[] = [
+  'discovery',
+  'enrichment',
+  'review',
+  'published',
+  'terminal',
+];
 
 function buildCategories(statusData: PipelineStatusGridProps['statusData']): CategoryData[] {
-  const safeData = statusData || [];
-  return CATEGORY_ORDER.map((key) => {
-    const config = CATEGORY_CONFIG[key];
-    const statuses = safeData.filter((s) => s.category === key).sort((a, b) => a.code - b.code);
-    return {
-      category: key,
-      ...config,
-      statuses,
-      total: statuses.reduce((sum, s) => sum + s.count, 0),
-    };
+  return buildStatusCategories({
+    statusData,
+    order: CATEGORY_ORDER,
+    config: STATUS_CATEGORY_CONFIG,
   });
-}
-
-function CategoryHeader({
-  cat,
-  isExpanded,
-  onToggle,
-}: Readonly<{ cat: CategoryData; isExpanded: boolean; onToggle: () => void }>) {
-  return (
-    <button
-      onClick={onToggle}
-      className="w-full flex items-center gap-3 p-3 hover:bg-neutral-800/50 transition-colors"
-    >
-      <span className={cn('font-medium', cat.color)}>{cat.label}</span>
-      <span className={cn('text-xl font-bold ml-auto', cat.color)}>{cat.total}</span>
-      <span className="text-neutral-500 ml-2">
-        {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-      </span>
-    </button>
-  );
 }
 
 function CategoryPills({ cat }: Readonly<{ cat: CategoryData }>) {
@@ -153,24 +62,21 @@ function CategoryRow({
 }: Readonly<{ cat: CategoryData; isExpanded: boolean; onToggle: () => void }>) {
   return (
     <div className={cn(cat.category === 'terminal' && 'opacity-60')}>
-      <CategoryHeader cat={cat} isExpanded={isExpanded} onToggle={onToggle} />
+      <ExpandableCategoryHeader
+        label={cat.label}
+        total={cat.total}
+        color={cat.color}
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+      />
       {isExpanded && <CategoryPills cat={cat} />}
     </div>
   );
 }
 
 export function PipelineStatusGrid({ statusData }: Readonly<PipelineStatusGridProps>) {
-  const [expanded, setExpanded] = useState<Set<string>>(
-    new Set(['discovery', 'enrichment', 'review']),
-  );
+  const { expanded, toggle } = useStatusGridExpansion(['discovery', 'enrichment', 'review']);
   const categories = buildCategories(statusData);
-  const toggle = (c: string) =>
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(c)) next.delete(c);
-      else next.add(c);
-      return next;
-    });
   return (
     <div className="rounded-xl border border-neutral-800 bg-neutral-900/60 divide-y divide-neutral-800">
       {categories.map((cat) => (

--- a/apps/admin/src/components/dashboard/status-grid-common.tsx
+++ b/apps/admin/src/components/dashboard/status-grid-common.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export const ChevronDown = ({ size = 16 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <path d="M6 9l6 6 6-6" />
+  </svg>
+);
+
+export const ChevronRight = ({ size = 16 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <path d="M9 18l6-6-6-6" />
+  </svg>
+);
+
+export interface StatusCode {
+  code: number;
+  name: string;
+  count: number;
+}
+
+export type StatusCategoryKey = 'discovery' | 'enrichment' | 'review' | 'published' | 'terminal';
+
+export interface CategoryConfig {
+  label: string;
+  color: string;
+  bgColor: string;
+  borderColor: string;
+}
+
+export const STATUS_CATEGORY_CONFIG: Record<StatusCategoryKey, CategoryConfig> = {
+  discovery: {
+    label: 'Discovery',
+    color: 'text-violet-400',
+    bgColor: 'bg-violet-500/10',
+    borderColor: 'border-violet-500/30',
+  },
+  enrichment: {
+    label: 'Enrichment',
+    color: 'text-cyan-400',
+    bgColor: 'bg-cyan-500/10',
+    borderColor: 'border-cyan-500/30',
+  },
+  review: {
+    label: 'Review',
+    color: 'text-amber-400',
+    bgColor: 'bg-amber-500/10',
+    borderColor: 'border-amber-500/30',
+  },
+  published: {
+    label: 'Published',
+    color: 'text-emerald-400',
+    bgColor: 'bg-emerald-500/10',
+    borderColor: 'border-emerald-500/30',
+  },
+  terminal: {
+    label: 'Terminal',
+    color: 'text-neutral-400',
+    bgColor: 'bg-neutral-500/10',
+    borderColor: 'border-neutral-500/30',
+  },
+};
+
+export interface CategoryData {
+  category: StatusCategoryKey;
+  label: string;
+  color: string;
+  bgColor: string;
+  borderColor: string;
+  statuses: StatusCode[];
+  total: number;
+}
+
+export function buildStatusCategories(opts: {
+  statusData: { code: number; name: string; category: string; count: number }[];
+  order: StatusCategoryKey[];
+  config: Record<StatusCategoryKey, CategoryConfig>;
+}): CategoryData[] {
+  const safeData = opts.statusData || [];
+  return opts.order.map((key) => {
+    const cfg = opts.config[key];
+    const statuses = safeData.filter((s) => s.category === key).sort((a, b) => a.code - b.code);
+    return {
+      category: key,
+      ...cfg,
+      statuses,
+      total: statuses.reduce((sum, s) => sum + s.count, 0),
+    };
+  });
+}
+
+export function ExpandableCategoryHeader({
+  label,
+  total,
+  color,
+  isExpanded,
+  onToggle,
+}: Readonly<{
+  label: string;
+  total: number;
+  color: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+}>) {
+  return (
+    <button
+      onClick={onToggle}
+      className="w-full flex items-center gap-3 p-3 hover:bg-neutral-800/50 transition-colors"
+    >
+      <span className={cn('font-medium', color)}>{label}</span>
+      <span className={cn('text-xl font-bold ml-auto', color)}>{total}</span>
+      <span className="text-neutral-500 ml-2">
+        {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+      </span>
+    </button>
+  );
+}

--- a/apps/admin/src/components/dashboard/use-status-grid-expansion.ts
+++ b/apps/admin/src/components/dashboard/use-status-grid-expansion.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useState } from 'react';
+
+export function useStatusGridExpansion(initialExpanded: string[]) {
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(initialExpanded));
+
+  const toggle = (c: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(c)) next.delete(c);
+      else next.add(c);
+      return next;
+    });
+
+  return { expanded, toggle };
+}


### PR DESCRIPTION
## Problem

Sonar flagged duplicated lines on new code in:

- `apps/admin/src/app/(dashboard)/items/items-status-grid.tsx`
- `apps/admin/src/components/dashboard/PipelineStatusGrid.tsx`

and also indicated duplication in:

- `apps/admin/src/app/(dashboard)/add/hooks/useAddArticle.ts`

## Root Cause

Two status grid components implemented the same:

- chevron icons
- category config/types
- category building logic
- expandable header UI
- expand/collapse state management

`useAddArticle.ts` also repeated the same option/dependency type shapes across multiple helper functions.

## Solution

- Extracted shared status-grid primitives:
  - `apps/admin/src/components/dashboard/status-grid-common.tsx` (icons, shared types/config, category builder, expandable header)
  - `apps/admin/src/components/dashboard/use-status-grid-expansion.ts` (expand/collapse state)
- Updated both status grid components to reuse shared helpers.
- Deduplicated `useAddArticle.ts` by introducing shared type aliases for repeated edit/reset dependency shapes.

## Files Changed

- `apps/admin/src/components/dashboard/status-grid-common.tsx`
- `apps/admin/src/components/dashboard/use-status-grid-expansion.ts`
- `apps/admin/src/app/(dashboard)/items/items-status-grid.tsx`
- `apps/admin/src/components/dashboard/PipelineStatusGrid.tsx`
- `apps/admin/src/app/(dashboard)/add/hooks/useAddArticle.ts`

## Verification

- `npm run lint -w apps/admin`
- `node scripts/ci/check-large-files.cjs`
