### PR TITLE
fix(ci): allow empty commit in nightly quality run

### DIFF
--- a/.github/workflows/nightly-quality.yml
+++ b/.github/workflows/nightly-quality.yml
@@ -35,9 +35,11 @@ jobs:
         run: node scripts/ci/quality-report.cjs
 
       - name: Commit quality reports
+        env:
+          ALLOW_EMPTY_COMMIT: '1'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add docs/architecture/quality/nightly-*.md
-          git diff --staged --quiet || git commit -m "docs: update nightly quality reports [skip ci]"
+          git diff --staged --quiet || git commit --allow-empty -m "docs: update nightly quality reports [skip ci]"
           git push

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+if [ "$ALLOW_EMPTY_COMMIT" = "1" ]; then
+  npx lint-staged --allow-empty
+else
+  npx lint-staged
+fi
 
 # Check for large files in staged changes (BLOCKS commit if new code violates Quality Gate)
 node scripts/ci/check-large-files.cjs


### PR DESCRIPTION
## Summary
The nightly quality report workflow can legitimately produce no net diff after lint-staged formatting. In that case lint-staged aborts the commit as empty, failing the workflow.

## Fix
- Only for the nightly workflow, set ALLOW_EMPTY_COMMIT=1 so the pre-commit hook runs lint-staged with --allow-empty
- In nightly-quality workflow, use git commit --allow-empty (still guarded by a staged-diff check)

## Files Modified
- .husky/pre-commit
- .github/workflows/nightly-quality.yml
