### PR TITLE
docs(agent-api): env migration plan + legacy inventory

### DIFF
--- a/services/agent-api/docs/env-inventory.md
+++ b/services/agent-api/docs/env-inventory.md
@@ -1,0 +1,83 @@
+# Agent API legacy env inventory (PUBLIC*SUPABASE*\*)
+
+This file is a snapshot inventory used to drive the staged migration away from legacy env var names.
+
+## Summary counts (current)
+
+- `services/agent-api/src/**`
+  - `PUBLIC_SUPABASE_*` occurrences: 49 matches across 42 files
+- `services/agent-api/tests/**`
+  - `PUBLIC_SUPABASE_*` occurrences: 26 matches across 7 files
+- `services/agent-api` docs/config (`*.md`, `render.yaml`, `.env*`)
+  - `PUBLIC_SUPABASE_*` occurrences: 11 matches across 4 files
+
+Additionally (direct reads):
+
+- `process.env.PUBLIC_SUPABASE_*` occurrences (all of `services/agent-api`): 68 matches across 48 files
+
+## File list: `services/agent-api/src/**`
+
+Top offenders by match count:
+
+- `services/agent-api/src/env-shim.js` (4)
+- `services/agent-api/src/lib/supabase.js` (3)
+- `services/agent-api/src/lib/queue-update.js` (2)
+- `services/agent-api/src/scripts/validate-agent-registry.js` (2)
+
+Other files with matches (1 each):
+
+- `services/agent-api/src/agents/discover-classics-db.js`
+- `services/agent-api/src/agents/discoverer.js`
+- `services/agent-api/src/agents/improver-config.js`
+- `services/agent-api/src/agents/orchestrator.js`
+- `services/agent-api/src/agents/scorer-prompt.js`
+- `services/agent-api/src/agents/summarizer.js`
+- `services/agent-api/src/agents/tagger-config.js`
+- `services/agent-api/src/cli/commands/eval.js`
+- `services/agent-api/src/cli/commands/fetch.js`
+- `services/agent-api/src/cli/commands/filter.js`
+- `services/agent-api/src/cli/commands/health.js`
+- `services/agent-api/src/cli/commands/summarize.js`
+- `services/agent-api/src/cli/commands/tag.js`
+- `services/agent-api/src/cli/commands/thumbnail.js`
+- `services/agent-api/src/index.js`
+- `services/agent-api/src/lib/discovery-config.js`
+- `services/agent-api/src/lib/discovery-queue.js`
+- `services/agent-api/src/lib/embeddings.js`
+- `services/agent-api/src/lib/evals-config.js`
+- `services/agent-api/src/lib/pdf-extractor.js`
+- `services/agent-api/src/lib/pipeline-tracking.js`
+- `services/agent-api/src/lib/prompt-eval.js`
+- `services/agent-api/src/lib/replay-helpers.js`
+- `services/agent-api/src/lib/runner.js`
+- `services/agent-api/src/lib/state-machine.js`
+- `services/agent-api/src/lib/status-codes.js`
+- `services/agent-api/src/lib/taxonomy-loader.js`
+- `services/agent-api/src/lib/vendor-loader.js`
+- `services/agent-api/src/lib/wip-limits.js`
+- `services/agent-api/src/routes/agent-jobs.js`
+- `services/agent-api/src/routes/agents/discovery.js`
+- `services/agent-api/src/routes/agents/filter.js`
+- `services/agent-api/src/routes/agents/summarize.js`
+- `services/agent-api/src/routes/agents/tag.js`
+- `services/agent-api/src/routes/agents/thumbnail.js`
+- `services/agent-api/src/routes/discovery-control.js`
+- `services/agent-api/src/routes/evals.js`
+- `services/agent-api/src/scripts/utils.js`
+
+## File list: `services/agent-api/tests/**`
+
+- `services/agent-api/tests/lib/env-shim.spec.js` (9)
+- `services/agent-api/tests/lib/supabase.spec.js` (7)
+- `services/agent-api/tests/lib/queue-update.spec.js` (6)
+- `services/agent-api/tests/agents/tagger.spec.js` (1)
+- `services/agent-api/tests/evals/run-eval.js` (1)
+- `services/agent-api/tests/lib/pdf-extraction.test.js` (1)
+- `services/agent-api/tests/lib/replay-helpers.spec.js` (1)
+
+## Docs/config files with matches
+
+- `services/agent-api/DEPLOYMENT.md` (4)
+- `services/agent-api/.env.example` (3)
+- `services/agent-api/.env.local` (2)
+- `services/agent-api/render.yaml` (2)

--- a/services/agent-api/docs/env-migration.md
+++ b/services/agent-api/docs/env-migration.md
@@ -1,0 +1,41 @@
+# Agent API env var migration (Supabase)
+
+## Goal
+
+Standardize server-side configuration on canonical env var names (e.g. `SUPABASE_URL`) and stop reading legacy `PUBLIC_*` env vars directly in Agent API code.
+
+This is a multi-phase migration.
+
+## Canonical (server) env vars
+
+- `SUPABASE_URL`
+  - Supabase project URL.
+- `SUPABASE_SERVICE_KEY`
+  - Service role key (server-only).
+
+Optional / only if actually needed server-side:
+
+- `SUPABASE_ANON_KEY`
+
+## Legacy env vars (deprecated)
+
+- `PUBLIC_SUPABASE_URL`
+- `PUBLIC_SUPABASE_ANON_KEY`
+
+These exist due to historical coupling with client-side naming conventions.
+
+## Rules
+
+- New code in `services/agent-api/src/**` MUST NOT read any `process.env.PUBLIC_SUPABASE_*` directly.
+- Env access should be centralized behind a single module (to be introduced in Phase 1), which will temporarily support fallback:
+  - `SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL`
+- A temporary compatibility shim exists to support deployments that still set legacy names.
+  - The shim must remain until the final cleanup phase.
+
+## Migration phases (high-level)
+
+- Phase 0: Document + inventory only.
+- Phase 1: Introduce an env module + add a guard to prevent new direct legacy reads.
+- Phase 2: Centralize Supabase client creation behind a factory.
+- Phase 3+: Mechanical replacement in small batches.
+- Final: Remove legacy references from codebase, then remove shim.


### PR DESCRIPTION
## Summary
Phase 0 of the Agent API env migration: document canonical vs legacy Supabase env vars and check in an inventory of current  usage.

## Changes
- Added a short migration guide defining canonical vars (, ) and deprecated legacy vars (, ).
- Added an inventory snapshot with counts and file paths to drive staged refactors.

## Verification
- npm -w services/agent-api run lint
- npm -w services/agent-api run typecheck
- npm -w services/agent-api test
