### PR TITLE
chore(agent-api): allow SUPABASE_URL via env shim

### DIFF
--- a/services/agent-api/.env.example
+++ b/services/agent-api/.env.example
@@ -1,8 +1,13 @@
 # Supabase
-# Note: Code currently uses PUBLIC_SUPABASE_URL (legacy). New code should use SUPABASE_URL.
-# Both are supported during migration - set whichever your .env.local uses.
+# Preferred: use SUPABASE_URL (shim copies it to PUBLIC_SUPABASE_URL for legacy code paths)
 SUPABASE_URL=https://your-project.supabase.co
+
+# Legacy (deprecated): only needed if you cannot set SUPABASE_URL
 PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+
+# Optional: if any tooling uses anon key with non-PUBLIC naming, shim will copy it
+SUPABASE_ANON_KEY=
+PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_KEY=your-service-role-key
 
 # OpenAI

--- a/services/agent-api/DEPLOYMENT.md
+++ b/services/agent-api/DEPLOYMENT.md
@@ -22,12 +22,13 @@ Hosted agent service for content processing pipeline.
 
    | Variable               | Description                                            |
    | ---------------------- | ------------------------------------------------------ |
-   | `PUBLIC_SUPABASE_URL`  | Your Supabase project URL (legacy name, see note)      |
+   | `SUPABASE_URL`         | Your Supabase project URL (preferred)                  |
+   | `PUBLIC_SUPABASE_URL`  | Legacy name (supported via shim; deprecated)           |
    | `SUPABASE_SERVICE_KEY` | Service role key (not anon!)                           |
    | `OPENAI_API_KEY`       | OpenAI API key                                         |
    | `AGENT_API_KEY`        | Secret key for API auth (auto-generated or create one) |
 
-   > **Note:** The codebase currently uses `PUBLIC_SUPABASE_URL`. This is a legacy naming convention—backend services should use `SUPABASE_URL` (no `PUBLIC_` prefix). A future refactor will standardize this.
+   > **Note:** Agent API prefers `SUPABASE_URL`. A small shim keeps `PUBLIC_SUPABASE_URL` working for legacy code paths.
 
 ## API Endpoints
 
@@ -87,8 +88,8 @@ npm install
 npx playwright install chromium
 
 # Copy and configure environment
-cp .env.example .env
-# Edit .env with your values
+cp .env.example .env.local
+# Edit .env.local with your values
 
 # Run in development mode (auto-reload)
 npm run dev
@@ -96,20 +97,21 @@ npm run dev
 
 ## Environment Variables
 
-| Variable               | Required  | Description                                   |
-| ---------------------- | --------- | --------------------------------------------- |
-| `PUBLIC_SUPABASE_URL`  | ✅        | Supabase project URL (legacy name, see below) |
-| `SUPABASE_SERVICE_KEY` | ✅        | Service role key for backend access           |
-| `OPENAI_API_KEY`       | ✅        | OpenAI API key for agents                     |
-| `ANTHROPIC_API_KEY`    | ❌        | Anthropic API key (optional, for Claude)      |
-| `AGENT_API_KEY`        | ✅ (prod) | API authentication key                        |
-| `PORT`                 | ❌        | Server port (default: 3000)                   |
-| `NODE_ENV`             | ❌        | Environment (development/production)          |
-| `LANGSMITH_API_KEY`    | ❌        | LangSmith API key (optional, for tracing)     |
-| `LANGSMITH_TRACING`    | ❌        | Enable tracing (true/false)                   |
-| `LANGSMITH_PROJECT`    | ❌        | LangSmith project name                        |
+| Variable               | Required  | Description                               |
+| ---------------------- | --------- | ----------------------------------------- |
+| `SUPABASE_URL`         | ✅        | Supabase project URL (preferred)          |
+| `PUBLIC_SUPABASE_URL`  | ❌        | Legacy name (supported via shim)          |
+| `SUPABASE_SERVICE_KEY` | ✅        | Service role key for backend access       |
+| `OPENAI_API_KEY`       | ✅        | OpenAI API key for agents                 |
+| `ANTHROPIC_API_KEY`    | ❌        | Anthropic API key (optional, for Claude)  |
+| `AGENT_API_KEY`        | ✅ (prod) | API authentication key                    |
+| `PORT`                 | ❌        | Server port (default: 3000)               |
+| `NODE_ENV`             | ❌        | Environment (development/production)      |
+| `LANGSMITH_API_KEY`    | ❌        | LangSmith API key (optional, for tracing) |
+| `LANGSMITH_TRACING`    | ❌        | Enable tracing (true/false)               |
+| `LANGSMITH_PROJECT`    | ❌        | LangSmith project name                    |
 
-> **Note on `PUBLIC_SUPABASE_URL`:** This is a legacy naming convention. Backend services should use `SUPABASE_URL` (no `PUBLIC_` prefix). The codebase will be refactored to use `SUPABASE_URL` in a future PR.
+> **Note:** Agent API now prefers `SUPABASE_URL`. A small shim keeps `PUBLIC_SUPABASE_URL` working for legacy code paths.
 
 ## Discovery Source Types
 

--- a/services/agent-api/render.yaml
+++ b/services/agent-api/render.yaml
@@ -11,8 +11,10 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
+      - key: SUPABASE_URL
+        sync: false # Preferred (shim will copy to PUBLIC_SUPABASE_URL for legacy code paths)
       - key: PUBLIC_SUPABASE_URL
-        sync: false # Set manually in Render dashboard
+        sync: false # Legacy (deprecated)
       - key: SUPABASE_SERVICE_KEY
         sync: false
       - key: OPENAI_API_KEY

--- a/services/agent-api/src/env-shim.js
+++ b/services/agent-api/src/env-shim.js
@@ -1,0 +1,19 @@
+import process from 'node:process';
+
+export function applyEnvShim() {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const publicUrl = process.env.PUBLIC_SUPABASE_URL;
+
+  if (supabaseUrl && !publicUrl) {
+    process.env.PUBLIC_SUPABASE_URL = supabaseUrl;
+  }
+
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+  const publicAnonKey = process.env.PUBLIC_SUPABASE_ANON_KEY;
+
+  if (supabaseAnonKey && !publicAnonKey) {
+    process.env.PUBLIC_SUPABASE_ANON_KEY = supabaseAnonKey;
+  }
+}
+
+applyEnvShim();

--- a/services/agent-api/tests/lib/env-shim.spec.js
+++ b/services/agent-api/tests/lib/env-shim.spec.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { applyEnvShim } from '../../src/env-shim.js';
+
+describe('env-shim', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('copies SUPABASE_URL to PUBLIC_SUPABASE_URL when legacy var is missing', () => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    delete process.env.PUBLIC_SUPABASE_URL;
+
+    applyEnvShim();
+
+    expect(process.env.PUBLIC_SUPABASE_URL).toBe('https://example.supabase.co');
+  });
+
+  it('does not overwrite PUBLIC_SUPABASE_URL when it is already set', () => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.PUBLIC_SUPABASE_URL = 'https://legacy.supabase.co';
+
+    applyEnvShim();
+
+    expect(process.env.PUBLIC_SUPABASE_URL).toBe('https://legacy.supabase.co');
+  });
+
+  it('copies SUPABASE_ANON_KEY to PUBLIC_SUPABASE_ANON_KEY when legacy var is missing', () => {
+    process.env.SUPABASE_ANON_KEY = 'anon-key';
+    delete process.env.PUBLIC_SUPABASE_ANON_KEY;
+
+    applyEnvShim();
+
+    expect(process.env.PUBLIC_SUPABASE_ANON_KEY).toBe('anon-key');
+  });
+});


### PR DESCRIPTION
## Summary
Agent API code currently reads PUBLIC_SUPABASE_URL. This change adds a small startup shim so you can configure SUPABASE_URL (preferred) without touching the rest of the codebase.

## Changes

### Files Created
- services/agent-api/src/env-shim.js - copies SUPABASE_URL -> PUBLIC_SUPABASE_URL (and SUPABASE_ANON_KEY -> PUBLIC_SUPABASE_ANON_KEY) when legacy vars are missing
- services/agent-api/tests/lib/env-shim.spec.js - unit tests for the shim

### Files Modified
- services/agent-api/src/index.js - imports env-shim early so it runs before Supabase clients are created
- services/agent-api/render.yaml - documents SUPABASE_URL as preferred env var (keeps legacy PUBLIC_SUPABASE_URL)
- services/agent-api/.env.example - documents SUPABASE_URL as preferred + legacy fallback vars
- services/agent-api/DEPLOYMENT.md - updated env var guidance and local dev instructions

## Verification
- npm -w services/agent-api run typecheck
- npm -w services/agent-api run lint
- npm -w services/agent-api test
