### PR TITLE
chore: unify artifact output paths and reorganize .gitignore

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Debug coverage output
         run: |
           echo "=== Main coverage files ==="
-          ls -la coverage/ || echo "No coverage folder"
+          ls -la artifacts/test/coverage/ || echo "No coverage folder"
           echo "=== Agent-api coverage files ==="
           ls -la services/agent-api/coverage/ || echo "No agent-api coverage folder"
           echo "=== First 20 lines of main lcov.info ==="
-          head -20 coverage/lcov.info || echo "No main lcov.info"
+          head -20 artifacts/test/coverage/lcov.info || echo "No main lcov.info"
           echo "=== First 20 lines of agent-api lcov.info ==="
           head -20 services/agent-api/coverage/lcov.info || echo "No agent-api lcov.info"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,39 +1,72 @@
-# build output
-dist/
-# generated types
-.astro/
+# ============================================================================
+# BFSI Insights - .gitignore
+# ============================================================================
+# Organized by: Dependencies → Build → Artifacts → Environment → IDE/OS
+# ============================================================================
 
-# dependencies
+# ----------------------------------------------------------------------------
+# Dependencies
+# ----------------------------------------------------------------------------
 node_modules/
 
-# logs
+# ----------------------------------------------------------------------------
+# Build output (monorepo-safe)
+# ----------------------------------------------------------------------------
+dist/
+**/dist/
+**/.astro/
+**/.next/
+**/out/
+.vercel/
+
+# ----------------------------------------------------------------------------
+# Artifacts (all generated/transient output)
+# ----------------------------------------------------------------------------
+# Unified artifacts directory
+artifacts/
+
+# Legacy paths (in case tools bypass artifacts/)
+coverage/
+playwright-report/
+test-results/
+.playwright/
+.lighthouseci/
+reports/
+
+# ----------------------------------------------------------------------------
+# Logs
+# ----------------------------------------------------------------------------
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
-
-# environment variables
+# ----------------------------------------------------------------------------
+# Environment files
+# ----------------------------------------------------------------------------
 .env
+.env.local
+.env.*.local
 .env.production
+!.env.example
 
-# macOS-specific files
-.DS_Store
-
-# jetbrains setting folder
+# ----------------------------------------------------------------------------
+# IDE / Editor (allowlist approach for .vscode)
+# ----------------------------------------------------------------------------
 .idea/
-.lighthouseci/
-reports/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
+!.vscode/launch.json
 
-# Test artifacts
-playwright-report/
-test-results/
-.playwright/
-coverage/
+# ----------------------------------------------------------------------------
+# OS-specific
+# ----------------------------------------------------------------------------
+.DS_Store
+Thumbs.db
+
+# ----------------------------------------------------------------------------
+# Project-specific transient files
+# ----------------------------------------------------------------------------
 summaries-review.json
 public/thumbs/
-.env*.local
-
-**/.next/
-**/out/
-.vercel/

--- a/.lighthouserc.desktop.json
+++ b/.lighthouserc.desktop.json
@@ -14,6 +14,6 @@
         "categories:seo": ["error", { "minScore": 0.95 }]
       }
     },
-    "upload": { "target": "filesystem", "outputDir": "./reports/lhci" }
+    "upload": { "target": "filesystem", "outputDir": "./artifacts/perf/lighthouse" }
   }
 }

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -38,7 +38,7 @@
     },
     "upload": {
       "target": "filesystem",
-      "outputDir": "./reports/lhci"
+      "outputDir": "./artifacts/perf/lighthouse"
     }
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,15 @@
+# Build output
 dist/
-.astro/
+**/dist/
+**/.astro/
+**/.next/
+
+# Artifacts
+artifacts/
+
+# Legacy artifact paths
 reports/
-node_modules
+coverage/
+
+# Dependencies
+node_modules/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,8 +2,10 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: 'apps/web/e2e',
+  outputDir: 'artifacts/test/playwright',
   timeout: 30_000,
   retries: process.env.CI ? 2 : 0,
+  reporter: [['html', { outputFolder: 'artifacts/test/playwright-report' }]],
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:4321',
     trace: 'on-first-retry',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,8 +33,8 @@ sonar.exclusions=\
 sonar.test.inclusions=**/*.spec.ts,**/*.test.ts,**/*.spec.js,**/*.test.js,**/tests/**,**/e2e/**
 
 # Coverage reports (from Vitest)
-sonar.javascript.lcov.reportPaths=coverage/lcov.info,services/agent-api/coverage/lcov.info
-sonar.typescript.lcov.reportPaths=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=artifacts/test/coverage/lcov.info,services/agent-api/coverage/lcov.info
+sonar.typescript.lcov.reportPaths=artifacts/test/coverage/lcov.info
 
 # Coverage exclusions (orchestration wrappers, configs, DOM glue - NOT business logic)
 # See docs/quality/sonar-exclusions.md for rationale and review schedule.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
-      reportsDirectory: resolve(__dirname, 'coverage'),
+      reportsDirectory: resolve(__dirname, 'artifacts/test/coverage'),
       include: [
         'apps/web/**/*.ts',
         'apps/admin/src/components/ui/**/*.ts',


### PR DESCRIPTION
## Summary
Restructures repository to clearly separate tracked source from gitignored artifacts. All test/build outputs now go to a unified artifacts/ directory.

## Changes

### Files Modified
- .gitignore - reorganized with clear sections (Dependencies, Build, Artifacts, Logs, Environment, IDE, OS), monorepo-safe patterns, .vscode allowlist approach
- .prettierignore - updated to match new artifact structure
- vitest.config.ts - coverage output redirected to artifacts/test/coverage
- playwright.config.ts - test output redirected to artifacts/test/playwright
- .lighthouserc.json - output redirected to artifacts/perf/lighthouse
- .lighthouserc.desktop.json - output redirected to artifacts/perf/lighthouse
- sonar-project.properties - updated coverage paths for SonarCloud
- .github/workflows/sonarcloud.yml - updated coverage paths

## Why
The repo had multiple generated/artifact directories at root level (.astro/, coverage/, dist/, reports/, test-results/, .lighthouseci/). This change:
1. Unifies all generated output under artifacts/ directory
2. Makes tracked vs gitignored status unambiguous
3. Keeps repo root surface crisp and focused on source
4. Applies monorepo-safe ignore patterns (e.g., **/dist/, **/.astro/)
5. Uses .vscode allowlist (only settings.json, extensions.json, launch.json tracked)

## Testing
- npm test (129 tests pass)
- npm run build (145 pages built)
- npm run lint -w apps/admin (0 warnings)
