### PR TITLE
refactor(agent-api): add supabase client factory and migrate initial callers (Phase 2)

### DIFF
--- a/services/agent-api/src/cli/commands/eval.js
+++ b/services/agent-api/src/cli/commands/eval.js
@@ -2,63 +2,101 @@
  * Evaluation Command Handlers
  */
 
-import { createClient } from '@supabase/supabase-js';
 import process from 'node:process';
 import { runRelevanceFilter } from '../../agents/screener.js';
 import { runSummarizer } from '../../agents/summarizer.js';
 import { runTagger } from '../../agents/tagger.js';
 import { runGoldenEval, runLLMJudgeEval, getEvalHistory } from '../../lib/evals.js';
 import { STATUS } from '../../lib/status-codes.js';
+import { getSupabaseAdminClient } from '../../clients/supabase.js';
 
-const supabase = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+/** @type {any} */
+const STATUS_ANY = STATUS;
 
-export async function runEvalCmd(options) {
-  const agentName = options.agent;
-  const evalType = options.type || 'golden';
+/** @type {Record<string, (input: any) => Promise<any>>} */
+const agentFns = {
+  screener: async (input) => {
+    const result = await runRelevanceFilter({ id: 'eval', payload: input });
+    return { relevant: result.relevant, reason: result.reason };
+  },
+  summarizer: async (input) => {
+    const result = await runSummarizer({ id: 'eval', payload: input });
+    return { summary: result.summary, published_at: result.published_at };
+  },
+  tagger: async (input) => {
+    const result = await runTagger({ id: 'eval', payload: input });
+    return { industry_codes: result.industry_codes || [], topic_codes: result.topic_codes || [] };
+  },
+};
 
-  if (!agentName) {
-    console.log('Usage: node cli.js eval --agent=<name> [--type=golden|judge] [--limit=N]');
-    console.log('Agents: screener, summarizer, tagger');
-    process.exit(1);
-  }
+function printUsageAndExit() {
+  console.log('Usage: node cli.js eval --agent=<name> [--type=golden|judge] [--limit=N]');
+  console.log('Agents: screener, summarizer, tagger');
+  process.exit(1);
+}
 
-  console.log(`🧪 Running ${evalType} eval for ${agentName}\n`);
-
-  const agentFns = {
-    screener: async (input) => {
-      const result = await runRelevanceFilter({ id: 'eval', payload: input });
-      return { relevant: result.relevant, reason: result.reason };
-    },
-    summarizer: async (input) => {
-      const result = await runSummarizer({ id: 'eval', payload: input });
-      return { summary: result.summary, published_at: result.published_at };
-    },
-    tagger: async (input) => {
-      const result = await runTagger({ id: 'eval', payload: input });
-      return { industry_codes: result.industry_codes || [], topic_codes: result.topic_codes || [] };
-    },
-  };
-
+/** @param {string} agentName */
+function getAgentFnOrExit(agentName) {
   const agentFn = agentFns[agentName];
   if (!agentFn) {
     console.error(`Unknown agent: ${agentName}`);
     process.exit(1);
   }
+  return agentFn;
+}
+
+/**
+ * @param {number | undefined} limit
+ * @param {number} fallback
+ */
+function getLimitOrDefault(limit, fallback) {
+  return typeof limit === 'number' ? limit : fallback;
+}
+
+/**
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} agentName
+ * @param {(input: any) => Promise<any>} agentFn
+ * @param {number} limit
+ */
+async function runJudgeEval(supabase, agentName, agentFn, limit) {
+  const { data: samples } = await supabase
+    .from('ingestion_queue')
+    .select('payload')
+    .eq('status_code', STATUS_ANY.ENRICHED)
+    .limit(limit);
+
+  const inputs = samples?.map((/** @type {any} */ s) => s.payload) || [];
+  await runLLMJudgeEval(agentName, agentFn, inputs);
+}
+
+/** @param {{ agent?: string; type?: string; limit?: number }} options */
+export async function runEvalCmd(options) {
+  const supabase = getSupabaseAdminClient();
+  const agentName = options.agent;
+  const evalType = options.type || 'golden';
+
+  if (!agentName) {
+    printUsageAndExit();
+    return;
+  }
+
+  const resolvedAgentName = /** @type {string} */ (agentName);
+
+  console.log(`🧪 Running ${evalType} eval for ${resolvedAgentName}\n`);
+
+  const agentFn = getAgentFnOrExit(resolvedAgentName);
 
   if (evalType === 'golden') {
-    await runGoldenEval(agentName, agentFn, { limit: options.limit || 100 });
+    await runGoldenEval(resolvedAgentName, agentFn, {
+      limit: getLimitOrDefault(options.limit, 100),
+    });
   } else if (evalType === 'judge') {
-    const { data: samples } = await supabase
-      .from('ingestion_queue')
-      .select('payload')
-      .eq('status_code', STATUS.ENRICHED)
-      .limit(options.limit || 10);
-
-    const inputs = samples?.map((s) => s.payload) || [];
-    await runLLMJudgeEval(agentName, agentFn, inputs);
+    await runJudgeEval(supabase, resolvedAgentName, agentFn, getLimitOrDefault(options.limit, 10));
   }
 }
 
+/** @param {{ agent?: string; limit?: number }} options */
 export async function runEvalHistoryCmd(options) {
   const agentName = options.agent;
 

--- a/services/agent-api/src/clients/supabase.js
+++ b/services/agent-api/src/clients/supabase.js
@@ -1,0 +1,35 @@
+import { createClient } from '@supabase/supabase-js';
+
+import { env } from '../config/env.js';
+
+/** @type {import('@supabase/supabase-js').SupabaseClient | null} */
+let adminClient = null;
+/** @type {import('@supabase/supabase-js').SupabaseClient | null} */
+let anonClient = null;
+
+export function getSupabaseAdminClient() {
+  if (adminClient) return adminClient;
+
+  if (!env.SUPABASE_URL || !env.SUPABASE_SERVICE_KEY) {
+    throw new Error('Missing Supabase environment variables');
+  }
+
+  adminClient = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_KEY);
+  return adminClient;
+}
+
+export function getSupabaseAnonClient() {
+  if (anonClient) return anonClient;
+
+  if (!env.SUPABASE_URL || !env.SUPABASE_ANON_KEY) {
+    throw new Error('Missing Supabase environment variables');
+  }
+
+  anonClient = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY);
+  return anonClient;
+}
+
+export function resetSupabaseClientsForTests() {
+  adminClient = null;
+  anonClient = null;
+}

--- a/services/agent-api/src/config/env.js
+++ b/services/agent-api/src/config/env.js
@@ -1,7 +1,13 @@
 import process from 'node:process';
 
 export const env = {
-  SUPABASE_URL: process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL,
-  SUPABASE_SERVICE_KEY: process.env.SUPABASE_SERVICE_KEY,
-  SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY ?? process.env.PUBLIC_SUPABASE_ANON_KEY,
+  get SUPABASE_URL() {
+    return process.env.SUPABASE_URL ?? process.env.PUBLIC_SUPABASE_URL;
+  },
+  get SUPABASE_SERVICE_KEY() {
+    return process.env.SUPABASE_SERVICE_KEY;
+  },
+  get SUPABASE_ANON_KEY() {
+    return process.env.SUPABASE_ANON_KEY ?? process.env.PUBLIC_SUPABASE_ANON_KEY;
+  },
 };

--- a/services/agent-api/src/lib/evals-config.js
+++ b/services/agent-api/src/lib/evals-config.js
@@ -4,15 +4,16 @@
  * Shared clients and configuration for the evals framework.
  */
 
-import process from 'node:process';
-import { createClient } from '@supabase/supabase-js';
 import OpenAI from 'openai';
+import process from 'node:process';
 
-export const supabase = createClient(
-  process.env.PUBLIC_SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_KEY,
-);
+import { getSupabaseAdminClient } from '../clients/supabase.js';
 
+export function getEvalsSupabase() {
+  return getSupabaseAdminClient();
+}
+
+/** @type {import('openai').default | null} */
 let openai = null;
 
 export function getOpenAI() {

--- a/services/agent-api/src/lib/evals-db.js
+++ b/services/agent-api/src/lib/evals-db.js
@@ -4,17 +4,25 @@
  * Functions for storing and retrieving eval data from Supabase.
  */
 
-import { supabase } from './evals-config.js';
+import { getEvalsSupabase } from './evals-config.js';
 
 /** Fetch golden examples for an agent */
+/**
+ * @param {string} agentName
+ * @param {string | null} goldenSetName
+ * @param {number} limit
+ */
 export async function fetchGoldenExamples(agentName, goldenSetName, limit) {
+  const supabase = getEvalsSupabase();
   let query = supabase.from('eval_golden_set').select('*').eq('agent_name', agentName).limit(limit);
   if (goldenSetName) query = query.eq('name', goldenSetName);
   return query;
 }
 
 /** Get current prompt version for an agent */
+/** @param {string} agentName */
 export async function getPromptVersion(agentName) {
+  const supabase = getEvalsSupabase();
   const { data } = await supabase
     .from('prompt_version')
     .select('version')
@@ -25,13 +33,20 @@ export async function getPromptVersion(agentName) {
 }
 
 /** Create a new eval run */
+/** @param {any} runData */
 export async function createEvalRun(runData) {
+  const supabase = getEvalsSupabase();
   const { data } = await supabase.from('eval_run').insert(runData).select().single();
   return data;
 }
 
 /** Update eval run with results */
+/**
+ * @param {string} runId
+ * @param {any} updateData
+ */
 export async function updateEvalRun(runId, updateData) {
+  const supabase = getEvalsSupabase();
   return supabase
     .from('eval_run')
     .update({ ...updateData, finished_at: new Date().toISOString() })
@@ -39,12 +54,22 @@ export async function updateEvalRun(runId, updateData) {
 }
 
 /** Store eval result */
+/** @param {any} resultData */
 export async function storeEvalResult(resultData) {
+  const supabase = getEvalsSupabase();
   return supabase.from('eval_result').insert(resultData);
 }
 
 /** Add golden example */
+/**
+ * @param {string} agentName
+ * @param {string} name
+ * @param {any} input
+ * @param {any} expectedOutput
+ * @param {string | null} createdBy
+ */
 export async function addGoldenExample(agentName, name, input, expectedOutput, createdBy = null) {
+  const supabase = getEvalsSupabase();
   const { data, error } = await supabase
     .from('eval_golden_set')
     .insert({
@@ -61,7 +86,12 @@ export async function addGoldenExample(agentName, name, input, expectedOutput, c
 }
 
 /** Get eval history */
+/**
+ * @param {string} agentName
+ * @param {number} [limit=10]
+ */
 export async function getEvalHistory(agentName, limit = 10) {
+  const supabase = getEvalsSupabase();
   const { data, error } = await supabase
     .from('eval_run')
     .select('*')

--- a/services/agent-api/src/lib/queue-update.js
+++ b/services/agent-api/src/lib/queue-update.js
@@ -4,17 +4,14 @@
  * Use this instead of direct .update({ status_code }) calls.
  */
 
-import process from 'node:process';
-import { createClient } from '@supabase/supabase-js';
+import { getSupabaseAdminClient } from '../clients/supabase.js';
 
+/** @type {import('@supabase/supabase-js').SupabaseClient | null} */
 let supabaseClient = null;
 
 function getSupabaseClient() {
   if (supabaseClient) return supabaseClient;
-  if (!process.env.PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
-    throw new Error('Missing Supabase environment variables');
-  }
-  supabaseClient = createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  supabaseClient = getSupabaseAdminClient();
   return supabaseClient;
 }
 

--- a/services/agent-api/src/lib/supabase.js
+++ b/services/agent-api/src/lib/supabase.js
@@ -1,28 +1,33 @@
-import process from 'node:process';
-import { createClient } from '@supabase/supabase-js';
+import { env } from '../config/env.js';
+import {
+  getSupabaseAdminClient,
+  getSupabaseAnonClient,
+  resetSupabaseClientsForTests,
+} from '../clients/supabase.js';
 
+/** @type {import('@supabase/supabase-js').SupabaseClient | null} */
 let supabase = null;
 
 function getSupabaseKey() {
-  return process.env.SUPABASE_SERVICE_KEY || process.env.PUBLIC_SUPABASE_ANON_KEY || null;
+  return env.SUPABASE_SERVICE_KEY || env.SUPABASE_ANON_KEY || null;
 }
 
 export function getSupabase() {
   if (supabase) return supabase;
 
-  const url = process.env.PUBLIC_SUPABASE_URL;
   const key = getSupabaseKey();
 
-  if (!url || !key) {
+  if (!env.SUPABASE_URL || !key) {
     throw new Error(
       'CRITICAL: Supabase env vars missing. Required: PUBLIC_SUPABASE_URL and (SUPABASE_SERVICE_KEY or PUBLIC_SUPABASE_ANON_KEY).',
     );
   }
 
-  supabase = createClient(url, key);
+  supabase = env.SUPABASE_SERVICE_KEY ? getSupabaseAdminClient() : getSupabaseAnonClient();
   return supabase;
 }
 
 export function resetSupabaseForTests() {
   supabase = null;
+  resetSupabaseClientsForTests();
 }

--- a/services/agent-api/src/scripts/utils.js
+++ b/services/agent-api/src/scripts/utils.js
@@ -3,8 +3,8 @@
  * Content fetching logic is in ../lib/content-fetcher.js
  */
 import process from 'node:process';
-import { createClient } from '@supabase/supabase-js';
 import { fetchContent as baseFetchContent } from '../lib/content-fetcher.js';
+import { getSupabaseAdminClient } from '../clients/supabase.js';
 
 // Re-export delay from shared module
 export { delay } from '../lib/content-fetcher.js';
@@ -13,7 +13,7 @@ export { delay } from '../lib/content-fetcher.js';
  * Create Supabase client with service key
  */
 export function createSupabaseClient() {
-  return createClient(process.env.PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  return getSupabaseAdminClient();
 }
 
 /**
@@ -30,7 +30,8 @@ export function parseCliArgs(defaultLimit = 100) {
 /**
  * Fetch content from URL and extract text (wrapper for backfill scripts)
  */
+/** @param {string} url */
 export async function fetchContent(url) {
   const result = await baseFetchContent(url);
-  return { textContent: result.textContent };
+  return { textContent: 'textContent' in result ? result.textContent : undefined };
 }

--- a/services/agent-api/tests/cli/commands/eval.spec.js
+++ b/services/agent-api/tests/cli/commands/eval.spec.js
@@ -28,6 +28,8 @@ vi.mock('@supabase/supabase-js', () => ({
 
 describe('Eval CLI Commands', () => {
   beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
     vi.clearAllMocks();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/services/agent-api/tests/cli/commands/health.spec.js
+++ b/services/agent-api/tests/cli/commands/health.spec.js
@@ -30,6 +30,8 @@ import { runQueueHealthCmd } from '../../../src/cli/commands/health.js';
 
 describe('Health CLI Command', () => {
   beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY = 'service-key';
     vi.clearAllMocks();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.mocked(utils.getStatusIcon).mockReturnValue('✓');

--- a/services/agent-api/tests/lib/evals-db.spec.js
+++ b/services/agent-api/tests/lib/evals-db.spec.js
@@ -3,10 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const fromMock = vi.fn();
 
 vi.mock('../../src/lib/evals-config.js', () => {
+  const supabase = {
+    from: fromMock,
+  };
   return {
-    supabase: {
-      from: fromMock,
-    },
+    getEvalsSupabase: () => supabase,
   };
 });
 


### PR DESCRIPTION
## Summary

Phase 2 of the agent-api environment variable refactoring effort. This PR introduces a centralized Supabase client factory and migrates the first batch of ~10 callers to use it.

## Changes

### New Infrastructure
- src/clients/supabase.js: Centralized Supabase client factory
  - getSupabaseAdminClient(): Returns cached admin client (service key)
  - getSupabaseAnonClient(): Returns cached anon client
  - resetSupabaseClientsForTests(): Test helper for cache reset
  - Uses canonical env vars from src/config/env.js

### Migrated Modules (First Batch)
- src/lib/supabase.js: Refactored to use factory, preserves service key preference
- src/lib/evals-config.js: Lazy Supabase getter to avoid import-time client creation
- src/lib/evals-db.js: All functions now call getEvalsSupabase() at runtime
- src/lib/queue-update.js: Uses factory admin client
- src/scripts/utils.js: Uses factory admin client
- CLI commands (eval.js, health.js): Deferred client creation to avoid import-time errors

### Quality Improvements
- Refactored eval.js and health.js to keep all functions under 30 lines (Quality Gate compliance)
- Added JSDoc types throughout for tsconfig.checkjs compliance
- Made src/config/env.js use dynamic getters to fix test env var snapshot issues

### Test Updates
- Updated tests/lib/evals-db.spec.js to mock new getEvalsSupabase() export
- Added required env vars in CLI command tests (eval.spec.js, health.spec.js)

## Testing
- All 855 tests passing
- Lint clean
- Typecheck clean
- Quality Gate passed (no functions >30 lines)

## Next Steps
Phase 3 will migrate remaining callers (agents, more lib modules) to complete the refactor.

Related: #523 (Phase 1)
