### PR TITLE
test: increase agent-api test coverage from 57% to 73%

### DIFF
--- a/services/agent-api/src/agents/discover-classics-queue.test.js
+++ b/services/agent-api/src/agents/discover-classics-queue.test.js
@@ -1,0 +1,150 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/status-codes.js', () => ({
+  loadStatusCodes: vi.fn(() => Promise.resolve()),
+  STATUS: { PENDING_ENRICHMENT: 200 },
+}));
+
+vi.mock('../lib/semantic-scholar.js', () => ({
+  calculateImpactScore: vi.fn(() => 8),
+  extractCitationMetrics: vi.fn(() => ({ citationCount: 1000, influentialCitations: 50 })),
+}));
+
+vi.mock('./discover-classics-db.js', () => ({
+  urlExists: vi.fn(() => Promise.resolve(false)),
+  insertQueueItem: vi.fn(() => Promise.resolve({ data: { id: 'new-1' }, error: null })),
+}));
+
+import { queuePaper } from './discover-classics-queue.js';
+import { urlExists, insertQueueItem } from './discover-classics-db.js';
+
+describe('discover-classics-queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('queuePaper', () => {
+    const mockPaper = {
+      paperId: 'semantic-123',
+      title: 'Test Paper',
+      url: 'https://semanticscholar.org/paper/123',
+      year: 2020,
+      authors: [{ name: 'Author 1' }, { name: 'Author 2' }],
+    };
+
+    const mockClassic = {
+      id: 'classic-1',
+      title: 'Classic Paper',
+      significance: 'Foundational work',
+    };
+
+    it('queues new paper and returns queued action', async () => {
+      vi.mocked(urlExists).mockResolvedValue(false);
+      vi.mocked(insertQueueItem).mockResolvedValue({ data: { id: 'queue-1' }, error: null });
+
+      const result = await queuePaper(mockPaper, mockClassic, true);
+
+      expect(result.action).toBe('queued');
+      expect(result.id).toBe('queue-1');
+      expect(insertQueueItem).toHaveBeenCalled();
+    });
+
+    it('returns exists if URL already exists', async () => {
+      vi.mocked(urlExists).mockResolvedValue(true);
+
+      const result = await queuePaper(mockPaper, mockClassic, true);
+
+      expect(result.action).toBe('exists');
+      expect(insertQueueItem).not.toHaveBeenCalled();
+    });
+
+    it('returns exists on duplicate key constraint', async () => {
+      vi.mocked(urlExists).mockResolvedValue(false);
+      vi.mocked(insertQueueItem).mockResolvedValue({ data: null, error: { code: '23505' } });
+
+      const result = await queuePaper(mockPaper, mockClassic, true);
+
+      expect(result.action).toBe('exists');
+    });
+
+    it('throws on other database errors', async () => {
+      vi.mocked(urlExists).mockResolvedValue(false);
+      vi.mocked(insertQueueItem).mockResolvedValue({ data: null, error: new Error('DB error') });
+
+      await expect(queuePaper(mockPaper, mockClassic, true)).rejects.toThrow('DB error');
+    });
+
+    it('uses semantic scholar URL if paper.url not provided', async () => {
+      const paperWithoutUrl = { ...mockPaper, url: undefined };
+      vi.mocked(urlExists).mockResolvedValue(false);
+      vi.mocked(insertQueueItem).mockResolvedValue({ data: { id: 'queue-1' }, error: null });
+
+      await queuePaper(paperWithoutUrl, mockClassic, true);
+
+      expect(urlExists).toHaveBeenCalledWith('https://www.semanticscholar.org/paper/semantic-123');
+    });
+
+    it('builds payload with classic paper source', async () => {
+      vi.mocked(urlExists).mockResolvedValue(false);
+      vi.mocked(insertQueueItem).mockResolvedValue({ data: { id: 'queue-1' }, error: null });
+
+      await queuePaper(mockPaper, mockClassic, true);
+
+      expect(insertQueueItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            source: 'classic-paper',
+            source_classic_id: 'classic-1',
+          }),
+        }),
+      );
+    });
+
+    it('builds payload with citation-expansion source', async () => {
+      vi.mocked(urlExists).mockResolvedValue(false);
+      vi.mocked(insertQueueItem).mockResolvedValue({ data: { id: 'queue-1' }, error: null });
+
+      await queuePaper(mockPaper, mockClassic, false);
+
+      expect(insertQueueItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            source: 'citation-expansion',
+          }),
+        }),
+      );
+    });
+
+    it('includes authors in payload', async () => {
+      vi.mocked(urlExists).mockResolvedValue(false);
+      vi.mocked(insertQueueItem).mockResolvedValue({ data: { id: 'queue-1' }, error: null });
+
+      await queuePaper(mockPaper, mockClassic, true);
+
+      expect(insertQueueItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            authors: ['Author 1', 'Author 2'],
+          }),
+        }),
+      );
+    });
+
+    it('handles paper with no authors', async () => {
+      const paperNoAuthors = { ...mockPaper, authors: undefined };
+      vi.mocked(urlExists).mockResolvedValue(false);
+      vi.mocked(insertQueueItem).mockResolvedValue({ data: { id: 'queue-1' }, error: null });
+
+      await queuePaper(paperNoAuthors, mockClassic, true);
+
+      expect(insertQueueItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            authors: [],
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/services/agent-api/src/agents/discover-classics-run.test.js
+++ b/services/agent-api/src/agents/discover-classics-run.test.js
@@ -1,0 +1,183 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/semantic-scholar.js', () => ({
+  calculateImpactScore: vi.fn(() => 8),
+  extractCitationMetrics: vi.fn(() => ({ citationCount: 100, influentialCitations: 20 })),
+}));
+
+vi.mock('./discover-classics-db.js', () => ({
+  loadUndiscoveredClassics: vi.fn(() => []),
+  markClassicDiscovered: vi.fn(() => Promise.resolve()),
+  updateClassicCitations: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('./discover-classics-semantic.js', () => ({
+  API_DELAY_MS: 10,
+  getCitingPapers: vi.fn(() => Promise.resolve([])),
+  lookupClassicPaper: vi.fn(() => Promise.resolve(null)),
+  sleep: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('./discover-classics-queue.js', () => ({
+  queuePaper: vi.fn(() => Promise.resolve({ action: 'queued' })),
+}));
+
+import { runClassicsDiscoveryImpl } from './discover-classics-run.js';
+import { loadUndiscoveredClassics, markClassicDiscovered } from './discover-classics-db.js';
+import { lookupClassicPaper, getCitingPapers } from './discover-classics-semantic.js';
+import { queuePaper } from './discover-classics-queue.js';
+import { calculateImpactScore } from '../lib/semantic-scholar.js';
+
+describe('discover-classics-run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  describe('runClassicsDiscoveryImpl', () => {
+    it('returns zero counts when no classics to discover', async () => {
+      vi.mocked(loadUndiscoveredClassics).mockResolvedValue([]);
+
+      const result = await runClassicsDiscoveryImpl();
+
+      expect(result).toEqual({ classics: 0, expansions: 0 });
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('All classic papers'));
+    });
+
+    it('processes classics and queues papers', async () => {
+      const mockClassic = {
+        id: 'c1',
+        title: 'Attention Is All You Need',
+        category: 'transformers',
+      };
+      vi.mocked(loadUndiscoveredClassics).mockResolvedValue([mockClassic]);
+      vi.mocked(lookupClassicPaper).mockResolvedValue({
+        paperId: 'p1',
+        title: 'Attention Is All You Need',
+        citationCount: 50000,
+      });
+      vi.mocked(queuePaper).mockResolvedValue({ action: 'queued' });
+
+      const result = await runClassicsDiscoveryImpl({ limit: 1 });
+
+      expect(result.classics).toBe(1);
+      expect(queuePaper).toHaveBeenCalled();
+      expect(markClassicDiscovered).toHaveBeenCalledWith('c1', 'p1');
+    });
+
+    it('skips papers not found in Semantic Scholar', async () => {
+      const mockClassic = {
+        id: 'c1',
+        title: 'Unknown Paper',
+        category: 'unknown',
+      };
+      vi.mocked(loadUndiscoveredClassics).mockResolvedValue([mockClassic]);
+      vi.mocked(lookupClassicPaper).mockResolvedValue(null);
+
+      const result = await runClassicsDiscoveryImpl({ limit: 1 });
+
+      expect(result.classics).toBe(0);
+      expect(queuePaper).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Not found'));
+    });
+
+    it('respects dry run mode', async () => {
+      const mockClassic = {
+        id: 'c1',
+        title: 'Test Paper',
+        category: 'test',
+      };
+      vi.mocked(loadUndiscoveredClassics).mockResolvedValue([mockClassic]);
+      vi.mocked(lookupClassicPaper).mockResolvedValue({
+        paperId: 'p1',
+        title: 'Test Paper',
+        citationCount: 100,
+      });
+
+      const result = await runClassicsDiscoveryImpl({ dryRun: true, limit: 1 });
+
+      expect(result.classics).toBe(0);
+      expect(markClassicDiscovered).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[DRY]'));
+    });
+
+    it('skips already existing papers', async () => {
+      const mockClassic = {
+        id: 'c1',
+        title: 'Existing Paper',
+        category: 'test',
+      };
+      vi.mocked(loadUndiscoveredClassics).mockResolvedValue([mockClassic]);
+      vi.mocked(lookupClassicPaper).mockResolvedValue({
+        paperId: 'p1',
+        title: 'Existing Paper',
+        citationCount: 100,
+      });
+      vi.mocked(queuePaper).mockResolvedValue({ action: 'exists' });
+
+      const result = await runClassicsDiscoveryImpl({ limit: 1 });
+
+      expect(result.classics).toBe(0);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Already exists'));
+    });
+
+    it('expands citations when enabled and paper has enough citations', async () => {
+      const mockClassic = {
+        id: 'c1',
+        title: 'High Citation Paper',
+        category: 'test',
+      };
+      vi.mocked(loadUndiscoveredClassics).mockResolvedValue([mockClassic]);
+      vi.mocked(lookupClassicPaper).mockResolvedValue({
+        paperId: 'p1',
+        title: 'High Citation Paper',
+        citationCount: 100,
+      });
+      vi.mocked(getCitingPapers).mockResolvedValue([
+        { paperId: 'citing1', title: 'Citing Paper 1' },
+        { paperId: 'citing2', title: 'Citing Paper 2' },
+      ]);
+      vi.mocked(calculateImpactScore).mockReturnValue(8);
+      vi.mocked(queuePaper).mockResolvedValue({ action: 'queued' });
+
+      const result = await runClassicsDiscoveryImpl({
+        limit: 1,
+        expandCitations: true,
+      });
+
+      expect(getCitingPapers).toHaveBeenCalled();
+      expect(result.classics).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not expand citations when disabled', async () => {
+      const mockClassic = {
+        id: 'c1',
+        title: 'High Citation Paper',
+        category: 'test',
+      };
+      vi.mocked(loadUndiscoveredClassics).mockResolvedValue([mockClassic]);
+      vi.mocked(lookupClassicPaper).mockResolvedValue({
+        paperId: 'p1',
+        title: 'High Citation Paper',
+        citationCount: 100,
+      });
+      vi.mocked(queuePaper).mockResolvedValue({ action: 'queued' });
+
+      await runClassicsDiscoveryImpl({
+        limit: 1,
+        expandCitations: false,
+      });
+
+      expect(getCitingPapers).not.toHaveBeenCalled();
+    });
+
+    it('logs summary at end of run', async () => {
+      vi.mocked(loadUndiscoveredClassics).mockResolvedValue([]);
+
+      await runClassicsDiscoveryImpl();
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Starting Classic Papers'));
+    });
+  });
+});

--- a/services/agent-api/src/agents/discoverer-enrich.test.js
+++ b/services/agent-api/src/agents/discoverer-enrich.test.js
@@ -1,0 +1,110 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/sitemap.js', () => ({
+  fetchPageMetadata: vi.fn(() =>
+    Promise.resolve({ title: 'Fetched Title', description: 'Description' }),
+  ),
+}));
+
+vi.mock('../lib/discovery-config.js', () => ({
+  isPoorTitle: vi.fn((title) => !title || title.length < 10),
+}));
+
+import { enrichSitemapCandidates } from './discoverer-enrich.js';
+import { fetchPageMetadata } from '../lib/sitemap.js';
+import { isPoorTitle } from '../lib/discovery-config.js';
+
+describe('discoverer-enrich', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  describe('enrichSitemapCandidates', () => {
+    it('returns candidates unchanged if none need enrichment', async () => {
+      const candidates = [
+        { url: 'https://example.com/1', title: 'Good Title That Is Long Enough' },
+        { url: 'https://example.com/2', title: 'Another Good Title Here' },
+      ];
+      vi.mocked(isPoorTitle).mockReturnValue(false);
+      const stats = { metadataFetches: 0 };
+
+      const result = await enrichSitemapCandidates(candidates, stats);
+
+      expect(result).toEqual(candidates);
+      expect(fetchPageMetadata).not.toHaveBeenCalled();
+    });
+
+    it('enriches candidates with poor titles', async () => {
+      const candidates = [
+        { url: 'https://example.com/1', title: 'Bad' },
+        { url: 'https://example.com/2', title: 'Good Title That Is Long Enough' },
+      ];
+      vi.mocked(isPoorTitle).mockImplementation((title) => !title || title.length < 10);
+      vi.mocked(fetchPageMetadata).mockResolvedValue({
+        title: 'Enriched Title',
+        description: 'New description',
+      });
+      const stats = { metadataFetches: 0 };
+
+      const result = await enrichSitemapCandidates(candidates, stats);
+
+      expect(result[0].title).toBe('Enriched Title');
+      expect(result[0].description).toBe('New description');
+      expect(stats.metadataFetches).toBe(1);
+    });
+
+    it('limits prefetching to 20 candidates', async () => {
+      const candidates = Array.from({ length: 30 }, (_, i) => ({
+        url: `https://example.com/${i}`,
+        title: 'X',
+      }));
+      vi.mocked(isPoorTitle).mockReturnValue(true);
+      vi.mocked(fetchPageMetadata).mockResolvedValue({ title: 'New Title' });
+      const stats = { metadataFetches: 0 };
+
+      await enrichSitemapCandidates(candidates, stats);
+
+      expect(stats.metadataFetches).toBe(20);
+    });
+
+    it('handles metadata fetch returning no title', async () => {
+      const candidates = [{ url: 'https://example.com/1', title: 'Bad', description: 'Original' }];
+      vi.mocked(isPoorTitle).mockReturnValue(true);
+      vi.mocked(fetchPageMetadata).mockResolvedValue({ title: null, description: 'New desc' });
+      const stats = { metadataFetches: 0 };
+
+      const result = await enrichSitemapCandidates(candidates, stats);
+
+      expect(result[0].title).toBe('Bad');
+      expect(result[0].description).toBe('Original');
+    });
+
+    it('processes in batches of 3', async () => {
+      const candidates = Array.from({ length: 6 }, (_, i) => ({
+        url: `https://example.com/${i}`,
+        title: 'X',
+      }));
+      vi.mocked(isPoorTitle).mockReturnValue(true);
+      vi.mocked(fetchPageMetadata).mockResolvedValue({ title: 'New' });
+      const stats = { metadataFetches: 0 };
+
+      await enrichSitemapCandidates(candidates, stats);
+
+      expect(stats.metadataFetches).toBe(6);
+    });
+
+    it('preserves original description if metadata has none', async () => {
+      const candidates = [{ url: 'https://example.com/1', title: 'X', description: 'Keep This' }];
+      vi.mocked(isPoorTitle).mockReturnValue(true);
+      vi.mocked(fetchPageMetadata).mockResolvedValue({ title: 'New Title', description: null });
+      const stats = { metadataFetches: 0 };
+
+      const result = await enrichSitemapCandidates(candidates, stats);
+
+      expect(result[0].title).toBe('New Title');
+      expect(result[0].description).toBe('Keep This');
+    });
+  });
+});

--- a/services/agent-api/src/agents/discoverer-fetch.test.js
+++ b/services/agent-api/src/agents/discoverer-fetch.test.js
@@ -1,0 +1,129 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/scrapers.js', () => ({
+  scrapeWebsite: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('../lib/sitemap.js', () => ({
+  fetchFromSitemap: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('../lib/discovery-rss.js', () => ({
+  fetchRSS: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('./discoverer-enrich.js', () => ({
+  enrichSitemapCandidates: vi.fn((candidates) => Promise.resolve(candidates)),
+}));
+
+import { fetchCandidatesFromSource } from './discoverer-fetch.js';
+import { fetchRSS } from '../lib/discovery-rss.js';
+import { fetchFromSitemap } from '../lib/sitemap.js';
+import { scrapeWebsite } from '../lib/scrapers.js';
+import { enrichSitemapCandidates } from './discoverer-enrich.js';
+
+describe('discoverer-fetch', () => {
+  const config = { maxAge: 7, retryAfterDays: 14 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  describe('fetchCandidatesFromSource', () => {
+    it('returns candidates from RSS when available', async () => {
+      const source = { slug: 'test', rss_feed: 'https://example.com/rss' };
+      const candidates = [{ url: 'https://example.com/article1', title: 'Article 1' }];
+      vi.mocked(fetchRSS).mockResolvedValue(candidates);
+
+      const result = await fetchCandidatesFromSource(source, config);
+
+      expect(result).toEqual(candidates);
+      expect(fetchRSS).toHaveBeenCalledWith(source, config);
+      expect(fetchFromSitemap).not.toHaveBeenCalled();
+      expect(scrapeWebsite).not.toHaveBeenCalled();
+    });
+
+    it('falls back to sitemap when RSS not available', async () => {
+      const source = { slug: 'test', sitemap_url: 'https://example.com/sitemap.xml' };
+      const candidates = [{ url: 'https://example.com/article1', title: 'Article 1' }];
+      vi.mocked(fetchFromSitemap).mockResolvedValue(candidates);
+
+      const result = await fetchCandidatesFromSource(source, config);
+
+      expect(result).toEqual(candidates);
+      expect(fetchFromSitemap).toHaveBeenCalledWith(source, config);
+    });
+
+    it('falls back to sitemap when RSS fails', async () => {
+      const source = {
+        slug: 'test',
+        rss_feed: 'https://example.com/rss',
+        sitemap_url: 'https://example.com/sitemap.xml',
+      };
+      vi.mocked(fetchRSS).mockRejectedValue(new Error('RSS parsing failed'));
+      vi.mocked(fetchFromSitemap).mockResolvedValue([{ url: 'https://example.com/article1' }]);
+
+      const result = await fetchCandidatesFromSource(source, config);
+
+      expect(result).toHaveLength(1);
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('RSS failed'));
+    });
+
+    it('falls back to scraper when sitemap fails', async () => {
+      const source = {
+        slug: 'test',
+        sitemap_url: 'https://example.com/sitemap.xml',
+        scraper_config: { selector: '.article' },
+      };
+      vi.mocked(fetchFromSitemap).mockRejectedValue(new Error('Sitemap not found'));
+      vi.mocked(scrapeWebsite).mockResolvedValue([{ url: 'https://example.com/article1' }]);
+
+      const result = await fetchCandidatesFromSource(source, config);
+
+      expect(result).toHaveLength(1);
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Sitemap failed'));
+    });
+
+    it('returns empty array when all methods fail', async () => {
+      const source = {
+        slug: 'test',
+        rss_feed: 'https://example.com/rss',
+        sitemap_url: 'https://example.com/sitemap.xml',
+        scraper_config: { selector: '.article' },
+      };
+      vi.mocked(fetchRSS).mockRejectedValue(new Error('RSS failed'));
+      vi.mocked(fetchFromSitemap).mockRejectedValue(new Error('Sitemap failed'));
+      vi.mocked(scrapeWebsite).mockRejectedValue(new Error('Scraper failed'));
+
+      const result = await fetchCandidatesFromSource(source, config);
+
+      expect(result).toEqual([]);
+    });
+
+    it('enriches sitemap candidates with stats', async () => {
+      const source = { slug: 'test', sitemap_url: 'https://example.com/sitemap.xml' };
+      const candidates = [{ url: 'https://example.com/article1' }];
+      const stats = { metadataFetches: 0 };
+      vi.mocked(fetchFromSitemap).mockResolvedValue(candidates);
+      vi.mocked(enrichSitemapCandidates).mockResolvedValue([
+        { url: 'https://example.com/article1', title: 'Enriched Title' },
+      ]);
+
+      const result = await fetchCandidatesFromSource(source, config, stats);
+
+      expect(enrichSitemapCandidates).toHaveBeenCalledWith(candidates, stats);
+      expect(result[0].title).toBe('Enriched Title');
+    });
+
+    it('returns empty when source has no feed methods', async () => {
+      const source = { slug: 'test' };
+
+      const result = await fetchCandidatesFromSource(source, config);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/services/agent-api/src/agents/discoverer-premium.test.js
+++ b/services/agent-api/src/agents/discoverer-premium.test.js
@@ -1,0 +1,193 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/status-codes.js', () => ({
+  STATUS: { PENDING_ENRICHMENT: 200 },
+}));
+
+vi.mock('../lib/discovery-queue.js', () => ({
+  checkExists: vi.fn(() => Promise.resolve('new')),
+}));
+
+vi.mock('../lib/premium-handler.js', () => ({
+  buildPremiumPayload: vi.fn((candidate, source) => ({
+    title: candidate.title,
+    source: source.name,
+    premium_mode: 'headline_only',
+  })),
+}));
+
+import { processPremiumCandidates } from './discoverer-premium.js';
+import { checkExists } from '../lib/discovery-queue.js';
+
+describe('discoverer-premium', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('processPremiumCandidates', () => {
+    const mockSource = { slug: 'premium-source', name: 'Premium Source' };
+    const mockCandidate = { url: 'https://example.com/article', title: 'Premium Article Title' };
+
+    it('queues premium candidates and returns results', async () => {
+      const mockSupabase = {
+        from: vi.fn(() => ({
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({ data: { id: 'queue-1' }, error: null })),
+            })),
+          })),
+        })),
+      };
+      const stats = { found: 0, new: 0 };
+
+      const results = await processPremiumCandidates({
+        supabase: mockSupabase,
+        candidates: [mockCandidate],
+        source: mockSource,
+        dryRun: false,
+        limit: null,
+        stats,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].action).toBe('premium');
+      expect(results[0].url).toBe(mockCandidate.url);
+      expect(stats.new).toBe(1);
+    });
+
+    it('skips existing candidates', async () => {
+      vi.mocked(checkExists).mockResolvedValue('skip');
+      const stats = { found: 0, new: 0 };
+
+      const results = await processPremiumCandidates({
+        supabase: {},
+        candidates: [mockCandidate],
+        source: mockSource,
+        dryRun: false,
+        limit: null,
+        stats,
+      });
+
+      expect(results).toHaveLength(0);
+      expect(stats.found).toBe(1);
+      expect(stats.new).toBe(0);
+    });
+
+    it('respects limit', async () => {
+      const stats = { found: 0, new: 5 };
+
+      const results = await processPremiumCandidates({
+        supabase: {},
+        candidates: [mockCandidate],
+        source: mockSource,
+        dryRun: false,
+        limit: 5,
+        stats,
+      });
+
+      expect(results).toHaveLength(0);
+    });
+
+    it('logs dry run without queuing', async () => {
+      vi.mocked(checkExists).mockResolvedValue('new');
+      const stats = { found: 0, new: 0 };
+
+      const results = await processPremiumCandidates({
+        supabase: {},
+        candidates: [mockCandidate],
+        source: mockSource,
+        dryRun: true,
+        limit: null,
+        stats,
+      });
+
+      expect(results).toHaveLength(0);
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[DRY]'));
+    });
+
+    it('handles duplicate constraint error gracefully', async () => {
+      vi.mocked(checkExists).mockResolvedValue('new');
+      const mockSupabase = {
+        from: vi.fn(() => ({
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({ data: null, error: { code: '23505' } })),
+            })),
+          })),
+        })),
+      };
+      const stats = { found: 0, new: 0, duplicate: 0 };
+
+      const results = await processPremiumCandidates({
+        supabase: mockSupabase,
+        candidates: [mockCandidate],
+        source: mockSource,
+        dryRun: false,
+        limit: null,
+        stats,
+      });
+
+      expect(results).toHaveLength(0);
+      expect(stats.duplicate).toBe(1);
+    });
+
+    it('logs error on non-duplicate insert failure', async () => {
+      vi.mocked(checkExists).mockResolvedValue('new');
+      const mockSupabase = {
+        from: vi.fn(() => ({
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({ data: null, error: { message: 'DB error' } })),
+            })),
+          })),
+        })),
+      };
+      const stats = { found: 0, new: 0 };
+
+      const results = await processPremiumCandidates({
+        supabase: mockSupabase,
+        candidates: [mockCandidate],
+        source: mockSource,
+        dryRun: false,
+        limit: null,
+        stats,
+      });
+
+      expect(results).toHaveLength(0);
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to queue'));
+    });
+
+    it('processes multiple candidates', async () => {
+      vi.mocked(checkExists).mockResolvedValue('new');
+      const mockSupabase = {
+        from: vi.fn(() => ({
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({ data: { id: 'queue-1' }, error: null })),
+            })),
+          })),
+        })),
+      };
+      const candidates = [
+        { url: 'https://example.com/1', title: 'Article 1' },
+        { url: 'https://example.com/2', title: 'Article 2' },
+      ];
+      const stats = { found: 0, new: 0 };
+
+      const results = await processPremiumCandidates({
+        supabase: mockSupabase,
+        candidates,
+        source: mockSource,
+        dryRun: false,
+        limit: null,
+        stats,
+      });
+
+      expect(results).toHaveLength(2);
+      expect(stats.new).toBe(2);
+    });
+  });
+});

--- a/services/agent-api/src/agents/discoverer-run.test.js
+++ b/services/agent-api/src/agents/discoverer-run.test.js
@@ -1,0 +1,237 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/discovery-scoring.js', () => ({
+  processCandidates: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('../lib/embeddings.js', () => ({
+  getReferenceEmbedding: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock('../lib/discovery-config.js', () => ({
+  loadDiscoveryConfig: vi.fn(() => Promise.resolve({ maxAge: 7, retryAfterDays: 14 })),
+}));
+
+vi.mock('../lib/discovery-logging.js', () => ({
+  createStats: vi.fn(() => ({
+    found: 0,
+    new: 0,
+    retried: 0,
+    skipped: 0,
+    totalTokens: 0,
+  })),
+  logSummary: vi.fn(),
+}));
+
+vi.mock('../lib/status-codes.js', () => ({
+  loadStatusCodes: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../lib/premium-handler.js', () => ({
+  filterPremiumCandidates: vi.fn((c) => c),
+  getPremiumMode: vi.fn(() => 'headline_only'),
+  isPremiumSource: vi.fn(() => false),
+}));
+
+vi.mock('./discoverer-fetch.js', () => ({
+  fetchCandidatesFromSource: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('./discoverer-premium.js', () => ({
+  processPremiumCandidates: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock('./discoverer-sources.js', () => ({
+  loadSources: vi.fn(() => Promise.resolve([])),
+  logSkippedPremiumSources: vi.fn(() => Promise.resolve()),
+}));
+
+import { runDiscoveryImpl } from './discoverer-run.js';
+import { loadSources } from './discoverer-sources.js';
+import { fetchCandidatesFromSource } from './discoverer-fetch.js';
+import { processCandidates } from '../lib/discovery-scoring.js';
+import { getReferenceEmbedding } from '../lib/embeddings.js';
+import { logSummary, createStats } from '../lib/discovery-logging.js';
+import { isPremiumSource } from '../lib/premium-handler.js';
+import { processPremiumCandidates } from './discoverer-premium.js';
+
+describe('discoverer-run', () => {
+  const mockSupabase = {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() => Promise.resolve({ data: { value: true } })),
+        })),
+      })),
+    })),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('runDiscoveryImpl', () => {
+    it('returns early when discovery is disabled', async () => {
+      const disabledSupabase = {
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() => Promise.resolve({ data: { value: false } })),
+            })),
+          })),
+        })),
+      };
+
+      const result = await runDiscoveryImpl(disabledSupabase, {});
+
+      expect(result).toEqual({ found: 0, new: 0, items: [], skipped: 'disabled' });
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('disabled'));
+    });
+
+    it('returns empty when no sources found', async () => {
+      vi.mocked(loadSources).mockResolvedValue([]);
+
+      const result = await runDiscoveryImpl(mockSupabase, {});
+
+      expect(result).toEqual({ found: 0, new: 0, items: [] });
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No enabled sources'));
+    });
+
+    it('processes sources and returns results', async () => {
+      const mockSource = { slug: 'test', name: 'Test Source', url: 'https://test.com' };
+      vi.mocked(loadSources).mockResolvedValue([mockSource]);
+      vi.mocked(fetchCandidatesFromSource).mockResolvedValue([
+        { url: 'https://test.com/article1', title: 'Article 1' },
+      ]);
+      vi.mocked(processCandidates).mockResolvedValue([
+        { url: 'https://test.com/article1', action: 'queued' },
+      ]);
+      vi.mocked(createStats).mockReturnValue({
+        found: 1,
+        new: 1,
+        retried: 0,
+        skipped: 0,
+        totalTokens: 0,
+      });
+
+      await runDiscoveryImpl(mockSupabase, {});
+
+      expect(fetchCandidatesFromSource).toHaveBeenCalledWith(
+        mockSource,
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(processCandidates).toHaveBeenCalled();
+      expect(logSummary).toHaveBeenCalled();
+    });
+
+    it('logs startup with correct mode', async () => {
+      vi.mocked(loadSources).mockResolvedValue([]);
+
+      await runDiscoveryImpl(mockSupabase, { hybrid: true });
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Scoring: hybrid'));
+    });
+
+    it('uses agentic mode when specified', async () => {
+      vi.mocked(loadSources).mockResolvedValue([]);
+
+      await runDiscoveryImpl(mockSupabase, { agentic: true });
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Scoring: agentic'));
+    });
+
+    it('respects dry run mode', async () => {
+      vi.mocked(loadSources).mockResolvedValue([]);
+
+      await runDiscoveryImpl(mockSupabase, { dryRun: true });
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('DRY RUN'));
+    });
+
+    it('respects limit option', async () => {
+      vi.mocked(loadSources).mockResolvedValue([]);
+
+      await runDiscoveryImpl(mockSupabase, { limit: 10 });
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Limit: 10'));
+    });
+
+    it('skips enabled check when flag is set', async () => {
+      vi.mocked(loadSources).mockResolvedValue([]);
+
+      await runDiscoveryImpl(mockSupabase, { skipEnabledCheck: true });
+
+      expect(mockSupabase.from).not.toHaveBeenCalledWith('system_config');
+    });
+
+    it('handles hybrid mode with reference embedding', async () => {
+      vi.mocked(loadSources).mockResolvedValue([]);
+      vi.mocked(getReferenceEmbedding).mockResolvedValue([0.1, 0.2, 0.3]);
+
+      await runDiscoveryImpl(mockSupabase, { hybrid: true });
+
+      expect(getReferenceEmbedding).toHaveBeenCalled();
+    });
+
+    it('falls back to agentic when no reference embedding available', async () => {
+      vi.mocked(loadSources).mockResolvedValue([]);
+      vi.mocked(getReferenceEmbedding).mockResolvedValue(null);
+
+      await runDiscoveryImpl(mockSupabase, { hybrid: true, agentic: true });
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('falling back to agentic'));
+    });
+
+    it('processes premium sources differently', async () => {
+      const premiumSource = { slug: 'premium', name: 'Premium Source', url: 'https://premium.com' };
+      vi.mocked(loadSources).mockResolvedValue([premiumSource]);
+      vi.mocked(isPremiumSource).mockReturnValue(true);
+      vi.mocked(fetchCandidatesFromSource).mockResolvedValue([]);
+      vi.mocked(processPremiumCandidates).mockResolvedValue([]);
+
+      await runDiscoveryImpl(mockSupabase, { premium: true });
+
+      expect(processPremiumCandidates).toHaveBeenCalled();
+      expect(processCandidates).not.toHaveBeenCalled();
+    });
+
+    it('handles source processing errors gracefully', async () => {
+      const mockSource = { slug: 'fail', name: 'Failing Source', url: 'https://fail.com' };
+      vi.mocked(loadSources).mockResolvedValue([mockSource]);
+      vi.mocked(fetchCandidatesFromSource).mockRejectedValue(new Error('Network error'));
+
+      const result = await runDiscoveryImpl(mockSupabase, {});
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed source'),
+        'Network error',
+      );
+      expect(result.items).toEqual([]);
+    });
+
+    it('stops when limit is reached', async () => {
+      const sources = [
+        { slug: 's1', name: 'Source 1', url: 'https://s1.com' },
+        { slug: 's2', name: 'Source 2', url: 'https://s2.com' },
+      ];
+      vi.mocked(loadSources).mockResolvedValue(sources);
+      vi.mocked(fetchCandidatesFromSource).mockResolvedValue([]);
+      vi.mocked(processCandidates).mockResolvedValue([]);
+      vi.mocked(createStats).mockReturnValue({
+        found: 5,
+        new: 5,
+        retried: 0,
+        skipped: 0,
+        totalTokens: 0,
+      });
+
+      await runDiscoveryImpl(mockSupabase, { limit: 5 });
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Reached limit'));
+    });
+  });
+});

--- a/services/agent-api/src/agents/discoverer-sources.test.js
+++ b/services/agent-api/src/agents/discoverer-sources.test.js
@@ -1,0 +1,170 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadSources, logSkippedPremiumSources } from './discoverer-sources.js';
+
+describe('discoverer-sources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  describe('loadSources', () => {
+    it('loads enabled sources with feed methods', async () => {
+      const mockSources = [
+        { slug: 'source1', name: 'Source 1', rss_feed: 'https://example.com/rss' },
+        { slug: 'source2', name: 'Source 2', sitemap_url: 'https://example.com/sitemap.xml' },
+      ];
+
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        neq: vi.fn().mockResolvedValue({ data: mockSources, error: null }),
+      };
+
+      const supabase = {
+        from: vi.fn(() => ({
+          select: vi.fn(() => mockQuery),
+        })),
+      };
+
+      const result = await loadSources(supabase);
+
+      expect(result).toEqual(mockSources);
+      expect(supabase.from).toHaveBeenCalledWith('kb_source');
+    });
+
+    it('filters by source slug when provided', async () => {
+      const mockSource = { slug: 'specific', name: 'Specific Source' };
+      const eqMock = vi.fn().mockResolvedValue({ data: [mockSource], error: null });
+
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        order: vi.fn(() => ({ eq: eqMock })),
+        neq: vi.fn().mockReturnThis(),
+      };
+
+      const supabase = {
+        from: vi.fn(() => ({
+          select: vi.fn(() => mockQuery),
+        })),
+      };
+
+      const result = await loadSources(supabase, 'specific');
+
+      expect(result).toEqual([mockSource]);
+    });
+
+    it('includes premium sources when flag is true', async () => {
+      const mockSources = [{ slug: 'premium1', name: 'Premium Source', tier: 'premium' }];
+
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: mockSources, error: null }),
+        neq: vi.fn().mockReturnThis(),
+      };
+
+      const supabase = {
+        from: vi.fn(() => ({
+          select: vi.fn(() => mockQuery),
+        })),
+      };
+
+      const result = await loadSources(supabase, null, true);
+
+      expect(result).toEqual(mockSources);
+    });
+
+    it('throws on database error', async () => {
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        neq: vi.fn().mockResolvedValue({ data: null, error: new Error('DB error') }),
+      };
+
+      const supabase = {
+        from: vi.fn(() => ({
+          select: vi.fn(() => mockQuery),
+        })),
+      };
+
+      await expect(loadSources(supabase)).rejects.toThrow('DB error');
+    });
+
+    it('returns empty array when no sources found', async () => {
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        neq: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+
+      const supabase = {
+        from: vi.fn(() => ({
+          select: vi.fn(() => mockQuery),
+        })),
+      };
+
+      const result = await loadSources(supabase);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('logSkippedPremiumSources', () => {
+    it('does nothing when sourceSlug is provided', async () => {
+      const supabase = { from: vi.fn() };
+
+      await logSkippedPremiumSources(supabase, 'specific-source', false);
+
+      expect(supabase.from).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when includePremium is true', async () => {
+      const supabase = { from: vi.fn() };
+
+      await logSkippedPremiumSources(supabase, null, true);
+
+      expect(supabase.from).not.toHaveBeenCalled();
+    });
+
+    it('logs skipped premium sources', async () => {
+      const premiumSources = [{ name: 'Premium 1' }, { name: 'Premium 2' }];
+      const supabase = {
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn().mockResolvedValue({ data: premiumSources }),
+            })),
+          })),
+        })),
+      };
+
+      await logSkippedPremiumSources(supabase, null, false);
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping 2 premium sources'),
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Premium 1, Premium 2'));
+    });
+
+    it('does nothing when no premium sources exist', async () => {
+      const supabase = {
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn().mockResolvedValue({ data: [] }),
+            })),
+          })),
+        })),
+      };
+
+      await logSkippedPremiumSources(supabase, null, false);
+
+      expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining('Skipping'));
+    });
+  });
+});

--- a/services/agent-api/src/agents/improver-report.test.js
+++ b/services/agent-api/src/agents/improver-report.test.js
@@ -1,0 +1,136 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFrom = vi.fn();
+
+vi.mock('./improver-config.js', () => ({
+  getSupabase: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { generateImprovementReport } from './improver-report.js';
+
+describe('improver-report', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('generateImprovementReport', () => {
+    it('generates report with all sections', async () => {
+      // Mock category counts query
+      mockFrom.mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          not: vi.fn().mockResolvedValue({
+            data: [
+              { miss_category: 'source_not_tracked' },
+              { miss_category: 'source_not_tracked' },
+              { miss_category: 'filter_rejected' },
+            ],
+          }),
+        }),
+      });
+
+      // Mock missed domains query
+      mockFrom.mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  source_domain: 'example.com',
+                  submitter_urgency: 'important',
+                  why_valuable: 'Good content',
+                },
+              ],
+            }),
+          }),
+        }),
+      });
+
+      // Mock filter rejections query
+      mockFrom.mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({
+                data: [
+                  { miss_details: { relevance_scores: { exec: 3 } }, why_valuable: 'Missed this' },
+                ],
+              }),
+            }),
+          }),
+        }),
+      });
+
+      const result = await generateImprovementReport();
+
+      expect(result.generated_at).toBeDefined();
+      expect(result.summary.by_category).toEqual({
+        source_not_tracked: 2,
+        filter_rejected: 1,
+      });
+      expect(result.suggestions.add_sources).toHaveLength(1);
+      expect(result.suggestions.tune_filter).toHaveLength(1);
+    });
+
+    it('handles empty data gracefully', async () => {
+      mockFrom.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          not: vi.fn().mockResolvedValue({ data: null }),
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({ data: null }),
+            }),
+          }),
+        }),
+      });
+
+      const result = await generateImprovementReport();
+
+      expect(result.summary.total_pending).toBe(0);
+      expect(result.suggestions.add_sources).toEqual([]);
+    });
+
+    it('sorts missed domains by count', async () => {
+      mockFrom.mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          not: vi.fn().mockResolvedValue({ data: [] }),
+        }),
+      });
+
+      mockFrom.mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: [
+                { source_domain: 'low.com', submitter_urgency: null, why_valuable: null },
+                { source_domain: 'high.com', submitter_urgency: null, why_valuable: null },
+                {
+                  source_domain: 'high.com',
+                  submitter_urgency: 'critical',
+                  why_valuable: 'Important',
+                },
+                { source_domain: 'high.com', submitter_urgency: null, why_valuable: null },
+              ],
+            }),
+          }),
+        }),
+      });
+
+      mockFrom.mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({ data: [] }),
+            }),
+          }),
+        }),
+      });
+
+      const result = await generateImprovementReport();
+
+      expect(result.suggestions.add_sources[0].domain).toBe('high.com');
+      expect(result.suggestions.add_sources[0].miss_count).toBe(3);
+      expect(result.suggestions.add_sources[0].has_critical).toBe(true);
+    });
+  });
+});

--- a/services/agent-api/src/agents/tagger-prompt.test.js
+++ b/services/agent-api/src/agents/tagger-prompt.test.js
@@ -1,0 +1,221 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./tagger-config.js', () => ({
+  getGeographyFromTld: vi.fn(() => Promise.resolve(null)),
+}));
+
+import {
+  extractTld,
+  buildCountryTldHint,
+  buildContextData,
+  buildSystemPrompt,
+  buildUserContent,
+  logPromptDebug,
+  logTopicDebug,
+} from './tagger-prompt.js';
+import { getGeographyFromTld } from './tagger-config.js';
+
+describe('tagger-prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  describe('extractTld', () => {
+    it('extracts TLD from URL', () => {
+      expect(extractTld('https://example.com/page')).toBe('com');
+    });
+
+    it('extracts country TLD', () => {
+      expect(extractTld('https://example.nl/page')).toBe('nl');
+    });
+
+    it('handles URL with path', () => {
+      expect(extractTld('https://example.co.uk/path/to/page')).toBe('uk');
+    });
+
+    it('returns empty string for null URL', () => {
+      expect(extractTld(null)).toBe('');
+    });
+
+    it('returns empty string for undefined URL', () => {
+      expect(extractTld(undefined)).toBe('');
+    });
+
+    it('returns empty string for empty URL', () => {
+      expect(extractTld('')).toBe('');
+    });
+  });
+
+  describe('buildCountryTldHint', () => {
+    it('returns empty string when no geography match', async () => {
+      vi.mocked(getGeographyFromTld).mockResolvedValue(null);
+
+      const result = await buildCountryTldHint('https://example.com/page');
+
+      expect(result).toBe('');
+    });
+
+    it('returns hint when geography matches TLD', async () => {
+      vi.mocked(getGeographyFromTld).mockResolvedValue({
+        code: 'nl',
+        name: 'Netherlands',
+      });
+
+      const result = await buildCountryTldHint('https://example.nl/page');
+
+      expect(result).toContain('.nl');
+      expect(result).toContain('NL');
+      expect(result).toContain('Netherlands');
+    });
+  });
+
+  describe('buildContextData', () => {
+    it('builds context with all fields', () => {
+      const payload = {
+        title: 'Test Article',
+        summary: { short: 'Summary text' },
+        url: 'https://example.com',
+      };
+      const taxonomies = {
+        industries: 'banking, insurance',
+        topics: 'AI, ML',
+        geographies: 'NL, EU',
+        useCases: 'fraud detection',
+        capabilities: 'automation',
+        regulators: 'ECB',
+        regulations: 'GDPR',
+        obligations: 'reporting',
+        processes: 'kyc',
+      };
+      const vendorData = { formatted: 'Vendor1, Vendor2' };
+      const countryTldHint = 'NOTE: .nl domain';
+
+      const result = buildContextData(payload, taxonomies, vendorData, countryTldHint);
+
+      expect(result.title).toBe('Test Article');
+      expect(result.summary).toBe('Summary text');
+      expect(result.url).toBe('https://example.com');
+      expect(result.countryTldHint).toBe('NOTE: .nl domain');
+      expect(result.industries).toBe('banking, insurance');
+      expect(result.vendors).toBe('Vendor1, Vendor2');
+    });
+
+    it('uses description fallback when summary missing', () => {
+      const payload = {
+        title: 'Test',
+        description: 'Description text',
+      };
+      const taxonomies = {
+        industries: '',
+        topics: '',
+        geographies: '',
+        useCases: '',
+        capabilities: '',
+        regulators: '',
+        regulations: '',
+        obligations: '',
+        processes: '',
+      };
+
+      const result = buildContextData(payload, taxonomies, { formatted: '' }, '');
+
+      expect(result.summary).toBe('Description text');
+    });
+  });
+
+  describe('buildSystemPrompt', () => {
+    it('replaces placeholders with context data', () => {
+      const template = 'Title: {{title}}, Summary: {{summary}}';
+      const contextData = { title: 'My Title', summary: 'My Summary' };
+
+      const result = buildSystemPrompt(template, contextData);
+
+      expect(result).toBe('Title: My Title, Summary: My Summary');
+    });
+
+    it('replaces multiple occurrences of same placeholder', () => {
+      const template = '{{title}} - {{title}}';
+      const contextData = { title: 'Repeated' };
+
+      const result = buildSystemPrompt(template, contextData);
+
+      expect(result).toBe('Repeated - Repeated');
+    });
+
+    it('handles null values', () => {
+      const template = 'Value: {{field}}';
+      const contextData = { field: null };
+
+      const result = buildSystemPrompt(template, contextData);
+
+      expect(result).toBe('Value: ');
+    });
+  });
+
+  describe('buildUserContent', () => {
+    it('builds user content with all fields', () => {
+      const payload = {
+        title: 'Article Title',
+        summary: { short: 'Short summary' },
+        url: 'https://example.com/article',
+      };
+
+      const result = buildUserContent(payload);
+
+      expect(result).toContain('TITLE: Article Title');
+      expect(result).toContain('SUMMARY: Short summary');
+      expect(result).toContain('URL: https://example.com/article');
+    });
+
+    it('uses description fallback when no summary', () => {
+      const payload = {
+        title: 'Title',
+        description: 'Description fallback',
+      };
+
+      const result = buildUserContent(payload);
+
+      expect(result).toContain('SUMMARY: Description fallback');
+    });
+
+    it('handles missing URL', () => {
+      const payload = {
+        title: 'Title',
+        summary: { short: 'Summary' },
+      };
+
+      const result = buildUserContent(payload);
+
+      expect(result).toContain('URL: ');
+    });
+  });
+
+  describe('logPromptDebug', () => {
+    it('logs debug info', () => {
+      logPromptDebug('prompt with Kee Platforms', 'content', 'system prompt');
+
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[tagger]'));
+    });
+
+    it('handles null prompt template', () => {
+      logPromptDebug(null, 'content', 'system');
+
+      expect(console.log).toHaveBeenCalled();
+    });
+  });
+
+  describe('logTopicDebug', () => {
+    it('logs topic debug info', () => {
+      const rawTopics = ['topic1', 'topic2'];
+      const validatedTopics = ['topic1'];
+      const validCodes = { topics: new Set(['topic1']) };
+
+      logTopicDebug(rawTopics, validatedTopics, validCodes);
+
+      expect(console.log).toHaveBeenCalled();
+      expect(console.log.mock.calls.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/services/agent-api/src/agents/thumbnailer-browser.test.js
+++ b/services/agent-api/src/agents/thumbnailer-browser.test.js
@@ -1,0 +1,189 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Buffer } from 'node:buffer';
+
+vi.mock('playwright', () => ({
+  chromium: {
+    launch: vi.fn(() =>
+      Promise.resolve({
+        newContext: vi.fn(() =>
+          Promise.resolve({
+            newPage: vi.fn(),
+            close: vi.fn(),
+          }),
+        ),
+        close: vi.fn(),
+      }),
+    ),
+  },
+}));
+
+import {
+  validateUrlScheme,
+  launchBrowser,
+  createBrowserContext,
+  loadAndPreparePage,
+  captureScreenshot,
+  uploadScreenshot,
+} from './thumbnailer-browser.js';
+
+describe('thumbnailer-browser', () => {
+  const mockStepTracker = {
+    start: vi.fn(() => Promise.resolve('step-1')),
+    success: vi.fn(() => Promise.resolve()),
+    error: vi.fn(() => Promise.resolve()),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  describe('validateUrlScheme', () => {
+    it('accepts http:// URLs', () => {
+      expect(() => validateUrlScheme('http://example.com')).not.toThrow();
+    });
+
+    it('accepts https:// URLs', () => {
+      expect(() => validateUrlScheme('https://example.com')).not.toThrow();
+    });
+
+    it('accepts uppercase HTTP', () => {
+      expect(() => validateUrlScheme('HTTPS://example.com')).not.toThrow();
+    });
+
+    it('rejects ftp:// URLs', () => {
+      expect(() => validateUrlScheme('ftp://example.com')).toThrow('Invalid URL scheme');
+    });
+
+    it('rejects file:// URLs', () => {
+      expect(() => validateUrlScheme('file:///etc/passwd')).toThrow('Invalid URL scheme');
+    });
+
+    it('rejects URLs without scheme', () => {
+      expect(() => validateUrlScheme('example.com')).toThrow('Invalid URL scheme');
+    });
+
+    it('rejects javascript: URLs', () => {
+      expect(() => validateUrlScheme('javascript:alert(1)')).toThrow('Invalid URL scheme');
+    });
+  });
+
+  describe('launchBrowser', () => {
+    it('launches browser and tracks step', async () => {
+      const browser = await launchBrowser('https://example.com', mockStepTracker);
+
+      expect(browser).toBeDefined();
+      expect(mockStepTracker.start).toHaveBeenCalledWith('browser_launch', {
+        url: 'https://example.com',
+      });
+      expect(mockStepTracker.success).toHaveBeenCalledWith('step-1', { status: 'launched' });
+    });
+  });
+
+  describe('createBrowserContext', () => {
+    it('creates context with correct viewport', async () => {
+      const mockBrowser = {
+        newContext: vi.fn(() => Promise.resolve({ close: vi.fn() })),
+      };
+      const config = { viewport: { width: 1280, height: 720 } };
+
+      await createBrowserContext(mockBrowser, config);
+
+      expect(mockBrowser.newContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          viewport: { width: 1280, height: 720 },
+          deviceScaleFactor: 1,
+        }),
+      );
+    });
+  });
+
+  describe('captureScreenshot', () => {
+    it('captures screenshot and returns buffer', async () => {
+      const mockPage = {
+        screenshot: vi.fn(() => Promise.resolve(Buffer.from('screenshot'))),
+      };
+
+      const result = await captureScreenshot(mockPage, mockStepTracker);
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(mockStepTracker.start).toHaveBeenCalledWith('screenshot', { quality: 80 });
+      expect(mockStepTracker.success).toHaveBeenCalled();
+    });
+
+    it('tracks error on screenshot failure', async () => {
+      const mockPage = {
+        screenshot: vi.fn(() => Promise.reject(new Error('Screenshot failed'))),
+      };
+
+      await expect(captureScreenshot(mockPage, mockStepTracker)).rejects.toThrow(
+        'Screenshot failed',
+      );
+      expect(mockStepTracker.error).toHaveBeenCalledWith('step-1', 'Screenshot failed');
+    });
+  });
+
+  describe('uploadScreenshot', () => {
+    it('uploads screenshot to storage', async () => {
+      const mockSupabase = {
+        storage: {
+          from: vi.fn(() => ({
+            upload: vi.fn(() => Promise.resolve({ error: null })),
+            getPublicUrl: vi.fn(() => ({
+              data: { publicUrl: 'https://storage.example.com/thumb.jpg' },
+            })),
+          })),
+        },
+      };
+
+      const result = await uploadScreenshot(
+        Buffer.from('image'),
+        'queue-123',
+        mockSupabase,
+        mockStepTracker,
+      );
+
+      expect(result.path).toBe('thumbnails/queue-123.jpg');
+      expect(result.publicUrl).toBe('https://storage.example.com/thumb.jpg');
+      expect(mockStepTracker.success).toHaveBeenCalled();
+    });
+
+    it('throws on upload error', async () => {
+      const mockSupabase = {
+        storage: {
+          from: vi.fn(() => ({
+            upload: vi.fn(() => Promise.resolve({ error: { message: 'Storage error' } })),
+          })),
+        },
+      };
+
+      await expect(
+        uploadScreenshot(Buffer.from('image'), 'queue-123', mockSupabase, mockStepTracker),
+      ).rejects.toThrow('Storage error');
+      expect(mockStepTracker.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('loadAndPreparePage', () => {
+    it('loads page and prepares for screenshot', async () => {
+      const mockPage = {
+        goto: vi.fn(() => Promise.resolve()),
+        evaluate: vi.fn(() => Promise.resolve()),
+        addStyleTag: vi.fn(() => Promise.resolve()),
+      };
+      const config = { timeout: 30000, wait: 1000, viewport: { width: 1280, height: 720 } };
+
+      await loadAndPreparePage(mockPage, 'https://example.com', config, mockStepTracker);
+
+      expect(mockPage.goto).toHaveBeenCalledWith(
+        'https://example.com',
+        expect.objectContaining({ timeout: 30000 }),
+      );
+      expect(mockPage.addStyleTag).toHaveBeenCalled();
+      expect(mockStepTracker.start).toHaveBeenCalledWith('page_load', {
+        url: 'https://example.com',
+      });
+    });
+  });
+});

--- a/services/agent-api/src/agents/thumbnailer-pdf.test.js
+++ b/services/agent-api/src/agents/thumbnailer-pdf.test.js
@@ -1,0 +1,147 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Buffer } from 'node:buffer';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(() => Promise.resolve()),
+  unlink: vi.fn(() => Promise.resolve()),
+  readFile: vi.fn(() => Promise.resolve(Buffer.from('fake-image'))),
+}));
+
+import { downloadPdf, storePdf, uploadThumbnail } from './thumbnailer-pdf.js';
+
+describe('thumbnailer-pdf', () => {
+  const mockStepTracker = {
+    start: vi.fn(() => Promise.resolve('step-1')),
+    success: vi.fn(() => Promise.resolve()),
+    error: vi.fn(() => Promise.resolve()),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = vi.fn();
+  });
+
+  describe('downloadPdf', () => {
+    it('downloads PDF and returns buffer', async () => {
+      const pdfContent = Buffer.from('PDF content');
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(pdfContent),
+      });
+
+      const result = await downloadPdf('https://example.com/doc.pdf', mockStepTracker);
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(mockStepTracker.start).toHaveBeenCalledWith('pdf_download', {
+        url: 'https://example.com/doc.pdf',
+      });
+      expect(mockStepTracker.success).toHaveBeenCalled();
+    });
+
+    it('throws on HTTP error', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      await expect(downloadPdf('https://example.com/missing.pdf', mockStepTracker)).rejects.toThrow(
+        'HTTP 404',
+      );
+      expect(mockStepTracker.error).toHaveBeenCalled();
+    });
+
+    it('tracks step on error', async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+      await expect(downloadPdf('https://example.com/doc.pdf', mockStepTracker)).rejects.toThrow(
+        'Network error',
+      );
+      expect(mockStepTracker.error).toHaveBeenCalledWith('step-1', 'Network error');
+    });
+  });
+
+  describe('storePdf', () => {
+    it('uploads PDF to storage and returns path', async () => {
+      const mockSupabase = {
+        storage: {
+          from: vi.fn(() => ({
+            upload: vi.fn(() => Promise.resolve({ error: null })),
+            getPublicUrl: vi.fn(() => ({
+              data: { publicUrl: 'https://storage.example.com/pdf.pdf' },
+            })),
+          })),
+        },
+      };
+
+      const result = await storePdf(Buffer.from('pdf'), 'queue-123', mockSupabase, mockStepTracker);
+
+      expect(result.pdfPath).toBe('pdfs/queue-123.pdf');
+      expect(result.publicUrl).toBe('https://storage.example.com/pdf.pdf');
+      expect(mockStepTracker.success).toHaveBeenCalled();
+    });
+
+    it('throws on upload error', async () => {
+      const mockSupabase = {
+        storage: {
+          from: vi.fn(() => ({
+            upload: vi.fn(() => Promise.resolve({ error: { message: 'Upload failed' } })),
+          })),
+        },
+      };
+
+      await expect(
+        storePdf(Buffer.from('pdf'), 'queue-123', mockSupabase, mockStepTracker),
+      ).rejects.toThrow('Upload failed');
+      expect(mockStepTracker.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('uploadThumbnail', () => {
+    it('uploads thumbnail to storage and returns path', async () => {
+      const mockSupabase = {
+        storage: {
+          from: vi.fn(() => ({
+            upload: vi.fn(() => Promise.resolve({ error: null })),
+            getPublicUrl: vi.fn(() => ({
+              data: { publicUrl: 'https://storage.example.com/thumb.jpg' },
+            })),
+          })),
+        },
+      };
+
+      const result = await uploadThumbnail(
+        Buffer.from('image'),
+        'queue-123',
+        mockSupabase,
+        mockStepTracker,
+      );
+
+      expect(result.thumbnailPath).toBe('thumbnails/queue-123.jpg');
+      expect(result.publicUrl).toBe('https://storage.example.com/thumb.jpg');
+      expect(mockStepTracker.success).toHaveBeenCalled();
+    });
+
+    it('throws on upload error', async () => {
+      const mockSupabase = {
+        storage: {
+          from: vi.fn(() => ({
+            upload: vi.fn(() => Promise.resolve({ error: { message: 'Thumbnail upload failed' } })),
+          })),
+        },
+      };
+
+      await expect(
+        uploadThumbnail(Buffer.from('image'), 'queue-123', mockSupabase, mockStepTracker),
+      ).rejects.toThrow('Thumbnail upload failed');
+      expect(mockStepTracker.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/services/agent-api/src/lib/content-fetcher-http.test.js
+++ b/services/agent-api/src/lib/content-fetcher-http.test.js
@@ -1,0 +1,157 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  delay,
+  FETCH_HEADERS,
+  handleHttpError,
+  handleFetchError,
+  attemptFetch,
+} from './content-fetcher-http.js';
+
+describe('content-fetcher-http', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    globalThis.fetch = vi.fn();
+  });
+
+  describe('delay', () => {
+    it('resolves after specified time', async () => {
+      const start = Date.now();
+      await delay(50);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(40);
+    });
+  });
+
+  describe('FETCH_HEADERS', () => {
+    it('has User-Agent header', () => {
+      expect(FETCH_HEADERS['User-Agent']).toContain('Mozilla');
+    });
+
+    it('has Accept header', () => {
+      expect(FETCH_HEADERS['Accept']).toContain('text/html');
+    });
+
+    it('has Accept-Language header', () => {
+      expect(FETCH_HEADERS['Accept-Language']).toContain('en');
+    });
+  });
+
+  describe('handleHttpError', () => {
+    it('returns permanentFailure for 404', () => {
+      const response = { status: 404 };
+      const result = handleHttpError(response, 1, 3);
+      expect(result.permanentFailure).toBe(true);
+      expect(result.status).toBe(404);
+    });
+
+    it('returns permanentFailure for 410 Gone', () => {
+      const response = { status: 410 };
+      const result = handleHttpError(response, 1, 3);
+      expect(result.permanentFailure).toBe(true);
+    });
+
+    it('returns forbidden for 403', () => {
+      const response = { status: 403 };
+      const result = handleHttpError(response, 1, 3);
+      expect(result.forbidden).toBe(true);
+    });
+
+    it('returns retry for 500 when retries remain', () => {
+      const response = { status: 500 };
+      const result = handleHttpError(response, 1, 3);
+      expect(result.retry).toBe(true);
+    });
+
+    it('returns shouldThrow for 500 when no retries remain', () => {
+      const response = { status: 500 };
+      const result = handleHttpError(response, 3, 3);
+      expect(result.shouldThrow).toBe(true);
+    });
+
+    it('returns shouldThrow for non-retryable status', () => {
+      const response = { status: 400 };
+      const result = handleHttpError(response, 1, 3);
+      expect(result.shouldThrow).toBe(true);
+    });
+  });
+
+  describe('handleFetchError', () => {
+    it('returns retry for timeout when retries remain', () => {
+      const error = { name: 'AbortError' };
+      const result = handleFetchError(error, 1, 3);
+      expect(result.retry).toBe(true);
+    });
+
+    it('returns shouldThrow for timeout when no retries remain', () => {
+      const error = { name: 'AbortError' };
+      const result = handleFetchError(error, 3, 3);
+      expect(result.shouldThrow).toBe(true);
+      expect(result.message).toBe('Request timeout');
+    });
+
+    it('returns retry for network error when retries remain', () => {
+      const error = { message: 'Network error' };
+      const result = handleFetchError(error, 1, 3);
+      expect(result.retry).toBe(true);
+    });
+
+    it('returns shouldThrow with error when no retries remain', () => {
+      const error = new Error('Network failed');
+      const result = handleFetchError(error, 3, 3);
+      expect(result.shouldThrow).toBe(true);
+      expect(result.error).toBe(error);
+    });
+  });
+
+  describe('attemptFetch', () => {
+    it('returns success with HTML on successful fetch', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('<html>content</html>'),
+      });
+
+      const result = await attemptFetch('https://example.com', 1, 3);
+
+      expect(result.success).toBe(true);
+      expect(result.html).toBe('<html>content</html>');
+    });
+
+    it('returns retry for 500 error', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      const result = await attemptFetch('https://example.com', 1, 3);
+
+      expect(result.retry).toBe(true);
+    });
+
+    it('throws for permanent failure', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await attemptFetch('https://example.com', 1, 3);
+
+      expect(result.permanentFailure).toBe(true);
+    });
+
+    it('handles network errors with retry', async () => {
+      vi.mocked(globalThis.fetch).mockRejectedValue(new Error('Network error'));
+
+      const result = await attemptFetch('https://example.com', 1, 3);
+
+      expect(result.retry).toBe(true);
+    });
+
+    it('throws when all retries exhausted on error', async () => {
+      vi.mocked(globalThis.fetch).mockRejectedValue(new Error('Network error'));
+
+      await expect(attemptFetch('https://example.com', 3, 3)).rejects.toThrow('Network error');
+    });
+  });
+});

--- a/services/agent-api/src/lib/discovery-config.test.js
+++ b/services/agent-api/src/lib/discovery-config.test.js
@@ -1,0 +1,67 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: vi.fn() })),
+}));
+
+import { isPoorTitle, clearDiscoveryConfigCache } from './discovery-config.js';
+
+describe('discovery-config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearDiscoveryConfigCache();
+  });
+
+  describe('isPoorTitle', () => {
+    it('returns true for null title', () => {
+      expect(isPoorTitle(null)).toBe(true);
+    });
+
+    it('returns true for undefined title', () => {
+      expect(isPoorTitle(undefined)).toBe(true);
+    });
+
+    it('returns true for empty string', () => {
+      expect(isPoorTitle('')).toBe(true);
+    });
+
+    it('returns true for short title (< 10 chars)', () => {
+      expect(isPoorTitle('Short')).toBe(true);
+    });
+
+    it('returns true for title without spaces', () => {
+      expect(isPoorTitle('NoSpacesHere')).toBe(true);
+    });
+
+    it('returns true for URL slug patterns like fil123', () => {
+      expect(isPoorTitle('fil 123 document')).toBe(true);
+    });
+
+    it('returns true for URL slug patterns like nr123', () => {
+      expect(isPoorTitle('nr 456 report')).toBe(true);
+    });
+
+    it('returns true for URL slug patterns like bulletin123', () => {
+      expect(isPoorTitle('bulletin 789 update')).toBe(true);
+    });
+
+    it('returns false for good title with spaces', () => {
+      expect(isPoorTitle('This is a good title with spaces')).toBe(false);
+    });
+
+    it('returns false for proper article title', () => {
+      expect(isPoorTitle('How AI is Transforming Banking')).toBe(false);
+    });
+
+    it('returns false for longer title with multiple words', () => {
+      expect(isPoorTitle('The Future of Financial Services in 2024')).toBe(false);
+    });
+  });
+
+  describe('clearDiscoveryConfigCache', () => {
+    it('clears the cache without error', () => {
+      expect(() => clearDiscoveryConfigCache()).not.toThrow();
+    });
+  });
+});

--- a/services/agent-api/src/lib/random.test.js
+++ b/services/agent-api/src/lib/random.test.js
@@ -1,0 +1,43 @@
+// @ts-check
+import { describe, it, expect } from 'vitest';
+import { randomInt } from './random.js';
+
+describe('random', () => {
+  describe('randomInt', () => {
+    it('returns integer in range', () => {
+      const result = randomInt(0, 10);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThan(10);
+    });
+
+    it('returns integer (not float)', () => {
+      const result = randomInt(0, 100);
+      expect(Number.isInteger(result)).toBe(true);
+    });
+
+    it('respects min bound', () => {
+      const result = randomInt(50, 100);
+      expect(result).toBeGreaterThanOrEqual(50);
+    });
+
+    it('respects max bound (exclusive)', () => {
+      const results = [];
+      for (let i = 0; i < 100; i++) {
+        results.push(randomInt(0, 5));
+      }
+      const max = Math.max(...results);
+      expect(max).toBeLessThan(5);
+    });
+
+    it('works with negative min', () => {
+      const result = randomInt(-10, 10);
+      expect(result).toBeGreaterThanOrEqual(-10);
+      expect(result).toBeLessThan(10);
+    });
+
+    it('works with range of 1', () => {
+      const result = randomInt(5, 6);
+      expect(result).toBe(5);
+    });
+  });
+});

--- a/services/agent-api/src/lib/semantic-scholar-metrics.test.js
+++ b/services/agent-api/src/lib/semantic-scholar-metrics.test.js
@@ -1,0 +1,120 @@
+// @ts-check
+import { describe, it, expect } from 'vitest';
+import { extractCitationMetrics } from './semantic-scholar-metrics.js';
+
+describe('semantic-scholar-metrics', () => {
+  describe('extractCitationMetrics', () => {
+    it('returns zero values for null paper', () => {
+      const result = extractCitationMetrics(null);
+
+      expect(result.citationCount).toBe(0);
+      expect(result.influentialCitations).toBe(0);
+      expect(result.maxAuthorHIndex).toBe(0);
+      expect(result.paperYear).toBeNull();
+      expect(result.citationsPerYear).toBe(0);
+    });
+
+    it('returns zero values for undefined paper', () => {
+      const result = extractCitationMetrics(undefined);
+
+      expect(result.citationCount).toBe(0);
+      expect(result.influentialCitations).toBe(0);
+    });
+
+    it('extracts citation count', () => {
+      const paper = { citationCount: 500 };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.citationCount).toBe(500);
+    });
+
+    it('extracts influential citations', () => {
+      const paper = { influentialCitationCount: 50 };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.influentialCitations).toBe(50);
+    });
+
+    it('extracts max author h-index', () => {
+      const paper = {
+        citationCount: 100,
+        authors: [
+          { name: 'Author 1', hIndex: 30 },
+          { name: 'Author 2', hIndex: 50 },
+          { name: 'Author 3', hIndex: 25 },
+        ],
+      };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.maxAuthorHIndex).toBe(50);
+    });
+
+    it('handles authors without h-index', () => {
+      const paper = {
+        citationCount: 100,
+        authors: [{ name: 'Author 1' }, { name: 'Author 2', hIndex: 20 }],
+      };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.maxAuthorHIndex).toBe(20);
+    });
+
+    it('handles missing authors array', () => {
+      const paper = { citationCount: 100 };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.maxAuthorHIndex).toBe(0);
+    });
+
+    it('handles empty authors array', () => {
+      const paper = { citationCount: 100, authors: [] };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.maxAuthorHIndex).toBe(0);
+    });
+
+    it('calculates citations per year', () => {
+      const currentYear = new Date().getFullYear();
+      const paper = { citationCount: 1000, year: currentYear - 10 };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.citationsPerYear).toBe(100);
+    });
+
+    it('handles recent papers (age = 1)', () => {
+      const currentYear = new Date().getFullYear();
+      const paper = { citationCount: 50, year: currentYear };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.citationsPerYear).toBe(50);
+    });
+
+    it('handles missing year (defaults to age 1)', () => {
+      const paper = { citationCount: 100 };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.citationsPerYear).toBe(100);
+      expect(result.paperYear).toBeUndefined();
+    });
+
+    it('extracts all metrics together', () => {
+      const currentYear = new Date().getFullYear();
+      const paper = {
+        citationCount: 5000,
+        influentialCitationCount: 200,
+        year: currentYear - 5,
+        authors: [
+          { name: 'Top Author', hIndex: 80 },
+          { name: 'Junior Author', hIndex: 10 },
+        ],
+      };
+      const result = extractCitationMetrics(paper);
+
+      expect(result.citationCount).toBe(5000);
+      expect(result.influentialCitations).toBe(200);
+      expect(result.maxAuthorHIndex).toBe(80);
+      expect(result.paperYear).toBe(currentYear - 5);
+      expect(result.citationsPerYear).toBe(1000);
+    });
+  });
+});

--- a/services/agent-api/src/lib/sitemap-fetch.test.js
+++ b/services/agent-api/src/lib/sitemap-fetch.test.js
@@ -1,0 +1,94 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./sitemap-rate-limit.js', () => ({
+  enforceRateLimit: vi.fn(() => Promise.resolve()),
+}));
+
+import { fetchWithPoliteness, fetchHtml } from './sitemap-fetch.js';
+
+describe('sitemap-fetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn();
+  });
+
+  describe('fetchWithPoliteness', () => {
+    it('fetches URL with correct headers', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('<xml>content</xml>'),
+      });
+
+      const result = await fetchWithPoliteness('https://example.com/sitemap.xml');
+
+      expect(result).toBe('<xml>content</xml>');
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://example.com/sitemap.xml',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'User-Agent': expect.stringContaining('BFSI-Insights-Bot'),
+          }),
+        }),
+      );
+    });
+
+    it('throws on HTTP error', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      await expect(fetchWithPoliteness('https://example.com/missing.xml')).rejects.toThrow(
+        'HTTP 404',
+      );
+    });
+  });
+
+  describe('fetchHtml', () => {
+    it('fetches HTML content', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('<html>content</html>'),
+      });
+
+      const result = await fetchHtml('https://example.com/page');
+
+      expect(result).toBe('<html>content</html>');
+    });
+
+    it('returns null on HTTP error', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      const result = await fetchHtml('https://example.com/error');
+
+      expect(result).toBeNull();
+    });
+
+    it('uses custom timeout', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('<html>fast</html>'),
+      });
+
+      const result = await fetchHtml('https://example.com/page', 5000);
+
+      expect(result).toBe('<html>fast</html>');
+    });
+
+    it('clears timeout after fetch completes', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve('<html>done</html>'),
+      });
+
+      const result = await fetchHtml('https://example.com/page');
+
+      expect(result).toBe('<html>done</html>');
+    });
+  });
+});

--- a/services/agent-api/src/lib/sitemap-metadata.test.js
+++ b/services/agent-api/src/lib/sitemap-metadata.test.js
@@ -1,0 +1,129 @@
+// @ts-check
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./sitemap-fetch.js', () => ({
+  fetchHtml: vi.fn(() => Promise.resolve(null)),
+}));
+
+import { fetchPageMetadata } from './sitemap-metadata.js';
+import { fetchHtml } from './sitemap-fetch.js';
+
+describe('sitemap-metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('fetchPageMetadata', () => {
+    it('returns null values when fetch returns null', async () => {
+      vi.mocked(fetchHtml).mockResolvedValue(null);
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result).toEqual({ title: null, description: null });
+    });
+
+    it('extracts title from HTML', async () => {
+      vi.mocked(fetchHtml).mockResolvedValue('<html><head><title>Page Title</title></head></html>');
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result.title).toBe('Page Title');
+    });
+
+    it('extracts description from meta tag', async () => {
+      vi.mocked(fetchHtml).mockResolvedValue(
+        '<html><head><meta name="description" content="Page description here"></head></html>',
+      );
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result.description).toBe('Page description here');
+    });
+
+    it('extracts description with reversed attribute order', async () => {
+      vi.mocked(fetchHtml).mockResolvedValue(
+        '<html><head><meta content="Reversed description" name="description"></head></html>',
+      );
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result.description).toBe('Reversed description');
+    });
+
+    it('extracts both title and description', async () => {
+      vi.mocked(fetchHtml).mockResolvedValue(
+        '<html><head><title>Full Page</title><meta name="description" content="Full description"></head></html>',
+      );
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result.title).toBe('Full Page');
+      expect(result.description).toBe('Full description');
+    });
+
+    it('truncates long titles to 200 characters', async () => {
+      const longTitle = 'A'.repeat(300);
+      vi.mocked(fetchHtml).mockResolvedValue(
+        `<html><head><title>${longTitle}</title></head></html>`,
+      );
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result.title?.length).toBe(200);
+    });
+
+    it('truncates long descriptions to 500 characters', async () => {
+      const longDesc = 'B'.repeat(600);
+      vi.mocked(fetchHtml).mockResolvedValue(
+        `<html><head><meta name="description" content="${longDesc}"></head></html>`,
+      );
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result.description?.length).toBe(500);
+    });
+
+    it('returns null values on fetch error', async () => {
+      vi.mocked(fetchHtml).mockRejectedValue(new Error('Network error'));
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result).toEqual({ title: null, description: null });
+    });
+
+    it('handles HTML without title', async () => {
+      vi.mocked(fetchHtml).mockResolvedValue('<html><head></head><body>Content</body></html>');
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result.title).toBeFalsy();
+    });
+
+    it('handles HTML without description', async () => {
+      vi.mocked(fetchHtml).mockResolvedValue('<html><head><title>Title Only</title></head></html>');
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result.title).toBe('Title Only');
+      expect(result.description).toBeFalsy();
+    });
+
+    it('trims whitespace from title', async () => {
+      vi.mocked(fetchHtml).mockResolvedValue(
+        '<html><head><title>  Padded Title  </title></head></html>',
+      );
+
+      const result = await fetchPageMetadata('https://example.com/page');
+
+      expect(result.title).toBe('Padded Title');
+    });
+
+    it('uses custom timeout', async () => {
+      vi.mocked(fetchHtml).mockResolvedValue('<html><head><title>Fast</title></head></html>');
+
+      await fetchPageMetadata('https://example.com/page', 5000);
+
+      expect(fetchHtml).toHaveBeenCalledWith('https://example.com/page', 5000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Added comprehensive unit tests for agent-api to increase test coverage from 57% to 73%.

## Changes

Added 17 new test files covering:
- **Discovery flow**: discover-classics-run, discoverer-run, discoverer-fetch, discoverer-sources, discoverer-premium, discoverer-enrich, discover-classics-queue
- **Thumbnailing**: thumbnailer-pdf, thumbnailer-browser
- **Utilities**: content-fetcher-http, discovery-config, tagger-prompt, improver-report, sitemap-fetch, sitemap-metadata, random, semantic-scholar-metrics

## Coverage

| Metric | Before | After |
|--------|--------|-------|
| Statements | 57% | 73% |
| Branches | ~60% | ~67% |
| Functions | ~66% | ~72% |
| Lines | ~58% | ~74% |

## Notes

The remaining ~7% gap to 80% coverage would require refactoring source files that initialize Supabase clients at module load time, making them difficult to mock in tests. This is a known limitation documented for future improvement.

## Testing

```bash
npm run test:coverage -w services/agent-api
```

All 847 tests pass.