### PR TITLE
fix: admin build failure in review list hooks

### DIFF
--- a/apps/admin/src/app/(dashboard)/items/review-list-hooks.tsx
+++ b/apps/admin/src/app/(dashboard)/items/review-list-hooks.tsx
@@ -15,6 +15,13 @@ function useSuccessMessage() {
   return { message, show };
 }
 
+function getActionError(r: unknown): string {
+  if (typeof r === 'object' && r !== null && 'error' in r && typeof r.error === 'string') {
+    return r.error;
+  }
+  return 'Failed';
+}
+
 async function runApprove(
   ids: Set<string>,
   clear: () => void,
@@ -26,7 +33,7 @@ async function runApprove(
   setLoading('approve');
   show(`⏳ Approving ${ids.size} items...`);
   const r = await bulkApproveAction(Array.from(ids));
-  show(r.success ? `✅ ${r.count} items approved` : `❌ Failed: ${r.error}`);
+  show(r.success ? `✅ ${r.count} items approved` : `❌ Failed: ${getActionError(r)}`);
   setLoading(null);
   clear();
   refresh();
@@ -45,7 +52,7 @@ async function runReject(
   setLoading('reject');
   show(`⏳ Rejecting ${ids.size} items...`);
   const r = await bulkRejectAction(Array.from(ids), reason);
-  show(r.success ? `✅ ${r.count} items rejected` : `❌ Failed: ${r.error}`);
+  show(r.success ? `✅ ${r.count} items rejected` : `❌ Failed: ${getActionError(r)}`);
   setLoading(null);
   clear();
   refresh();


### PR DESCRIPTION
## Problem
Admin build failed due to a TypeScript error in `review-list-hooks.tsx` when accessing `r.error` on bulk action results.

## Root Cause
`bulkApproveAction` / `bulkRejectAction` return union types where `error` is not guaranteed on all branches, so direct `r.error` access fails typechecking.

## Solution
- Added a small `getActionError()` helper that safely extracts an error string via an `'error' in r` guard.
- Updated approve/reject toast messaging to use `getActionError(r)` instead of `r.error`.

## Files Changed
- `apps/admin/src/app/(dashboard)/items/review-list-hooks.tsx`

## Verification
- `npm run lint -w apps/admin`
- `npm run build -w apps/admin`