### PR TITLE
test: raise coverage on new code

### DIFF
--- a/apps/admin/tests/agent-job-card.spec.tsx
+++ b/apps/admin/tests/agent-job-card.spec.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { AgentJobCard } from '@/components/dashboard/AgentJobCard';
+
+describe('AgentJobCard', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('renders title and pending badge and fetches jobs', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn(async () => {
+      return {
+        ok: true,
+        json: async () => ({ jobs: [] }),
+      } as any;
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <AgentJobCard title="Discovery" pendingCount={3} agentName="discoverer" color="violet" />,
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Discovery');
+    expect(container.textContent).toContain('3 pending');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/jobs/discoverer/jobs');
+  });
+});

--- a/apps/admin/tests/dashboard-card.spec.tsx
+++ b/apps/admin/tests/dashboard-card.spec.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { DashboardCard } from '@/components/dashboard/DashboardCard';
+
+describe('DashboardCard', () => {
+  it('renders title and badge', () => {
+    const html = renderToStaticMarkup(
+      <DashboardCard title="Title" badge="Badge" color="cyan">
+        <div>Child</div>
+      </DashboardCard>,
+    );
+
+    expect(html).toContain('Title');
+    expect(html).toContain('Badge');
+    expect(html).toContain('Child');
+    expect(html).toContain('text-cyan-400');
+  });
+
+  it('does not render badge when omitted', () => {
+    const html = renderToStaticMarkup(
+      <DashboardCard title="Title">
+        <div>Child</div>
+      </DashboardCard>,
+    );
+
+    expect(html).toContain('Title');
+    expect(html).not.toContain('text-cyan-400');
+    expect(html).not.toContain('text-violet-400');
+  });
+});

--- a/apps/admin/tests/discovery-control-card-view.spec.tsx
+++ b/apps/admin/tests/discovery-control-card-view.spec.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { DiscoveryControlCardView } from '@/components/dashboard/DiscoveryControlCardView';
+
+describe('DiscoveryControlCardView', () => {
+  it('renders paused state when disabled', () => {
+    const html = renderToStaticMarkup(
+      <DiscoveryControlCardView
+        status={{ enabled: false, pendingCount: 10, sourceCount: 2 }}
+        toggling={false}
+        processing={false}
+        batchSize={10}
+        onChangeBatchSize={() => {}}
+        onToggle={() => {}}
+        onRun={() => {}}
+        error={null}
+        result={null}
+      />,
+    );
+
+    expect(html).toContain('Discovery paused');
+    expect(html).toContain('2 sources');
+    expect(html).toContain('Run Discovery');
+  });
+
+  it('renders error and result messages', () => {
+    const html = renderToStaticMarkup(
+      <DiscoveryControlCardView
+        status={{ enabled: true, pendingCount: 0, sourceCount: 5 }}
+        toggling={false}
+        processing={false}
+        batchSize={25}
+        onChangeBatchSize={() => {}}
+        onToggle={() => {}}
+        onRun={() => {}}
+        error="boom"
+        result={{ found: 7, new: 2 }}
+      />,
+    );
+
+    expect(html).toContain('Discovery active');
+    expect(html).toContain('boom');
+    expect(html).toContain('Found 7, added 2 new items');
+  });
+});

--- a/apps/admin/tests/discovery-control-card.spec.tsx
+++ b/apps/admin/tests/discovery-control-card.spec.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { DiscoveryControlCard } from '@/components/dashboard/DiscoveryControlCard';
+
+vi.mock('@/components/dashboard/useDiscoveryControl', () => {
+  return {
+    useDiscoveryControl: () => ({
+      status: { enabled: false, pendingCount: 0, sourceCount: 3 },
+      toggling: false,
+      processing: false,
+      batchSize: 10,
+      setBatchSize: () => {},
+      toggleDiscovery: () => {},
+      runBatch: () => {},
+      error: null,
+      result: null,
+    }),
+  };
+});
+
+describe('DiscoveryControlCard', () => {
+  it('renders view with model data', () => {
+    const html = renderToStaticMarkup(<DiscoveryControlCard />);
+    expect(html).toContain('Discovery');
+    expect(html).toContain('3 sources');
+  });
+});

--- a/apps/admin/tests/live-pipeline-status.spec.tsx
+++ b/apps/admin/tests/live-pipeline-status.spec.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { LivePipelineStatus } from '@/components/dashboard/LivePipelineStatus';
+
+vi.mock('@/components/dashboard/PipelineStatusGrid', () => {
+  return {
+    PipelineStatusGrid: ({ statusData }: any) => (
+      <div data-testid="grid">{JSON.stringify(statusData)}</div>
+    ),
+  };
+});
+
+describe('LivePipelineStatus', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('renders initial data and updates after polling', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ statusData: [{ code: 1, name: 'A', category: 'x', count: 1 }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ statusData: [{ code: 2, name: 'B', category: 'y', count: 2 }] }),
+      });
+
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <LivePipelineStatus
+          initialData={[{ code: 0, name: 'Init', category: 'init', count: 0 }]}
+          pollInterval={1000}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Init');
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/apps/admin/tests/markdown-renderer.spec.tsx
+++ b/apps/admin/tests/markdown-renderer.spec.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { MarkdownRenderer } from '@/components/ui/markdown-renderer';
+
+function renderIntoContainer(ui: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+describe('MarkdownRenderer', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('renders plain text initially (before mounted effect)', () => {
+    const { container } = renderIntoContainer(<MarkdownRenderer content="**bold**" />);
+    expect(container.textContent).toContain('bold');
+  });
+
+  it('renders markdown after mount', async () => {
+    const { container } = renderIntoContainer(<MarkdownRenderer content="**bold**" />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const strong = container.querySelector('strong');
+    expect(strong?.textContent).toBe('bold');
+  });
+});

--- a/apps/admin/tests/mobile-header.spec.tsx
+++ b/apps/admin/tests/mobile-header.spec.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { MobileHeader } from '@/components/ui/sidebar/MobileHeader';
+
+vi.mock('next/link', () => {
+  return {
+    default: ({ href, children, ...props }: any) => (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+describe('MobileHeader', () => {
+  it('renders admin logo link', () => {
+    const html = renderToStaticMarkup(<MobileHeader isOpen={false} onToggle={() => {}} />);
+    expect(html).toContain('BFSI');
+    expect(html).toContain('Admin');
+    expect(html).toContain('href="/"');
+  });
+
+  it('uses correct aria label based on open state', () => {
+    const closed = renderToStaticMarkup(<MobileHeader isOpen={false} onToggle={() => {}} />);
+    expect(closed).toContain('aria-label="Open menu"');
+
+    const open = renderToStaticMarkup(<MobileHeader isOpen={true} onToggle={() => {}} />);
+    expect(open).toContain('aria-label="Close menu"');
+  });
+});

--- a/apps/admin/tests/navigation.spec.tsx
+++ b/apps/admin/tests/navigation.spec.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { Navigation } from '@/components/ui/sidebar/Navigation';
+
+vi.mock('next/link', () => {
+  return {
+    default: ({ href, children, ...props }: any) => (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+describe('Navigation', () => {
+  it('renders items and highlights active route', () => {
+    const html = renderToStaticMarkup(
+      <Navigation
+        items={[{ href: '/dashboard', label: 'Dashboard', icon: 'D' }]}
+        pathname="/dashboard"
+        expandedMenus={new Set()}
+        onToggleMenu={() => {}}
+      />,
+    );
+
+    expect(html).toContain('Dashboard');
+    expect(html).toContain('bg-neutral-800');
+  });
+
+  it('renders child links when expanded', () => {
+    const html = renderToStaticMarkup(
+      <Navigation
+        items={[
+          {
+            href: '/evals',
+            label: 'Evals',
+            icon: 'E',
+            children: [{ href: '/evals/history', label: 'History' }],
+          },
+        ]}
+        pathname="/evals/history"
+        expandedMenus={new Set(['/evals'])}
+        onToggleMenu={() => {}}
+      />,
+    );
+
+    expect(html).toContain('History');
+    expect(html).toContain('▼');
+  });
+});

--- a/apps/admin/tests/pipeline-status-badge.spec.tsx
+++ b/apps/admin/tests/pipeline-status-badge.spec.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { PipelineStatusBadge } from '@/components/ui/sidebar/PipelineStatusBadge';
+
+describe('PipelineStatusBadge', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders status and tooltip details', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-01-06T12:00:00.000Z').getTime());
+
+    const html = renderToStaticMarkup(
+      <PipelineStatusBadge
+        status={{
+          status: 'processing',
+          lastQueueRun: '2026-01-06T11:59:30.000Z',
+          lastBuildTime: null,
+          processingCount: 3,
+          pendingReviewCount: 0,
+          recentFailedCount: 0,
+        }}
+      />,
+    );
+
+    expect(html).toContain('processing');
+    expect(html).toContain('Last run');
+    expect(html).toContain('Just now');
+    expect(html).toContain('Last build');
+    expect(html).toContain('Never');
+  });
+
+  it('renders degraded state styling and failure count', () => {
+    const html = renderToStaticMarkup(
+      <PipelineStatusBadge
+        status={{
+          status: 'degraded',
+          lastQueueRun: null,
+          lastBuildTime: null,
+          processingCount: 0,
+          pendingReviewCount: 0,
+          recentFailedCount: 2,
+        }}
+      />,
+    );
+
+    expect(html).toContain('degraded');
+    expect(html).toContain('text-red-400');
+  });
+});

--- a/services/agent-api/tests/lib/evals-db.spec.js
+++ b/services/agent-api/tests/lib/evals-db.spec.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const fromMock = vi.fn();
+
+vi.mock('../../src/lib/evals-config.js', () => {
+  return {
+    supabase: {
+      from: fromMock,
+    },
+  };
+});
+
+const modulePath = '../../src/lib/evals-db.js';
+
+describe('evals-db', () => {
+  beforeEach(() => {
+    fromMock.mockReset();
+  });
+
+  it('fetchGoldenExamples builds a query with required filters', async () => {
+    const queryResult = { ok: true };
+    const eqNameMock = vi.fn(() => queryResult);
+    const limitMock = vi.fn(() => ({ eq: eqNameMock }));
+    const eqAgentMock = vi.fn(() => ({ limit: limitMock }));
+    const selectMock = vi.fn(() => ({ eq: eqAgentMock }));
+
+    fromMock.mockReturnValue({ select: selectMock });
+
+    const { fetchGoldenExamples } = await import(modulePath);
+
+    const query = await fetchGoldenExamples('tagger', 'default', 5);
+
+    expect(fromMock).toHaveBeenCalledWith('eval_golden_set');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqAgentMock).toHaveBeenCalledWith('agent_name', 'tagger');
+    expect(limitMock).toHaveBeenCalledWith(5);
+    expect(eqNameMock).toHaveBeenCalledWith('name', 'default');
+    expect(query).toBe(queryResult);
+  });
+
+  it('getPromptVersion returns unknown when no version is returned', async () => {
+    const singleMock = vi.fn(async () => ({ data: null }));
+    const eq2Mock = vi.fn(() => ({ single: singleMock }));
+    const eq1Mock = vi.fn(() => ({ eq: eq2Mock }));
+    const selectMock = vi.fn(() => ({ eq: eq1Mock }));
+
+    fromMock.mockReturnValue({ select: selectMock });
+
+    const { getPromptVersion } = await import(modulePath);
+
+    const version = await getPromptVersion('tagger');
+
+    expect(version).toBe('unknown');
+  });
+
+  it('addGoldenExample throws when insert fails', async () => {
+    const singleMock = vi.fn(async () => ({ data: null, error: new Error('nope') }));
+    const selectMock = vi.fn(() => ({ single: singleMock }));
+    const insertMock = vi.fn(() => ({ select: selectMock }));
+
+    fromMock.mockReturnValue({ insert: insertMock });
+
+    const { addGoldenExample } = await import(modulePath);
+
+    await expect(addGoldenExample('tagger', 'x', { a: 1 }, { b: 2 })).rejects.toThrow('nope');
+  });
+});

--- a/services/agent-api/tests/lib/evals-judge.spec.js
+++ b/services/agent-api/tests/lib/evals-judge.spec.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const createMock = vi.fn();
+
+vi.mock('../../src/lib/evals-config.js', () => {
+  return {
+    getOpenAI: () => ({
+      chat: {
+        completions: {
+          create: createMock,
+        },
+      },
+    }),
+  };
+});
+
+describe('evals-judge', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it('judgeWithLLM calls OpenAI and parses JSON response', async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: '{"score":0.8,"reasoning":"ok"}' } }],
+    });
+
+    const { judgeWithLLM } = await import('../../src/lib/evals-judge.js');
+
+    const result = await judgeWithLLM({ x: 1 }, { y: 2 }, 'accuracy', 'gpt-4o-mini');
+
+    expect(createMock).toHaveBeenCalled();
+    expect(result).toEqual({ score: 0.8, reasoning: 'ok' });
+
+    const args = createMock.mock.calls[0][0];
+    expect(args.model).toBe('gpt-4o-mini');
+    expect(args.messages[0].role).toBe('system');
+    expect(args.messages[1].role).toBe('user');
+  });
+
+  it('compareWithLLM returns parsed winner', async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: '{"winner":"a","reasoning":"better"}' } }],
+    });
+
+    const { compareWithLLM } = await import('../../src/lib/evals-judge.js');
+
+    const result = await compareWithLLM({ q: 1 }, { a: 1 }, { b: 2 }, 'gpt-4o-mini');
+
+    expect(result.winner).toBe('a');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, 'apps/admin/src'),
     },
+    dedupe: ['react', 'react-dom'],
   },
   test: {
     environment: 'happy-dom',


### PR DESCRIPTION
## Summary
Sonar Quality Gate is failing because coverage on new code is below 80%. This PR adds targeted unit/component tests for the files Sonar reports as uncovered, focusing on cheap render/mocking tests.

## Changes

### Files Modified
- vitest.config.ts - ensure React/ReactDOM are deduped in Vitest to avoid invalid hook call issues

### Files Added (Admin)
- apps/admin/tests/dashboard-card.spec.tsx
- apps/admin/tests/mobile-header.spec.tsx
- apps/admin/tests/navigation.spec.tsx
- apps/admin/tests/pipeline-status-badge.spec.tsx
- apps/admin/tests/markdown-renderer.spec.tsx
- apps/admin/tests/discovery-control-card-view.spec.tsx
- apps/admin/tests/discovery-control-card.spec.tsx
- apps/admin/tests/agent-job-card.spec.tsx
- apps/admin/tests/live-pipeline-status.spec.tsx

### Files Added (Agent API)
- services/agent-api/tests/lib/evals-db.spec.js
- services/agent-api/tests/lib/evals-judge.spec.js

## Verification
- npm -w apps/admin run lint
- npm -w apps/admin run test:coverage
- npm -w services/agent-api run test:coverage
