### PR TITLE
refactor(agent-api): canonical env module + guard legacy PUBLIC_SUPABASE_* reads

### DIFF
--- a/services/agent-api/eslint.config.mjs
+++ b/services/agent-api/eslint.config.mjs
@@ -2,6 +2,21 @@ export default [
   {
     files: ['src/**/*.js'],
     rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "MemberExpression[object.object.name='process'][object.property.name='env'][property.name='PUBLIC_SUPABASE_URL']",
+          message:
+            'Do not read process.env.PUBLIC_SUPABASE_URL directly. Use the canonical env module (src/config/env.js).',
+        },
+        {
+          selector:
+            "MemberExpression[object.object.name='process'][object.property.name='env'][property.name='PUBLIC_SUPABASE_ANON_KEY']",
+          message:
+            'Do not read process.env.PUBLIC_SUPABASE_ANON_KEY directly. Use the canonical env module (src/config/env.js).',
+        },
+      ],
       'no-restricted-properties': [
         'error',
         {
@@ -11,6 +26,57 @@ export default [
             'Use randomInt() from lib/random.js instead. Math.random() is not cryptographically secure.',
         },
       ],
+    },
+  },
+  {
+    // Temporary allowlist: existing legacy reads will be removed in follow-up PRs.
+    files: [
+      'src/config/env.js',
+      'src/env-shim.js',
+      'src/index.js',
+      'src/agents/discover-classics-db.js',
+      'src/agents/discoverer.js',
+      'src/agents/improver-config.js',
+      'src/agents/orchestrator.js',
+      'src/agents/scorer-prompt.js',
+      'src/agents/summarizer.js',
+      'src/agents/tagger-config.js',
+      'src/cli/commands/eval.js',
+      'src/cli/commands/fetch.js',
+      'src/cli/commands/filter.js',
+      'src/cli/commands/health.js',
+      'src/cli/commands/summarize.js',
+      'src/cli/commands/tag.js',
+      'src/cli/commands/thumbnail.js',
+      'src/lib/discovery-config.js',
+      'src/lib/discovery-queue.js',
+      'src/lib/embeddings.js',
+      'src/lib/evals-config.js',
+      'src/lib/pdf-extractor.js',
+      'src/lib/pipeline-tracking.js',
+      'src/lib/prompt-eval.js',
+      'src/lib/queue-update.js',
+      'src/lib/replay-helpers.js',
+      'src/lib/runner.js',
+      'src/lib/state-machine.js',
+      'src/lib/status-codes.js',
+      'src/lib/supabase.js',
+      'src/lib/taxonomy-loader.js',
+      'src/lib/vendor-loader.js',
+      'src/lib/wip-limits.js',
+      'src/routes/agent-jobs.js',
+      'src/routes/agents/discovery.js',
+      'src/routes/agents/filter.js',
+      'src/routes/agents/summarize.js',
+      'src/routes/agents/tag.js',
+      'src/routes/agents/thumbnail.js',
+      'src/routes/discovery-control.js',
+      'src/routes/evals.js',
+      'src/scripts/utils.js',
+      'src/scripts/validate-agent-registry.js',
+    ],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
   {

--- a/services/agent-api/src/config/env.js
+++ b/services/agent-api/src/config/env.js
@@ -1,0 +1,7 @@
+import process from 'node:process';
+
+export const env = {
+  SUPABASE_URL: process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL,
+  SUPABASE_SERVICE_KEY: process.env.SUPABASE_SERVICE_KEY,
+  SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY ?? process.env.PUBLIC_SUPABASE_ANON_KEY,
+};


### PR DESCRIPTION
## Summary
Phase 1 of the Agent API env migration: introduce a single canonical env surface and add a guard to prevent new direct reads of  in .

## Changes
- Added  exporting canonical server env values with temporary legacy fallback.
- Added an ESLint guard () to disallow direct  /  reads.
- Included a temporary allowlist for existing legacy offenders to keep CI green until they’re migrated in follow-up PRs.

## Verification
- npm -w services/agent-api run lint
- npm -w services/agent-api run typecheck
- npm -w services/agent-api test
