### PR TITLE
fix: add .test.js to coverage exclusions in vitest.config.ts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
         '**/*.spec.ts',
         '**/*.spec.tsx',
         '**/*.test.ts',
+        '**/*.test.js',
         '**/scripts/**',
         '**/cli.js',
         '**/*.config.{js,ts}',


### PR DESCRIPTION
## Summary

JavaScript test files (`.test.js`) were not excluded from coverage calculation in the root vitest config, which could cause them to appear as uncovered source code in coverage reports.

## Changes

Added `**/*.test.js` to the `coverage.exclude` array in `vitest.config.ts`.

## Note on Test Scope

The root vitest config intentionally does **not** include `services/agent-api` tests because:
- Root config uses `happy-dom` environment (for React/browser tests)
- Agent-api uses `node` environment (for Node.js tests)

Both test suites run separately in CI and both generate coverage reports that SonarCloud picks up via:
```
sonar.javascript.lcov.reportPaths=coverage/lcov.info,services/agent-api/coverage/lcov.info
```