### PR TITLE
fix: separate coverage scopes for root and agent-api vitest configs

### DIFF
--- a/services/agent-api/vitest.config.js
+++ b/services/agent-api/vitest.config.js
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
 
 export default defineConfig({
+  root: repoRoot,
   test: {
     globals: true,
     environment: 'node',
-    include: ['tests/**/*.spec.js', 'src/**/*.test.js'],
+    include: ['services/agent-api/tests/**/*.spec.js', 'services/agent-api/src/**/*.test.js'],
     env: {
       NODE_ENV: 'test',
       SITEMAP_RATE_LIMIT_MS: '5', // Fast rate limiting for tests
@@ -12,17 +18,19 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      reportsDirectory: './coverage',
+      reportsDirectory: 'services/agent-api/coverage',
+      include: ['services/agent-api/src/**/*.js'],
       exclude: [
-        'node_modules/**',
-        'tests/**',
+        '**/node_modules/**',
+        'services/agent-api/tests/**',
+        'services/agent-api/src/**/*.test.js',
         // Orchestration files - tested via integration, not unit tests
-        'src/cli.js',
-        'src/index.js',
-        'src/agents/discover.js', // RSS/sitemap orchestration
-        'src/agents/enrich-item.js', // Pipeline orchestration
-        'src/routes/**',
-        'src/scripts/**',
+        'services/agent-api/src/cli.js',
+        'services/agent-api/src/index.js',
+        'services/agent-api/src/agents/discover.js',
+        'services/agent-api/src/agents/enrich-item.js',
+        'services/agent-api/src/routes/**',
+        'services/agent-api/src/scripts/**',
       ],
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,12 +25,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov'],
       reportsDirectory: resolve(__dirname, 'coverage'),
-      include: [
-        'apps/web/**/*.ts',
-        'apps/admin/src/**/*.ts',
-        'apps/admin/src/**/*.tsx',
-        'services/agent-api/src/**/*.js',
-      ],
+      include: ['apps/web/**/*.ts', 'apps/admin/src/**/*.ts', 'apps/admin/src/**/*.tsx'],
       exclude: [
         '**/node_modules/**',
         '**/dist/**',


### PR DESCRIPTION
## Summary

Fix vitest configuration so coverage scopes are properly separated and SonarCloud receives correct repo-relative paths.

## Changes

### Files Modified
- `vitest.config.ts` - removed `services/agent-api/src/**/*.js` from coverage.include (root doesn't run those tests)
- `services/agent-api/vitest.config.js` - set root to repo root, updated all paths to be repo-relative for SonarCloud

### Files Created
- None

### Files Deleted
- None

## Why

**Problem 1**: Root vitest included agent-api source files in coverage scope but ran NO tests for them, creating 0% coverage entries that polluted SonarCloud metrics.

**Problem 2**: Agent-api lcov.info had relative paths (`src/agents/...`) instead of repo-relative paths (`services/agent-api/src/agents/...`), causing SonarCloud to fail to match coverage to source files.

## Testing

```bash
# Root coverage (apps/web, apps/admin only)
npm test -- --coverage --run
grep "SF:" coverage/lcov.info | head -3
# Should show: apps/admin/src/... and apps/web/...

# Agent-api coverage (repo-relative paths)
npm run test:coverage -w services/agent-api
grep "SF:" services/agent-api/coverage/lcov.info | head -3
# Should show: services/agent-api/src/...
```

## Notes

After merge, SonarCloud should correctly attribute coverage to both:
- apps/web + apps/admin (from coverage/lcov.info)
- services/agent-api (from services/agent-api/coverage/lcov.info)
